### PR TITLE
feat(execution): route cli and arm through owned snapshots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4295,6 +4295,7 @@ dependencies = [
  "nika-display",
  "nika-error",
  "nika-event",
+ "nika-execution",
  "nika-fs",
  "nika-graph",
  "nika-http",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4050,6 +4050,7 @@ version = "0.113.0"
 dependencies = [
  "jiff",
  "nika-cadence",
+ "nika-execution",
  "nika-fs",
  "nix 0.31.3",
  "serde_json",

--- a/crates/nika-arm/Cargo.toml
+++ b/crates/nika-arm/Cargo.toml
@@ -16,6 +16,7 @@ test-support = []
 [dependencies]
 nika-cadence = { path = "../nika-cadence", version = "0.113.0" }
 nika-fs      = { path = "../nika-fs", version = "0.113.0" }
+nika-execution = { path = "../nika-execution", version = "0.113.0" }
 jiff         = { workspace = true }
 nix          = { workspace = true }
 serde_json   = { workspace = true }

--- a/crates/nika-arm/public-api.txt
+++ b/crates/nika-arm/public-api.txt
@@ -1,5 +1,6 @@
 pub mod nika_arm
 pub use nika_arm::Claim
+pub use nika_arm::ExecutionLink
 pub use nika_arm::FireKind
 pub use nika_arm::HistoryEntry
 pub use nika_arm::LastRecord
@@ -35,6 +36,7 @@ pub type nika_arm::fire::Wait::Output = T
 impl nika_arm::fire::FireCtx
 pub fn nika_arm::fire::FireCtx::into_registry(self) -> nika_cadence::registry::ArmRegistry
 pub fn nika_arm::fire::FireCtx::new(project_root: std::path::PathBuf, registry: nika_cadence::registry::ArmRegistry, index: usize, now: jiff::zoned::Zoned, pid: u32, run: nika_arm::fire::RunSeam) -> core::result::Result<Self, nika_arm::fire::FireCtxError>
+pub fn nika_arm::fire::FireCtx::with_execution_service(self, service: nika_execution::service::ExecutionService) -> Self
 pub fn nika_arm::fire::FireCtx::with_wait(self, wait: nika_arm::fire::WaitSeam) -> Self
 impl<D> owo_colors::OwoColorize for nika_arm::fire::FireCtx
 impl<T, U> core::convert::Into<U> for nika_arm::fire::FireCtx where U: core::convert::From<T>
@@ -118,7 +120,6 @@ pub fn nika_arm::fire::RunShot::ceiling(&self) -> f64
 pub fn nika_arm::fire::RunShot::generation(&self) -> &nika_cadence::firing::ArmGeneration
 pub fn nika_arm::fire::RunShot::project(&self) -> &nika_fs::owned_dir::OwnedDir
 pub fn nika_arm::fire::RunShot::root(&self) -> &std::path::Path
-pub fn nika_arm::fire::RunShot::source(&self) -> &str
 pub fn nika_arm::fire::RunShot::workflow(&self) -> &str
 impl<D> owo_colors::OwoColorize for nika_arm::fire::RunShot
 impl<T, U> core::convert::Into<U> for nika_arm::fire::RunShot where U: core::convert::From<T>
@@ -167,10 +168,11 @@ impl<T> typenum::type_operators::Same for nika_arm::fire::RunUpshot
 pub type nika_arm::fire::RunUpshot::Output = T
 pub fn nika_arm::fire::fire_beat(ctx: &nika_arm::fire::FireCtx) -> nika_arm::fire::FireVerdict
 pub fn nika_arm::fire::labels(registry: &nika_cadence::registry::ArmRegistry) -> alloc::vec::Vec<alloc::string::String>
-pub type nika_arm::fire::RunSeam = alloc::rc::Rc<dyn core::ops::function::Fn(&nika_arm::fire::RunShot) -> nika_arm::fire::RunUpshot>
+pub type nika_arm::fire::RunSeam = alloc::rc::Rc<dyn for<'a> core::ops::function::Fn(nika_execution::service::ExecutionContext<'a>, &nika_arm::fire::RunShot) -> nika_arm::fire::RunUpshot>
 pub type nika_arm::fire::WaitSeam = alloc::boxed::Box<dyn core::ops::function::Fn(jiff::signed_duration::SignedDuration) -> nika_arm::fire::Wait>
 pub mod nika_arm::state
 pub use nika_arm::state::Claim
+pub use nika_arm::state::ExecutionLink
 pub use nika_arm::state::FireKind
 pub use nika_arm::state::HistoryEntry
 pub use nika_arm::state::LastRecord
@@ -361,6 +363,7 @@ pub type nika_arm::state::ArmState::Output = T
 impl nika_arm::fire::FireCtx
 pub fn nika_arm::fire::FireCtx::into_registry(self) -> nika_cadence::registry::ArmRegistry
 pub fn nika_arm::fire::FireCtx::new(project_root: std::path::PathBuf, registry: nika_cadence::registry::ArmRegistry, index: usize, now: jiff::zoned::Zoned, pid: u32, run: nika_arm::fire::RunSeam) -> core::result::Result<Self, nika_arm::fire::FireCtxError>
+pub fn nika_arm::fire::FireCtx::with_execution_service(self, service: nika_execution::service::ExecutionService) -> Self
 pub fn nika_arm::fire::FireCtx::with_wait(self, wait: nika_arm::fire::WaitSeam) -> Self
 impl<D> owo_colors::OwoColorize for nika_arm::fire::FireCtx
 impl<T, U> core::convert::Into<U> for nika_arm::fire::FireCtx where U: core::convert::From<T>
@@ -528,7 +531,6 @@ pub fn nika_arm::fire::RunShot::ceiling(&self) -> f64
 pub fn nika_arm::fire::RunShot::generation(&self) -> &nika_cadence::firing::ArmGeneration
 pub fn nika_arm::fire::RunShot::project(&self) -> &nika_fs::owned_dir::OwnedDir
 pub fn nika_arm::fire::RunShot::root(&self) -> &std::path::Path
-pub fn nika_arm::fire::RunShot::source(&self) -> &str
 pub fn nika_arm::fire::RunShot::workflow(&self) -> &str
 impl<D> owo_colors::OwoColorize for nika_arm::fire::RunShot
 impl<T, U> core::convert::Into<U> for nika_arm::fire::RunShot where U: core::convert::From<T>
@@ -577,5 +579,5 @@ impl<T> typenum::type_operators::Same for nika_arm::fire::RunUpshot
 pub type nika_arm::fire::RunUpshot::Output = T
 pub fn nika_arm::fire_beat(ctx: &nika_arm::fire::FireCtx) -> nika_arm::fire::FireVerdict
 pub fn nika_arm::labels(registry: &nika_cadence::registry::ArmRegistry) -> alloc::vec::Vec<alloc::string::String>
-pub type nika_arm::RunSeam = alloc::rc::Rc<dyn core::ops::function::Fn(&nika_arm::fire::RunShot) -> nika_arm::fire::RunUpshot>
+pub type nika_arm::RunSeam = alloc::rc::Rc<dyn for<'a> core::ops::function::Fn(nika_execution::service::ExecutionContext<'a>, &nika_arm::fire::RunShot) -> nika_arm::fire::RunUpshot>
 pub type nika_arm::WaitSeam = alloc::boxed::Box<dyn core::ops::function::Fn(jiff::signed_duration::SignedDuration) -> nika_arm::fire::Wait>

--- a/crates/nika-arm/public-api.txt
+++ b/crates/nika-arm/public-api.txt
@@ -36,6 +36,7 @@ pub type nika_arm::fire::Wait::Output = T
 impl nika_arm::fire::FireCtx
 pub fn nika_arm::fire::FireCtx::into_registry(self) -> nika_cadence::registry::ArmRegistry
 pub fn nika_arm::fire::FireCtx::new(project_root: std::path::PathBuf, registry: nika_cadence::registry::ArmRegistry, index: usize, now: jiff::zoned::Zoned, pid: u32, run: nika_arm::fire::RunSeam) -> core::result::Result<Self, nika_arm::fire::FireCtxError>
+pub fn nika_arm::fire::FireCtx::new_with_execution(project_root: std::path::PathBuf, registry: nika_cadence::registry::ArmRegistry, index: usize, now: jiff::zoned::Zoned, pid: u32, run: nika_arm::fire::ExecutionRunSeam) -> core::result::Result<Self, nika_arm::fire::FireCtxError>
 pub fn nika_arm::fire::FireCtx::with_execution_service(self, service: nika_execution::service::ExecutionService) -> Self
 pub fn nika_arm::fire::FireCtx::with_wait(self, wait: nika_arm::fire::WaitSeam) -> Self
 impl<D> owo_colors::OwoColorize for nika_arm::fire::FireCtx
@@ -120,6 +121,7 @@ pub fn nika_arm::fire::RunShot::ceiling(&self) -> f64
 pub fn nika_arm::fire::RunShot::generation(&self) -> &nika_cadence::firing::ArmGeneration
 pub fn nika_arm::fire::RunShot::project(&self) -> &nika_fs::owned_dir::OwnedDir
 pub fn nika_arm::fire::RunShot::root(&self) -> &std::path::Path
+pub fn nika_arm::fire::RunShot::source(&self) -> &str
 pub fn nika_arm::fire::RunShot::workflow(&self) -> &str
 impl<D> owo_colors::OwoColorize for nika_arm::fire::RunShot
 impl<T, U> core::convert::Into<U> for nika_arm::fire::RunShot where U: core::convert::From<T>
@@ -168,7 +170,8 @@ impl<T> typenum::type_operators::Same for nika_arm::fire::RunUpshot
 pub type nika_arm::fire::RunUpshot::Output = T
 pub fn nika_arm::fire::fire_beat(ctx: &nika_arm::fire::FireCtx) -> nika_arm::fire::FireVerdict
 pub fn nika_arm::fire::labels(registry: &nika_cadence::registry::ArmRegistry) -> alloc::vec::Vec<alloc::string::String>
-pub type nika_arm::fire::RunSeam = alloc::rc::Rc<dyn for<'a> core::ops::function::Fn(nika_execution::service::ExecutionContext<'a>, &nika_arm::fire::RunShot) -> nika_arm::fire::RunUpshot>
+pub type nika_arm::fire::ExecutionRunSeam = alloc::rc::Rc<dyn for<'a> core::ops::function::Fn(nika_execution::service::ExecutionContext<'a>, &nika_arm::fire::RunShot) -> nika_arm::fire::RunUpshot>
+pub type nika_arm::fire::RunSeam = alloc::rc::Rc<dyn core::ops::function::Fn(&nika_arm::fire::RunShot) -> nika_arm::fire::RunUpshot>
 pub type nika_arm::fire::WaitSeam = alloc::boxed::Box<dyn core::ops::function::Fn(jiff::signed_duration::SignedDuration) -> nika_arm::fire::Wait>
 pub mod nika_arm::state
 pub use nika_arm::state::Claim
@@ -190,6 +193,7 @@ pub fn nika_arm::state::ArmState::last(&self, label: &str) -> core::io::error::R
 pub fn nika_arm::state::ArmState::last_fired(&self, label: &str) -> core::io::error::Result<core::option::Option<jiff::zoned::Zoned>>
 pub fn nika_arm::state::ArmState::open(project_dir: &std::path::Path) -> core::io::error::Result<Self>
 pub fn nika_arm::state::ArmState::orphans(&self, known: &[alloc::string::String]) -> alloc::vec::Vec<alloc::string::String>
+pub fn nika_arm::state::ArmState::peek_last_fired(&self, label: &str) -> core::io::error::Result<core::option::Option<jiff::zoned::Zoned>>
 pub fn nika_arm::state::ArmState::record_disarm(&self, label: &str, decided_at: jiff::timestamp::Timestamp, pid: u32, reason: &str) -> core::io::error::Result<nika_cadence::ledger::RecordOutcome>
 pub fn nika_arm::state::ArmState::root(&self) -> &std::path::Path
 pub fn nika_arm::state::ArmState::tallies(&self, label: &str) -> core::option::Option<(usize, usize)>
@@ -334,6 +338,7 @@ pub fn nika_arm::state::ArmState::last(&self, label: &str) -> core::io::error::R
 pub fn nika_arm::state::ArmState::last_fired(&self, label: &str) -> core::io::error::Result<core::option::Option<jiff::zoned::Zoned>>
 pub fn nika_arm::state::ArmState::open(project_dir: &std::path::Path) -> core::io::error::Result<Self>
 pub fn nika_arm::state::ArmState::orphans(&self, known: &[alloc::string::String]) -> alloc::vec::Vec<alloc::string::String>
+pub fn nika_arm::state::ArmState::peek_last_fired(&self, label: &str) -> core::io::error::Result<core::option::Option<jiff::zoned::Zoned>>
 pub fn nika_arm::state::ArmState::record_disarm(&self, label: &str, decided_at: jiff::timestamp::Timestamp, pid: u32, reason: &str) -> core::io::error::Result<nika_cadence::ledger::RecordOutcome>
 pub fn nika_arm::state::ArmState::root(&self) -> &std::path::Path
 pub fn nika_arm::state::ArmState::tallies(&self, label: &str) -> core::option::Option<(usize, usize)>
@@ -363,6 +368,7 @@ pub type nika_arm::state::ArmState::Output = T
 impl nika_arm::fire::FireCtx
 pub fn nika_arm::fire::FireCtx::into_registry(self) -> nika_cadence::registry::ArmRegistry
 pub fn nika_arm::fire::FireCtx::new(project_root: std::path::PathBuf, registry: nika_cadence::registry::ArmRegistry, index: usize, now: jiff::zoned::Zoned, pid: u32, run: nika_arm::fire::RunSeam) -> core::result::Result<Self, nika_arm::fire::FireCtxError>
+pub fn nika_arm::fire::FireCtx::new_with_execution(project_root: std::path::PathBuf, registry: nika_cadence::registry::ArmRegistry, index: usize, now: jiff::zoned::Zoned, pid: u32, run: nika_arm::fire::ExecutionRunSeam) -> core::result::Result<Self, nika_arm::fire::FireCtxError>
 pub fn nika_arm::fire::FireCtx::with_execution_service(self, service: nika_execution::service::ExecutionService) -> Self
 pub fn nika_arm::fire::FireCtx::with_wait(self, wait: nika_arm::fire::WaitSeam) -> Self
 impl<D> owo_colors::OwoColorize for nika_arm::fire::FireCtx
@@ -531,6 +537,7 @@ pub fn nika_arm::fire::RunShot::ceiling(&self) -> f64
 pub fn nika_arm::fire::RunShot::generation(&self) -> &nika_cadence::firing::ArmGeneration
 pub fn nika_arm::fire::RunShot::project(&self) -> &nika_fs::owned_dir::OwnedDir
 pub fn nika_arm::fire::RunShot::root(&self) -> &std::path::Path
+pub fn nika_arm::fire::RunShot::source(&self) -> &str
 pub fn nika_arm::fire::RunShot::workflow(&self) -> &str
 impl<D> owo_colors::OwoColorize for nika_arm::fire::RunShot
 impl<T, U> core::convert::Into<U> for nika_arm::fire::RunShot where U: core::convert::From<T>
@@ -579,5 +586,6 @@ impl<T> typenum::type_operators::Same for nika_arm::fire::RunUpshot
 pub type nika_arm::fire::RunUpshot::Output = T
 pub fn nika_arm::fire_beat(ctx: &nika_arm::fire::FireCtx) -> nika_arm::fire::FireVerdict
 pub fn nika_arm::labels(registry: &nika_cadence::registry::ArmRegistry) -> alloc::vec::Vec<alloc::string::String>
-pub type nika_arm::RunSeam = alloc::rc::Rc<dyn for<'a> core::ops::function::Fn(nika_execution::service::ExecutionContext<'a>, &nika_arm::fire::RunShot) -> nika_arm::fire::RunUpshot>
+pub type nika_arm::ExecutionRunSeam = alloc::rc::Rc<dyn for<'a> core::ops::function::Fn(nika_execution::service::ExecutionContext<'a>, &nika_arm::fire::RunShot) -> nika_arm::fire::RunUpshot>
+pub type nika_arm::RunSeam = alloc::rc::Rc<dyn core::ops::function::Fn(&nika_arm::fire::RunShot) -> nika_arm::fire::RunUpshot>
 pub type nika_arm::WaitSeam = alloc::boxed::Box<dyn core::ops::function::Fn(jiff::signed_duration::SignedDuration) -> nika_arm::fire::Wait>

--- a/crates/nika-arm/src/fire.rs
+++ b/crates/nika-arm/src/fire.rs
@@ -99,7 +99,7 @@ pub struct FireCtx {
     wait: WaitSeam,
     /// The run seam — interfaces adapt their execution service here; tests and
     /// simulations can inject a deterministic substitute.
-    run: RunSeam,
+    run: RunAdapter,
     /// The one shared owned-byte admission/execution boundary.
     service: ExecutionService,
 }
@@ -151,6 +151,51 @@ impl FireCtx {
         now: Zoned,
         pid: u32,
         run: RunSeam,
+    ) -> Result<Self, FireCtxError> {
+        Self::build(
+            project_root,
+            registry,
+            index,
+            now,
+            pid,
+            RunAdapter::Legacy(run),
+        )
+    }
+
+    /// Build one firing transaction with the typed execution context seam.
+    ///
+    /// This additive constructor preserves [`Self::new`] and the original
+    /// [`RunSeam`] while allowing in-process adapters to consume the immutable
+    /// world admitted by [`ExecutionService`].
+    ///
+    /// # Errors
+    /// The same custody and registry conditions as [`Self::new`].
+    #[must_use = "an invalid registry index must be handled"]
+    pub fn new_with_execution(
+        project_root: PathBuf,
+        registry: ArmRegistry,
+        index: usize,
+        now: Zoned,
+        pid: u32,
+        run: ExecutionRunSeam,
+    ) -> Result<Self, FireCtxError> {
+        Self::build(
+            project_root,
+            registry,
+            index,
+            now,
+            pid,
+            RunAdapter::Execution(run),
+        )
+    }
+
+    fn build(
+        project_root: PathBuf,
+        registry: ArmRegistry,
+        index: usize,
+        now: Zoned,
+        pid: u32,
+        run: RunAdapter,
     ) -> Result<Self, FireCtxError> {
         let Some(label) = labels(&registry).get(index).cloned() else {
             return Err(FireCtxError {
@@ -288,6 +333,7 @@ pub struct RunShot {
     project: OwnedDir,
     root: PathBuf,
     workflow: String,
+    source: String,
     generation: ArmGeneration,
     ceiling: f64,
 }
@@ -307,6 +353,12 @@ impl RunShot {
     #[must_use]
     pub fn workflow(&self) -> &str {
         &self.workflow
+    }
+
+    /// The exact root bytes admitted for this firing.
+    #[must_use]
+    pub fn source(&self) -> &str {
+        &self.source
     }
 
     #[must_use]
@@ -336,7 +388,25 @@ impl RunUpshot {
     }
 }
 
-pub type RunSeam = Rc<dyn for<'a> Fn(ExecutionContext<'a>, &RunShot) -> RunUpshot>;
+/// Original ARM runner seam, retained for source and binary compatibility.
+pub type RunSeam = Rc<dyn Fn(&RunShot) -> RunUpshot>;
+
+/// Typed runner seam for adapters consuming the service-admitted world.
+pub type ExecutionRunSeam = Rc<dyn for<'a> Fn(ExecutionContext<'a>, &RunShot) -> RunUpshot>;
+
+enum RunAdapter {
+    Legacy(RunSeam),
+    Execution(ExecutionRunSeam),
+}
+
+impl RunAdapter {
+    fn run(&self, execution: ExecutionContext<'_>, shot: &RunShot) -> RunUpshot {
+        match self {
+            Self::Legacy(run) => run(shot),
+            Self::Execution(run) => run(execution, shot),
+        }
+    }
+}
 
 /// What a fire leaves: the ONE stdout line (D8) + the process exit.
 pub struct FireVerdict {
@@ -657,6 +727,14 @@ fn claim_run_receipt(
     claim.generation = Some(pinned.generation.clone());
     let execution_id = pinned.admitted.execution_id();
     let trace_id = pinned.admitted.trace_id();
+    let Some(source) = pinned
+        .admitted
+        .snapshot()
+        .text(pinned.admitted.snapshot().root())
+        .map(str::to_owned)
+    else {
+        return invalid_execution_identity(ctx);
+    };
     let Some(execution) = direct_execution_link(&pinned.admitted) else {
         return invalid_execution_identity(ctx);
     };
@@ -673,12 +751,13 @@ fn claim_run_receipt(
         project: pinned.project,
         root: ctx.project_root.clone(),
         workflow: beat.workflow.clone(),
+        source,
         generation: pinned.generation,
         ceiling: plafond,
     };
-    let executed = ctx
-        .service
-        .execute(pinned.admitted, |execution| (ctx.run)(execution, &request));
+    let executed = ctx.service.execute_with(pinned.admitted, |execution| {
+        ctx.run.run(execution, &request)
+    });
     debug_assert_eq!(executed.execution_id(), execution_id);
     debug_assert_eq!(executed.trace_id(), trace_id);
     let upshot = executed.into_outcome();
@@ -901,7 +980,7 @@ mod tests {
             state: ArmState::at_project(Path::new("/project")),
             pid: 7,
             wait: Box::new(os_wait),
-            run: Rc::new(|_, _| RunUpshot::new(exit::OK, None)),
+            run: RunAdapter::Execution(Rc::new(|_, _| RunUpshot::new(exit::OK, None))),
             service: ExecutionService::default(),
         }
     }
@@ -926,11 +1005,13 @@ mod tests {
             project: OwnedDir::open(project.path()).expect("project capability"),
             root: project.path().to_path_buf(),
             workflow: "workflows/doctor.nika.yaml".to_owned(),
+            source: "nika: doctor\ntasks: {}\n".to_owned(),
             generation: generation.clone(),
             ceiling: 0.25,
         };
         assert_eq!(shot.root(), project.path());
         assert_eq!(shot.workflow(), "workflows/doctor.nika.yaml");
+        assert_eq!(shot.source(), "nika: doctor\ntasks: {}\n");
         assert_eq!(shot.generation(), &generation);
         assert_eq!(shot.ceiling().to_bits(), 0.25f64.to_bits());
 
@@ -946,7 +1027,7 @@ mod tests {
     #[test]
     fn context_derives_the_label_and_rejects_an_invalid_index() {
         let registry = registry_with(BASE);
-        let Err(error) = FireCtx::new(
+        let Err(error) = FireCtx::new_with_execution(
             PathBuf::from("/project"),
             registry,
             1,

--- a/crates/nika-arm/src/fire.rs
+++ b/crates/nika-arm/src/fire.rs
@@ -755,9 +755,9 @@ fn claim_run_receipt(
         generation: pinned.generation,
         ceiling: plafond,
     };
-    let executed = ctx.service.execute_with(pinned.admitted, |execution| {
-        ctx.run.run(execution, &request)
-    });
+    let session = ctx.service.begin(pinned.admitted);
+    let upshot = ctx.run.run(session.context(), &request);
+    let executed = session.complete(upshot);
     debug_assert_eq!(executed.execution_id(), execution_id);
     debug_assert_eq!(executed.trace_id(), trace_id);
     let upshot = executed.into_outcome();

--- a/crates/nika-arm/src/fire.rs
+++ b/crates/nika-arm/src/fire.rs
@@ -643,6 +643,18 @@ fn wait_quantum(budget_ms: i64, waited_ms: i64) -> i64 {
     budget_ms.saturating_sub(waited_ms).min(POLL_MS)
 }
 
+fn claim_deadline(ctx: &FireCtx) -> jiff::Timestamp {
+    next_slot(ctx).map_or_else(
+        || {
+            ctx.now
+                .timestamp()
+                .checked_add(CLAIM_DEADLINE_FALLBACK)
+                .unwrap_or_else(|_| ctx.now.timestamp())
+        },
+        |next| next.timestamp(),
+    )
+}
+
 /// Act on a Skip decision: journal it when it bears one (the inner
 /// ledger lock serializes the append; the caller's beat lock, when it
 /// holds one, outlives this), then the ONE line — the ledger's repair
@@ -689,39 +701,13 @@ fn claim_run_receipt(
     slot: &Zoned,
     slots: Option<u32>,
 ) -> FireVerdict {
-    let Some(beat) = beat_of(ctx) else {
-        return FireVerdict {
-            line: format!(
-                "failed {} · engine fault: the label resolved past the registry",
-                ctx.label
-            ),
-            code: exit::FILE,
-        };
-    };
-    let Some(plafond) = beat.plafond else {
-        return FireVerdict {
-            line: format!(
-                "failed {} · engine fault: plafond absent après validation — à reporter avec le fichier",
-                ctx.label
-            ),
-            code: exit::FILE,
-        };
-    };
-    let pinned = match admit_workflow(ctx, beat) {
-        Ok(pinned) => pinned,
-        Err(error) => return record_refused(ctx, &error),
+    let (beat, plafond, pinned) = match admit_due_workflow(ctx) {
+        Ok(admitted) => admitted,
+        Err(verdict) => return verdict,
     };
     let mut claim = Claim::new(
         SlotId::derive(&beat.workflow, &beat.cadence, slot),
-        next_slot(ctx).map_or_else(
-            || {
-                ctx.now
-                    .timestamp()
-                    .checked_add(CLAIM_DEADLINE_FALLBACK)
-                    .unwrap_or_else(|_| ctx.now.timestamp())
-            },
-            |next| next.timestamp(),
-        ),
+        claim_deadline(ctx),
         ctx.now.timestamp(),
     );
     claim.generation = Some(pinned.generation.clone());
@@ -788,6 +774,32 @@ fn claim_run_receipt(
         line: with_repair(line, repaired),
         code: upshot.code,
     }
+}
+
+fn admit_due_workflow(ctx: &FireCtx) -> Result<(&Beat, f64, PinnedExecution), FireVerdict> {
+    let Some(beat) = beat_of(ctx) else {
+        return Err(FireVerdict {
+            line: format!(
+                "failed {} · engine fault: the label resolved past the registry",
+                ctx.label
+            ),
+            code: exit::FILE,
+        });
+    };
+    let Some(plafond) = beat.plafond else {
+        return Err(FireVerdict {
+            line: format!(
+                "failed {} · engine fault: plafond absent après validation — à reporter avec le fichier",
+                ctx.label
+            ),
+            code: exit::FILE,
+        });
+    };
+    let pinned = match admit_workflow(ctx, beat) {
+        Ok(pinned) => pinned,
+        Err(error) => return Err(record_refused(ctx, &error)),
+    };
+    Ok((beat, plafond, pinned))
 }
 
 /// Fold the run's terminal lifecycle before the receipt speaks its kind.

--- a/crates/nika-arm/src/fire.rs
+++ b/crates/nika-arm/src/fire.rs
@@ -41,13 +41,14 @@ use std::io::Read as _;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 
-use crate::state::{ArmState, Claim, FireKind, HistoryEntry, LockOutcome, Receipt};
+use crate::state::{ArmState, Claim, ExecutionLink, FireKind, HistoryEntry, LockOutcome, Receipt};
 #[cfg(test)]
 use jiff::Timestamp;
 use jiff::{SignedDuration, Zoned};
 use nika_cadence::firing::{self, ArmGeneration, FencingToken, FiringEvent, FiringState, SlotId};
 use nika_cadence::registry::{ArmRegistry, Beat, Cadence, Overlap};
 use nika_cadence::{TickDecision, tick_decision};
+use nika_execution::{AdmittedExecution, ExecutionContext, ExecutionService};
 use nika_fs::OwnedDir;
 
 mod exit {
@@ -99,6 +100,8 @@ pub struct FireCtx {
     /// The run seam — interfaces adapt their execution service here; tests and
     /// simulations can inject a deterministic substitute.
     run: RunSeam,
+    /// The one shared owned-byte admission/execution boundary.
+    service: ExecutionService,
 }
 
 /// A firing context could not bind its registry position to one beat.
@@ -183,6 +186,7 @@ impl FireCtx {
             pid,
             wait: Box::new(os_wait),
             run,
+            service: ExecutionService::default(),
         })
     }
 
@@ -190,6 +194,13 @@ impl FireCtx {
     #[must_use]
     pub fn with_wait(mut self, wait: WaitSeam) -> Self {
         self.wait = wait;
+        self
+    }
+
+    /// Replace the default immutable-world limits for this firing adapter.
+    #[must_use]
+    pub fn with_execution_service(mut self, service: ExecutionService) -> Self {
+        self.service = service;
         self
     }
 
@@ -277,7 +288,6 @@ pub struct RunShot {
     project: OwnedDir,
     root: PathBuf,
     workflow: String,
-    source: String,
     generation: ArmGeneration,
     ceiling: f64,
 }
@@ -297,11 +307,6 @@ impl RunShot {
     #[must_use]
     pub fn workflow(&self) -> &str {
         &self.workflow
-    }
-
-    #[must_use]
-    pub fn source(&self) -> &str {
-        &self.source
     }
 
     #[must_use]
@@ -331,7 +336,7 @@ impl RunUpshot {
     }
 }
 
-pub type RunSeam = Rc<dyn Fn(&RunShot) -> RunUpshot>;
+pub type RunSeam = Rc<dyn for<'a> Fn(ExecutionContext<'a>, &RunShot) -> RunUpshot>;
 
 /// What a fire leaves: the ONE stdout line (D8) + the process exit.
 pub struct FireVerdict {
@@ -632,7 +637,7 @@ fn claim_run_receipt(
             code: exit::FILE,
         };
     };
-    let pinned = match pin_workflow(ctx, beat) {
+    let pinned = match admit_workflow(ctx, beat) {
         Ok(pinned) => pinned,
         Err(error) => return record_refused(ctx, &error),
     };
@@ -650,6 +655,12 @@ fn claim_run_receipt(
         ctx.now.timestamp(),
     );
     claim.generation = Some(pinned.generation.clone());
+    let execution_id = pinned.admitted.execution_id();
+    let trace_id = pinned.admitted.trace_id();
+    let Some(execution) = direct_execution_link(&pinned.admitted) else {
+        return invalid_execution_identity(ctx);
+    };
+    claim.execution = Some(execution);
     let mut repaired = 0u64;
     let fencing = match ArmState::record_claim_with_lease(lease, &claim) {
         Ok(outcome) => {
@@ -658,14 +669,19 @@ fn claim_run_receipt(
         }
         Err(e) => return record_refused(ctx, &e),
     };
-    let upshot = (ctx.run)(&RunShot {
+    let request = RunShot {
         project: pinned.project,
         root: ctx.project_root.clone(),
         workflow: beat.workflow.clone(),
-        source: pinned.source,
         generation: pinned.generation,
         ceiling: plafond,
-    });
+    };
+    let executed = ctx
+        .service
+        .execute(pinned.admitted, |execution| (ctx.run)(execution, &request));
+    debug_assert_eq!(executed.execution_id(), execution_id);
+    debug_assert_eq!(executed.trace_id(), trace_id);
+    let upshot = executed.into_outcome();
     let folded = fold_finished_run(&claim, fencing, upshot.code);
     let (kind, line) = verdict_line(
         ctx,
@@ -737,33 +753,49 @@ fn slot_id_of(ctx: &FireCtx, slot: &Zoned) -> Option<SlotId> {
     Some(SlotId::derive(&beat.workflow, &beat.cadence, slot))
 }
 
-struct PinnedWorkflow {
+struct PinnedExecution {
     project: OwnedDir,
     generation: ArmGeneration,
-    source: String,
+    admitted: AdmittedExecution,
 }
 
-fn pin_workflow(ctx: &FireCtx, beat: &Beat) -> std::io::Result<PinnedWorkflow> {
-    let (project, mut source) = ctx.state.open_project_file(Path::new(&beat.workflow))?;
-    if !source.metadata()?.file_type().is_file() {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidData,
-            "arm workflow: source is not a regular file",
-        ));
+fn direct_execution_link(admitted: &AdmittedExecution) -> Option<ExecutionLink> {
+    ExecutionLink::new(
+        admitted.execution_id().to_string(),
+        admitted.trace_id().to_string(),
+    )
+}
+
+fn invalid_execution_identity(ctx: &FireCtx) -> FireVerdict {
+    FireVerdict {
+        line: format!(
+            "failed {} · engine fault: execution identity is not canonical",
+            ctx.label
+        ),
+        code: exit::FILE,
     }
-    let mut bytes = Vec::new();
-    source.read_to_end(&mut bytes)?;
-    let generation = ArmGeneration::compute(beat, &bytes);
-    let source = String::from_utf8(bytes).map_err(|error| {
-        std::io::Error::new(
-            std::io::ErrorKind::InvalidData,
-            format!("arm workflow: source is not UTF-8: {error}"),
-        )
-    })?;
-    Ok(PinnedWorkflow {
+}
+
+fn admit_workflow(ctx: &FireCtx, beat: &Beat) -> std::io::Result<PinnedExecution> {
+    let project = ctx.state.held_project()?;
+    let admitted = ctx
+        .service
+        .admit(&project, Path::new(&beat.workflow))
+        .map_err(|error| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("arm workflow admission refused: {error}"),
+            )
+        })?;
+    let source = admitted
+        .snapshot()
+        .unit(admitted.snapshot().root())
+        .ok_or_else(|| std::io::Error::other("arm workflow admission lost its root unit"))?;
+    let generation = ArmGeneration::compute(beat, source.bytes());
+    Ok(PinnedExecution {
         project,
         generation,
-        source,
+        admitted,
     })
 }
 
@@ -869,7 +901,8 @@ mod tests {
             state: ArmState::at_project(Path::new("/project")),
             pid: 7,
             wait: Box::new(os_wait),
-            run: Rc::new(|_| RunUpshot::new(exit::OK, None)),
+            run: Rc::new(|_, _| RunUpshot::new(exit::OK, None)),
+            service: ExecutionService::default(),
         }
     }
 
@@ -893,13 +926,11 @@ mod tests {
             project: OwnedDir::open(project.path()).expect("project capability"),
             root: project.path().to_path_buf(),
             workflow: "workflows/doctor.nika.yaml".to_owned(),
-            source: "schema: nika/workflow@0.12\ntasks: {}\n".to_owned(),
             generation: generation.clone(),
             ceiling: 0.25,
         };
         assert_eq!(shot.root(), project.path());
         assert_eq!(shot.workflow(), "workflows/doctor.nika.yaml");
-        assert_eq!(shot.source(), "schema: nika/workflow@0.12\ntasks: {}\n");
         assert_eq!(shot.generation(), &generation);
         assert_eq!(shot.ceiling().to_bits(), 0.25f64.to_bits());
 
@@ -921,7 +952,7 @@ mod tests {
             1,
             at("2026-08-19T03:02:00Z"),
             7,
-            Rc::new(|_| RunUpshot::new(exit::OK, None)),
+            Rc::new(|_, _| RunUpshot::new(exit::OK, None)),
         ) else {
             panic!("one-beat registry has no index one");
         };

--- a/crates/nika-arm/src/fire/firer_tests.rs
+++ b/crates/nika-arm/src/fire/firer_tests.rs
@@ -65,7 +65,7 @@ fn project(tag: &str) -> tempfile::TempDir {
     std::fs::create_dir_all(dir.path().join("workflows")).expect("workflows dir");
     std::fs::write(
         dir.path().join("workflows/doctor.nika.yaml"),
-        "schema: nika/workflow@0.12\ntasks: {}\n",
+        "nika: doctor\npermits: {}\ntasks:\n  answer:\n    infer: { prompt: \"admitted\" }\n",
     )
     .expect("workflow source");
     dir
@@ -124,7 +124,7 @@ fn ctx(root: &Path, fixture: RegistryFixture, now: &str, wait: WaitSeam, run: Ru
 fn run_counter() -> (Rc<Cell<u32>>, RunSeam) {
     let count = Rc::new(Cell::new(0u32));
     let seen = Rc::clone(&count);
-    let seam: RunSeam = Rc::new(move |_: &RunShot| {
+    let seam: RunSeam = Rc::new(move |_, _: &RunShot| {
         seen.set(seen.get() + 1);
         RunUpshot {
             code: exit::OK,
@@ -210,7 +210,7 @@ fn two_firers_one_run() {
 fn the_claim_precedes_the_run_and_the_receipt_settles_it() {
     let dir = project("ordering");
     let root = dir.path().to_path_buf();
-    let during = move |shot: &RunShot| {
+    let during = move |execution: nika_execution::ExecutionContext<'_>, shot: &RunShot| {
         // DURING the run: the chain's last line is the claim …
         let text = std::fs::read_to_string(root.join(".nika/arm/doctor/history.ndjson"))
             .expect("the claim lands BEFORE the run");
@@ -222,6 +222,11 @@ fn the_claim_precedes_the_run_and_the_receipt_settles_it() {
             "the claim fences its own seq: {text}"
         );
         assert_eq!(doc["payload"]["attempt"], 1, "one attempt — v0: {text}");
+        assert_eq!(
+            doc["payload"]["execution_id"],
+            execution.execution_id().to_string()
+        );
+        assert_eq!(doc["payload"]["trace_id"], execution.trace_id().to_string());
         assert_eq!(
             doc["payload"]["deadline"], "2026-08-20T03:00:00Z",
             "the deadline is the beat's next theoretical slot: {text}"
@@ -293,6 +298,45 @@ fn the_claim_precedes_the_run_and_the_receipt_settles_it() {
     assert_eq!(watermark, "2026-08-19T03:02:00Z\n");
 }
 
+/// W04.B: admission mints the execution identity before the durable claim.
+/// The receipt copies that exact identity pair from the service verdict, so a
+/// crash leaves a replayable claim-to-execution association instead of an
+/// anonymous attempt or a guessed latest trace.
+#[test]
+fn claim_and_receipt_carry_the_same_service_execution_identity() {
+    let dir = project("execution-identity");
+    let seen = Rc::new(RefCell::new(None::<(String, String)>));
+    let observed = Rc::clone(&seen);
+    let run: RunSeam = Rc::new(move |execution, _shot| {
+        let execution_id = execution.execution_id().to_string();
+        let trace_id = execution.trace_id().to_string();
+        *observed.borrow_mut() = Some((execution_id, trace_id));
+        RunUpshot::new(exit::OK, Some(".nika/traces/exact.ndjson".to_owned()))
+    });
+
+    let verdict = fire_beat(&ctx(
+        dir.path(),
+        registry_with(SAUTER),
+        "2026-08-19T03:02:00Z",
+        instant_wait(),
+        run,
+    ));
+    assert_eq!(verdict.code, exit::OK, "{}", verdict.line);
+
+    let text = history(dir.path(), "doctor");
+    let docs = text
+        .lines()
+        .map(|line| serde_json::from_str::<serde_json::Value>(line).expect("ledger json"))
+        .collect::<Vec<_>>();
+    let (execution_id, trace_id) = seen.borrow().clone().expect("service context observed");
+    assert_eq!(docs[0]["kind"], "claimed");
+    assert_eq!(docs[0]["payload"]["execution_id"], execution_id);
+    assert_eq!(docs[0]["payload"]["trace_id"], trace_id);
+    assert_eq!(docs[1]["payload"]["execution_id"], execution_id);
+    assert_eq!(docs[1]["payload"]["trace_id"], trace_id);
+    assert_eq!(docs[1]["payload"]["trace"], ".nika/traces/exact.ndjson");
+}
+
 #[test]
 fn source_edit_after_claim_cannot_change_the_pinned_run_bytes() {
     let dir = project("pin-edit");
@@ -302,13 +346,20 @@ fn source_edit_after_claim_cannot_change_the_pinned_run_bytes() {
     let expected = ArmGeneration::compute(registry.1.beats().next().expect("beat"), &original);
     let logical_path = Rc::new(RefCell::new(None::<String>));
     let seen_path = Rc::clone(&logical_path);
-    let seam: RunSeam = Rc::new(move |shot| {
+    let seam: RunSeam = Rc::new(move |execution, shot| {
         std::fs::write(
             &source,
-            "schema: nika/workflow@0.12\ntasks: {b: {exec: echo B}}\n",
+            "nika: changed\npermits: {}\ntasks:\n  b:\n    infer: { prompt: \"changed\" }\n",
         )
         .expect("replace declared source with B");
-        assert_eq!(shot.source().as_bytes(), original.as_slice());
+        assert_eq!(
+            execution
+                .snapshot()
+                .unit(execution.snapshot().root())
+                .expect("admitted root")
+                .bytes(),
+            original.as_slice()
+        );
         assert_eq!(shot.generation(), &expected);
         *seen_path.borrow_mut() = Some(shot.workflow().to_owned());
         RunUpshot::new(exit::OK, None)
@@ -328,6 +379,52 @@ fn source_edit_after_claim_cannot_change_the_pinned_run_bytes() {
     );
 }
 
+#[test]
+fn child_and_skill_edits_after_claim_cannot_change_the_admitted_world() {
+    let dir = project("closure-pin-edit");
+    let root = "nika: doctor\nmodel: mock/echo\npermits:\n  exec: [\"echo\"]\n  fs:\n    read: [\"skills/review/SKILL.md\"]\ntasks:\n  child:\n    invoke:\n      workflow: \"child.nika.yaml\"\n      args: { url: \"https://example.com\" }\n    returns: { object: { report: string } }\n  review:\n    agent: { prompt: \"review\", skills: [\"skills/review/SKILL.md\"] }\n";
+    let child = "nika: child\ninputs:\n  url: { type: string, required: true }\npermits:\n  exec: [\"echo\"]\ntasks:\n  fetch:\n    exec: { command: [\"echo\", \"${{ inputs.url }}\"] }\noutputs:\n  report: { value: \"${{ tasks.fetch.output }}\", type: string }\n";
+    let skill = "---\nname: review\ndescription: Review code.\n---\nOriginal.\n";
+    std::fs::write(dir.path().join("workflows/doctor.nika.yaml"), root).expect("root");
+    std::fs::write(dir.path().join("workflows/child.nika.yaml"), child).expect("child");
+    std::fs::create_dir_all(dir.path().join("workflows/skills/review")).expect("skill dir");
+    std::fs::write(dir.path().join("workflows/skills/review/SKILL.md"), skill).expect("skill");
+    let child_path = dir.path().join("workflows/child.nika.yaml");
+    let skill_path = dir.path().join("workflows/skills/review/SKILL.md");
+    let run: RunSeam = Rc::new(move |execution, _shot| {
+        std::fs::write(&child_path, "nika: replacement\ntasks: {}\n").expect("mutate child");
+        std::fs::write(&skill_path, "replacement").expect("mutate skill");
+        assert_eq!(
+            execution.snapshot().text("workflows/child.nika.yaml"),
+            Some(child)
+        );
+        assert_eq!(
+            execution
+                .snapshot()
+                .text("workflows/skills/review/SKILL.md"),
+            Some(skill)
+        );
+        assert_eq!(
+            execution
+                .skills()
+                .texts
+                .get("skills/review/SKILL.md")
+                .map(String::as_str),
+            Some(skill)
+        );
+        RunUpshot::new(exit::OK, None)
+    });
+
+    let verdict = fire_beat(&ctx(
+        dir.path(),
+        registry_with(SAUTER),
+        "2026-08-19T03:02:00Z",
+        instant_wait(),
+        run,
+    ));
+    assert_eq!(verdict.code, exit::OK, "{}", verdict.line);
+}
+
 #[cfg(unix)]
 #[test]
 fn source_symlink_swap_after_claim_cannot_change_the_pinned_run_bytes() {
@@ -339,15 +436,22 @@ fn source_symlink_swap_after_claim_cannot_change_the_pinned_run_bytes() {
     let original = std::fs::read(&source).expect("source A");
     std::fs::write(
         &replacement,
-        "schema: nika/workflow@0.12\ntasks: {b: {exec: echo B}}\n",
+        "nika: replacement\npermits: {}\ntasks:\n  b:\n    infer: { prompt: \"replacement\" }\n",
     )
     .expect("source B");
     let registry = registry_with(SAUTER);
     let expected = ArmGeneration::compute(registry.1.beats().next().expect("beat"), &original);
-    let seam: RunSeam = Rc::new(move |shot| {
+    let seam: RunSeam = Rc::new(move |execution, shot| {
         std::fs::remove_file(&source).expect("remove A");
         symlink(&replacement, &source).expect("swap to symlink B");
-        assert_eq!(shot.source().as_bytes(), original.as_slice());
+        assert_eq!(
+            execution
+                .snapshot()
+                .unit(execution.snapshot().root())
+                .expect("admitted root")
+                .bytes(),
+            original.as_slice()
+        );
         assert_eq!(shot.generation(), &expected);
         RunUpshot::new(exit::OK, None)
     });
@@ -369,7 +473,7 @@ fn a_symlink_workflow_is_refused_before_claim_or_run() {
     let dir = project("pin-initial-symlink");
     let source = dir.path().join("workflows/doctor.nika.yaml");
     let replacement = dir.path().join("workflows/replacement.nika.yaml");
-    std::fs::write(&replacement, "schema: nika/workflow@0.12\ntasks: {}\n").expect("target");
+    std::fs::write(&replacement, "nika: replacement\npermits: {}\ntasks: {}\n").expect("target");
     std::fs::remove_file(&source).expect("remove source");
     symlink(&replacement, &source).expect("source symlink");
     let (runs, run) = run_counter();
@@ -459,7 +563,7 @@ fn a_dot_suffixed_symlinked_project_root_is_refused() {
         0,
         at("2026-08-19T03:02:00Z"),
         std::process::id(),
-        Rc::new(|_| RunUpshot::new(exit::OK, None)),
+        Rc::new(|_, _| RunUpshot::new(exit::OK, None)),
     )
     .err()
     .expect("dot-suffixed symlink root refused");
@@ -478,7 +582,7 @@ fn a_registry_from_another_project_is_refused_at_construction() {
         0,
         at("2026-08-19T03:02:00Z"),
         std::process::id(),
-        Rc::new(|_| RunUpshot::new(exit::OK, None)),
+        Rc::new(|_, _| RunUpshot::new(exit::OK, None)),
     )
     .err()
     .expect("foreign registry refused");
@@ -497,8 +601,14 @@ fn project_path_replacement_cannot_split_workflow_and_state_custody() {
         .expect("original workflow");
     let seen = Rc::new(Cell::new(false));
     let saw_original = Rc::clone(&seen);
-    let run: RunSeam = Rc::new(move |shot| {
-        assert_eq!(shot.source(), original);
+    let run: RunSeam = Rc::new(move |execution, _shot| {
+        assert_eq!(
+            execution
+                .snapshot()
+                .text(execution.snapshot().root())
+                .expect("admitted root"),
+            original
+        );
         saw_original.set(true);
         RunUpshot::new(exit::OK, None)
     });
@@ -514,7 +624,7 @@ fn project_path_replacement_cannot_split_workflow_and_state_custody() {
     std::fs::create_dir_all(dir.path().join("workflows")).expect("replacement root");
     std::fs::write(
         dir.path().join("workflows/doctor.nika.yaml"),
-        "schema: nika/workflow@0.12\ntasks: {evil: {exec: echo evil}}\n",
+        "nika: evil\npermits: {}\ntasks:\n  evil:\n    infer: { prompt: \"evil\" }\n",
     )
     .expect("replacement workflow");
 

--- a/crates/nika-arm/src/fire/firer_tests.rs
+++ b/crates/nika-arm/src/fire/firer_tests.rs
@@ -106,9 +106,15 @@ impl Drop for LiveChild {
 
 /// The firer's context with every seam injected: the pid is the test
 /// process's own, the wait is scripted by the test, the run is a stub.
-fn ctx(root: &Path, fixture: RegistryFixture, now: &str, wait: WaitSeam, run: RunSeam) -> FireCtx {
+fn ctx(
+    root: &Path,
+    fixture: RegistryFixture,
+    now: &str,
+    wait: WaitSeam,
+    run: ExecutionRunSeam,
+) -> FireCtx {
     std::fs::write(root.join("nika.yaml"), &fixture.0).expect("project registry");
-    FireCtx::new(
+    FireCtx::new_with_execution(
         root.to_path_buf(),
         fixture.1,
         0,
@@ -121,10 +127,10 @@ fn ctx(root: &Path, fixture: RegistryFixture, now: &str, wait: WaitSeam, run: Ru
 }
 
 /// A run stub that counts its calls and exits clean.
-fn run_counter() -> (Rc<Cell<u32>>, RunSeam) {
+fn run_counter() -> (Rc<Cell<u32>>, ExecutionRunSeam) {
     let count = Rc::new(Cell::new(0u32));
     let seen = Rc::clone(&count);
-    let seam: RunSeam = Rc::new(move |_, _: &RunShot| {
+    let seam: ExecutionRunSeam = Rc::new(move |_, _: &RunShot| {
         seen.set(seen.get() + 1);
         RunUpshot {
             code: exit::OK,
@@ -132,6 +138,35 @@ fn run_counter() -> (Rc<Cell<u32>>, RunSeam) {
         }
     });
     (count, seam)
+}
+
+#[test]
+fn legacy_run_seam_receives_the_exact_admitted_root_source() {
+    let dir = project("legacy-run-seam");
+    let fixture = registry_with(SAUTER);
+    std::fs::write(dir.path().join("nika.yaml"), &fixture.0).expect("project registry");
+    let original = std::fs::read_to_string(dir.path().join("workflows/doctor.nika.yaml"))
+        .expect("root source");
+    let seen = Rc::new(Cell::new(false));
+    let observed = Rc::clone(&seen);
+    let run: RunSeam = Rc::new(move |shot| {
+        assert_eq!(shot.source(), original);
+        observed.set(true);
+        RunUpshot::new(exit::OK, None)
+    });
+    let ctx = FireCtx::new(
+        dir.path().to_path_buf(),
+        fixture.1,
+        0,
+        at("2026-08-19T03:02:00Z"),
+        std::process::id(),
+        run,
+    )
+    .expect("legacy context");
+
+    let verdict = fire_beat(&ctx);
+    assert_eq!(verdict.code, exit::OK, "{}", verdict.line);
+    assert!(seen.get(), "the compatibility adapter ran");
 }
 
 /// The wait that elapses at once (no signal, no scripted clock).
@@ -307,7 +342,7 @@ fn claim_and_receipt_carry_the_same_service_execution_identity() {
     let dir = project("execution-identity");
     let seen = Rc::new(RefCell::new(None::<(String, String)>));
     let observed = Rc::clone(&seen);
-    let run: RunSeam = Rc::new(move |execution, _shot| {
+    let run: ExecutionRunSeam = Rc::new(move |execution, _shot| {
         let execution_id = execution.execution_id().to_string();
         let trace_id = execution.trace_id().to_string();
         *observed.borrow_mut() = Some((execution_id, trace_id));
@@ -346,7 +381,7 @@ fn source_edit_after_claim_cannot_change_the_pinned_run_bytes() {
     let expected = ArmGeneration::compute(registry.1.beats().next().expect("beat"), &original);
     let logical_path = Rc::new(RefCell::new(None::<String>));
     let seen_path = Rc::clone(&logical_path);
-    let seam: RunSeam = Rc::new(move |execution, shot| {
+    let seam: ExecutionRunSeam = Rc::new(move |execution, shot| {
         std::fs::write(
             &source,
             "nika: changed\npermits: {}\ntasks:\n  b:\n    infer: { prompt: \"changed\" }\n",
@@ -391,7 +426,7 @@ fn child_and_skill_edits_after_claim_cannot_change_the_admitted_world() {
     std::fs::write(dir.path().join("workflows/skills/review/SKILL.md"), skill).expect("skill");
     let child_path = dir.path().join("workflows/child.nika.yaml");
     let skill_path = dir.path().join("workflows/skills/review/SKILL.md");
-    let run: RunSeam = Rc::new(move |execution, _shot| {
+    let run: ExecutionRunSeam = Rc::new(move |execution, _shot| {
         std::fs::write(&child_path, "nika: replacement\ntasks: {}\n").expect("mutate child");
         std::fs::write(&skill_path, "replacement").expect("mutate skill");
         assert_eq!(
@@ -441,7 +476,7 @@ fn source_symlink_swap_after_claim_cannot_change_the_pinned_run_bytes() {
     .expect("source B");
     let registry = registry_with(SAUTER);
     let expected = ArmGeneration::compute(registry.1.beats().next().expect("beat"), &original);
-    let seam: RunSeam = Rc::new(move |execution, shot| {
+    let seam: ExecutionRunSeam = Rc::new(move |execution, shot| {
         std::fs::remove_file(&source).expect("remove A");
         symlink(&replacement, &source).expect("swap to symlink B");
         assert_eq!(
@@ -531,7 +566,7 @@ fn a_symlinked_project_root_is_refused_before_claim_or_run() {
     let (runs, run) = run_counter();
     let fixture = registry_with(SAUTER);
     std::fs::write(project.path().join("nika.yaml"), &fixture.0).expect("registry");
-    let error = FireCtx::new(
+    let error = FireCtx::new_with_execution(
         linked,
         fixture.1,
         0,
@@ -557,7 +592,7 @@ fn a_dot_suffixed_symlinked_project_root_is_refused() {
     symlink(project.path(), &linked).expect("project symlink");
     let fixture = registry_with(SAUTER);
     std::fs::write(project.path().join("nika.yaml"), &fixture.0).expect("registry");
-    let error = FireCtx::new(
+    let error = FireCtx::new_with_execution(
         linked.join("."),
         fixture.1,
         0,
@@ -576,7 +611,7 @@ fn a_registry_from_another_project_is_refused_at_construction() {
     let held = registry_with(SAUTER);
     std::fs::write(project.path().join("nika.yaml"), held.0).expect("held registry");
     let foreign = registry_with(FILE);
-    let error = FireCtx::new(
+    let error = FireCtx::new_with_execution(
         project.path().to_path_buf(),
         foreign.1,
         0,
@@ -601,7 +636,7 @@ fn project_path_replacement_cannot_split_workflow_and_state_custody() {
         .expect("original workflow");
     let seen = Rc::new(Cell::new(false));
     let saw_original = Rc::clone(&seen);
-    let run: RunSeam = Rc::new(move |execution, _shot| {
+    let run: ExecutionRunSeam = Rc::new(move |execution, _shot| {
         assert_eq!(
             execution
                 .snapshot()

--- a/crates/nika-arm/src/lib.rs
+++ b/crates/nika-arm/src/lib.rs
@@ -16,8 +16,8 @@ pub mod fire;
 pub mod state;
 
 pub use fire::{
-    FireCtx, FireCtxError, FireVerdict, RunSeam, RunShot, RunUpshot, Wait, WaitSeam, fire_beat,
-    labels,
+    ExecutionRunSeam, FireCtx, FireCtxError, FireVerdict, RunSeam, RunShot, RunUpshot, Wait,
+    WaitSeam, fire_beat, labels,
 };
 pub use state::{
     ArmState, Claim, ExecutionLink, FireKind, Folded, HealOutcome, HistoryEntry, LastRecord,

--- a/crates/nika-arm/src/lib.rs
+++ b/crates/nika-arm/src/lib.rs
@@ -20,6 +20,6 @@ pub use fire::{
     labels,
 };
 pub use state::{
-    ArmState, Claim, FireKind, Folded, HealOutcome, HistoryEntry, LastRecord, Receipt,
-    RecordOutcome, Rotation, Unsettled,
+    ArmState, Claim, ExecutionLink, FireKind, Folded, HealOutcome, HistoryEntry, LastRecord,
+    Receipt, RecordOutcome, Rotation, Unsettled,
 };

--- a/crates/nika-arm/src/state.rs
+++ b/crates/nika-arm/src/state.rs
@@ -19,7 +19,8 @@ use nika_fs::OwnedDir;
 use nix::fcntl::{Flock, FlockArg};
 
 pub use nika_cadence::ledger::{
-    Claim, DecisionKind as FireKind, HistoryEntry, LastRecord, Receipt, RecordOutcome, Unsettled,
+    Claim, DecisionKind as FireKind, ExecutionLink, HistoryEntry, LastRecord, Receipt,
+    RecordOutcome, Unsettled,
 };
 
 mod replay;
@@ -415,6 +416,10 @@ impl ArmState {
     ) -> io::Result<(OwnedDir, std::fs::File)> {
         let project = self.project_dir()?;
         Ok((project.try_clone()?, project.open_relative(relative)?))
+    }
+
+    pub(crate) fn held_project(&self) -> io::Result<OwnedDir> {
+        self.project_dir()?.try_clone()
     }
 
     fn project_dir(&self) -> io::Result<&OwnedDir> {

--- a/crates/nika-arm/src/state.rs
+++ b/crates/nika-arm/src/state.rs
@@ -127,6 +127,26 @@ impl ArmState {
             .map(|r| r.slot.to_zoned(jiff::tz::TimeZone::UTC)))
     }
 
+    /// Read the last fired slot without creating, locking, repairing, or
+    /// projecting any sidecar state.
+    ///
+    /// This is the planning/dry-run surface: all traversal remains beneath
+    /// the held project descriptor, an absent path means never fired, and an
+    /// existing journal is verified from its bytes without rewriting caches.
+    ///
+    /// # Errors
+    /// An existing sidecar is unsafe, inaccessible, or fails verified replay.
+    pub fn peek_last_fired(&self, label: &str) -> io::Result<Option<Zoned>> {
+        let dir = match self.project_dir()?.open_below(&[".nika", "arm", label]) {
+            Ok(dir) => dir,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => return Err(error),
+        };
+        Ok(replay::replay_safe(&dir)?
+            .last
+            .map(|record| record.slot.to_zoned(jiff::tz::TimeZone::UTC)))
+    }
+
     /// Read the projection cache, rebuilding it from the verified chain on miss.
     /// # Errors
     /// The sidecar is inaccessible, redirected, or fails verified replay.

--- a/crates/nika-arm/src/state/tests.rs
+++ b/crates/nika-arm/src/state/tests.rs
@@ -96,6 +96,34 @@ fn last_fired_is_none_then_the_recorded_slot() {
     assert_eq!(fired.timestamp(), expected);
 }
 
+#[test]
+fn peek_last_fired_never_creates_or_repairs_sidecar_state() {
+    let (dir, state) = state("peek-last");
+    assert!(
+        state
+            .peek_last_fired("doctor")
+            .expect("fresh peek")
+            .is_none()
+    );
+    assert!(!dir.path().join(".nika").exists(), "fresh peek is inert");
+
+    state
+        .record("doctor", &entry(FireKind::Fired))
+        .expect("seed record");
+    let last = dir.path().join(".nika/arm/doctor/last.json");
+    std::fs::remove_file(&last).expect("remove projection cache");
+    let fired = state
+        .peek_last_fired("doctor")
+        .expect("verified read")
+        .expect("recorded slot");
+    let expected: Timestamp = "2026-08-19T03:00:00Z".parse().expect("ts");
+    assert_eq!(fired.timestamp(), expected);
+    assert!(
+        !last.exists(),
+        "peek never repairs a missing projection cache"
+    );
+}
+
 /// (b) The kernel lease, not PID metadata, is the lock authority.
 #[test]
 fn a_kernel_lease_refuses_overlap_then_releases_on_drop() {

--- a/crates/nika-cadence/public-api.txt
+++ b/crates/nika-cadence/public-api.txt
@@ -971,6 +971,7 @@ pub type nika_cadence::ledger::JournalFormat::Output = T
 #[non_exhaustive] pub struct nika_cadence::ledger::Claim
 pub nika_cadence::ledger::Claim::deadline: jiff::timestamp::Timestamp
 pub nika_cadence::ledger::Claim::decided_at: jiff::timestamp::Timestamp
+pub nika_cadence::ledger::Claim::execution: core::option::Option<nika_cadence::ExecutionLink>
 pub nika_cadence::ledger::Claim::generation: core::option::Option<nika_cadence::firing::ArmGeneration>
 pub nika_cadence::ledger::Claim::slot_id: nika_cadence::firing::SlotId
 impl nika_cadence::ledger::Claim
@@ -1003,8 +1004,50 @@ impl<T> core::convert::From<T> for nika_cadence::ledger::Claim
 pub fn nika_cadence::ledger::Claim::from(t: T) -> T
 impl<T> typenum::type_operators::Same for nika_cadence::ledger::Claim
 pub type nika_cadence::ledger::Claim::Output = T
+#[non_exhaustive] pub struct nika_cadence::ledger::ExecutionLink
+impl nika_cadence::ExecutionLink
+pub fn nika_cadence::ExecutionLink::execution_id(&self) -> &str
+pub fn nika_cadence::ExecutionLink::new(execution_id: impl core::convert::Into<alloc::string::String>, trace_id: impl core::convert::Into<alloc::string::String>) -> core::option::Option<Self>
+pub fn nika_cadence::ExecutionLink::trace_id(&self) -> &str
+impl core::clone::Clone for nika_cadence::ExecutionLink
+pub fn nika_cadence::ExecutionLink::clone(&self) -> nika_cadence::ExecutionLink
+impl core::cmp::Eq for nika_cadence::ExecutionLink
+impl core::cmp::PartialEq for nika_cadence::ExecutionLink
+pub fn nika_cadence::ExecutionLink::eq(&self, other: &nika_cadence::ExecutionLink) -> bool
+impl core::fmt::Debug for nika_cadence::ExecutionLink
+pub fn nika_cadence::ExecutionLink::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for nika_cadence::ExecutionLink
+impl<Q, K> equivalent::Equivalent<K> for nika_cadence::ExecutionLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn nika_cadence::ExecutionLink::equivalent(&self, key: &K) -> bool
+impl<Q, K> hashbrown::Equivalent<K> for nika_cadence::ExecutionLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn nika_cadence::ExecutionLink::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for nika_cadence::ExecutionLink where U: core::convert::From<T>
+pub fn nika_cadence::ExecutionLink::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_cadence::ExecutionLink where U: core::convert::Into<T>
+pub type nika_cadence::ExecutionLink::Error = core::convert::Infallible
+pub fn nika_cadence::ExecutionLink::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_cadence::ExecutionLink where U: core::convert::TryFrom<T>
+pub type nika_cadence::ExecutionLink::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_cadence::ExecutionLink::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_cadence::ExecutionLink where T: core::clone::Clone
+pub type nika_cadence::ExecutionLink::Owned = T
+pub fn nika_cadence::ExecutionLink::clone_into(&self, target: &mut T)
+pub fn nika_cadence::ExecutionLink::to_owned(&self) -> T
+impl<T> core::any::Any for nika_cadence::ExecutionLink where T: 'static + ?core::marker::Sized
+pub fn nika_cadence::ExecutionLink::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_cadence::ExecutionLink where T: ?core::marker::Sized
+pub fn nika_cadence::ExecutionLink::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_cadence::ExecutionLink where T: ?core::marker::Sized
+pub fn nika_cadence::ExecutionLink::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_cadence::ExecutionLink where T: core::clone::Clone
+pub unsafe fn nika_cadence::ExecutionLink::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_cadence::ExecutionLink
+pub fn nika_cadence::ExecutionLink::from(t: T) -> T
+impl<T> typenum::type_operators::Same for nika_cadence::ExecutionLink
+pub type nika_cadence::ExecutionLink::Output = T
 #[non_exhaustive] pub struct nika_cadence::ledger::HistoryEntry
 pub nika_cadence::ledger::HistoryEntry::decided_at: jiff::timestamp::Timestamp
+pub nika_cadence::ledger::HistoryEntry::execution: core::option::Option<nika_cadence::ExecutionLink>
 pub nika_cadence::ledger::HistoryEntry::exit: core::option::Option<u8>
 pub nika_cadence::ledger::HistoryEntry::fencing: core::option::Option<nika_cadence::firing::FencingToken>
 pub nika_cadence::ledger::HistoryEntry::generation: core::option::Option<nika_cadence::firing::ArmGeneration>
@@ -1045,6 +1088,7 @@ pub fn nika_cadence::ledger::HistoryEntry::from(t: T) -> T
 impl<T> typenum::type_operators::Same for nika_cadence::ledger::HistoryEntry
 pub type nika_cadence::ledger::HistoryEntry::Output = T
 #[non_exhaustive] pub struct nika_cadence::ledger::LastRecord
+pub nika_cadence::ledger::LastRecord::execution: core::option::Option<nika_cadence::ExecutionLink>
 pub nika_cadence::ledger::LastRecord::exit: core::option::Option<u8>
 pub nika_cadence::ledger::LastRecord::fired_at: jiff::timestamp::Timestamp
 pub nika_cadence::ledger::LastRecord::generation: core::option::Option<nika_cadence::firing::ArmGeneration>
@@ -1081,6 +1125,7 @@ impl<T> typenum::type_operators::Same for nika_cadence::ledger::LastRecord
 pub type nika_cadence::ledger::LastRecord::Output = T
 #[non_exhaustive] pub struct nika_cadence::ledger::Receipt
 pub nika_cadence::ledger::Receipt::decided_at: jiff::timestamp::Timestamp
+pub nika_cadence::ledger::Receipt::execution: core::option::Option<nika_cadence::ExecutionLink>
 pub nika_cadence::ledger::Receipt::exit: u8
 pub nika_cadence::ledger::Receipt::fencing: nika_cadence::firing::FencingToken
 pub nika_cadence::ledger::Receipt::generation: core::option::Option<nika_cadence::firing::ArmGeneration>
@@ -1165,6 +1210,7 @@ pub type nika_cadence::ledger::RecordOutcome::Output = T
 #[non_exhaustive] pub struct nika_cadence::ledger::Unsettled
 pub nika_cadence::ledger::Unsettled::claimed_at: jiff::timestamp::Timestamp
 pub nika_cadence::ledger::Unsettled::deadline: jiff::timestamp::Timestamp
+pub nika_cadence::ledger::Unsettled::execution: core::option::Option<nika_cadence::ExecutionLink>
 pub nika_cadence::ledger::Unsettled::seq: u64
 pub nika_cadence::ledger::Unsettled::slot_id: nika_cadence::firing::SlotId
 impl core::clone::Clone for nika_cadence::ledger::Unsettled
@@ -2487,6 +2533,7 @@ pub type nika_cadence::error::CadenceError::Output = T
 #[non_exhaustive] pub struct nika_cadence::Claim
 pub nika_cadence::Claim::deadline: jiff::timestamp::Timestamp
 pub nika_cadence::Claim::decided_at: jiff::timestamp::Timestamp
+pub nika_cadence::Claim::execution: core::option::Option<nika_cadence::ExecutionLink>
 pub nika_cadence::Claim::generation: core::option::Option<nika_cadence::firing::ArmGeneration>
 pub nika_cadence::Claim::slot_id: nika_cadence::firing::SlotId
 impl nika_cadence::ledger::Claim
@@ -2596,6 +2643,47 @@ impl<T> core::convert::From<T> for nika_cadence::due::Due<'a>
 pub fn nika_cadence::due::Due<'a>::from(t: T) -> T
 impl<T> typenum::type_operators::Same for nika_cadence::due::Due<'a>
 pub type nika_cadence::due::Due<'a>::Output = T
+#[non_exhaustive] pub struct nika_cadence::ExecutionLink
+impl nika_cadence::ExecutionLink
+pub fn nika_cadence::ExecutionLink::execution_id(&self) -> &str
+pub fn nika_cadence::ExecutionLink::new(execution_id: impl core::convert::Into<alloc::string::String>, trace_id: impl core::convert::Into<alloc::string::String>) -> core::option::Option<Self>
+pub fn nika_cadence::ExecutionLink::trace_id(&self) -> &str
+impl core::clone::Clone for nika_cadence::ExecutionLink
+pub fn nika_cadence::ExecutionLink::clone(&self) -> nika_cadence::ExecutionLink
+impl core::cmp::Eq for nika_cadence::ExecutionLink
+impl core::cmp::PartialEq for nika_cadence::ExecutionLink
+pub fn nika_cadence::ExecutionLink::eq(&self, other: &nika_cadence::ExecutionLink) -> bool
+impl core::fmt::Debug for nika_cadence::ExecutionLink
+pub fn nika_cadence::ExecutionLink::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for nika_cadence::ExecutionLink
+impl<Q, K> equivalent::Equivalent<K> for nika_cadence::ExecutionLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn nika_cadence::ExecutionLink::equivalent(&self, key: &K) -> bool
+impl<Q, K> hashbrown::Equivalent<K> for nika_cadence::ExecutionLink where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn nika_cadence::ExecutionLink::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for nika_cadence::ExecutionLink where U: core::convert::From<T>
+pub fn nika_cadence::ExecutionLink::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_cadence::ExecutionLink where U: core::convert::Into<T>
+pub type nika_cadence::ExecutionLink::Error = core::convert::Infallible
+pub fn nika_cadence::ExecutionLink::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_cadence::ExecutionLink where U: core::convert::TryFrom<T>
+pub type nika_cadence::ExecutionLink::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_cadence::ExecutionLink::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_cadence::ExecutionLink where T: core::clone::Clone
+pub type nika_cadence::ExecutionLink::Owned = T
+pub fn nika_cadence::ExecutionLink::clone_into(&self, target: &mut T)
+pub fn nika_cadence::ExecutionLink::to_owned(&self) -> T
+impl<T> core::any::Any for nika_cadence::ExecutionLink where T: 'static + ?core::marker::Sized
+pub fn nika_cadence::ExecutionLink::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_cadence::ExecutionLink where T: ?core::marker::Sized
+pub fn nika_cadence::ExecutionLink::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_cadence::ExecutionLink where T: ?core::marker::Sized
+pub fn nika_cadence::ExecutionLink::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_cadence::ExecutionLink where T: core::clone::Clone
+pub unsafe fn nika_cadence::ExecutionLink::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_cadence::ExecutionLink
+pub fn nika_cadence::ExecutionLink::from(t: T) -> T
+impl<T> typenum::type_operators::Same for nika_cadence::ExecutionLink
+pub type nika_cadence::ExecutionLink::Output = T
 pub struct nika_cadence::FencingToken(_)
 impl nika_cadence::firing::FencingToken
 pub const fn nika_cadence::firing::FencingToken::get(self) -> u64
@@ -2725,6 +2813,7 @@ impl<T> typenum::type_operators::Same for nika_cadence::firing::FiringPolicy
 pub type nika_cadence::firing::FiringPolicy::Output = T
 #[non_exhaustive] pub struct nika_cadence::HistoryEntry
 pub nika_cadence::HistoryEntry::decided_at: jiff::timestamp::Timestamp
+pub nika_cadence::HistoryEntry::execution: core::option::Option<nika_cadence::ExecutionLink>
 pub nika_cadence::HistoryEntry::exit: core::option::Option<u8>
 pub nika_cadence::HistoryEntry::fencing: core::option::Option<nika_cadence::firing::FencingToken>
 pub nika_cadence::HistoryEntry::generation: core::option::Option<nika_cadence::firing::ArmGeneration>
@@ -2765,6 +2854,7 @@ pub fn nika_cadence::ledger::HistoryEntry::from(t: T) -> T
 impl<T> typenum::type_operators::Same for nika_cadence::ledger::HistoryEntry
 pub type nika_cadence::ledger::HistoryEntry::Output = T
 #[non_exhaustive] pub struct nika_cadence::LastRecord
+pub nika_cadence::LastRecord::execution: core::option::Option<nika_cadence::ExecutionLink>
 pub nika_cadence::LastRecord::exit: core::option::Option<u8>
 pub nika_cadence::LastRecord::fired_at: jiff::timestamp::Timestamp
 pub nika_cadence::LastRecord::generation: core::option::Option<nika_cadence::firing::ArmGeneration>
@@ -2926,6 +3016,7 @@ pub type nika_cadence::firing::SlotId::Output = T
 #[non_exhaustive] pub struct nika_cadence::Unsettled
 pub nika_cadence::Unsettled::claimed_at: jiff::timestamp::Timestamp
 pub nika_cadence::Unsettled::deadline: jiff::timestamp::Timestamp
+pub nika_cadence::Unsettled::execution: core::option::Option<nika_cadence::ExecutionLink>
 pub nika_cadence::Unsettled::seq: u64
 pub nika_cadence::Unsettled::slot_id: nika_cadence::firing::SlotId
 impl core::clone::Clone for nika_cadence::ledger::Unsettled

--- a/crates/nika-cadence/src/ledger.rs
+++ b/crates/nika-cadence/src/ledger.rs
@@ -4,15 +4,23 @@
 //! Pure vocabulary and fold for the durable arm ledger.
 //!
 //! This module knows JSON bytes and firing semantics, never paths, locks, or
-//! files. The CLI adapter supplies journal texts oldest-first and owns every
-//! effect. Keeping the wire judge beside the firing machine makes replay
-//! available to every future firer without depending upward on `nika-cli`.
+//! files. Its replay judge stays available without depending on `nika-cli`.
 
 use jiff::Timestamp;
 
 use crate::firing::{
     self, ArmGeneration, FencingToken, FiringEvent, FiringState, SkipReason, SlotId,
 };
+
+mod execution;
+mod projection;
+
+pub use execution::ExecutionLink;
+use execution::{
+    parse as execution_link, parse_optional as optional_link,
+    render_fields as render_execution_fields,
+};
+pub use projection::{last_projection, parse_last, render_last};
 
 /// The versioned ledger schema tag.
 pub const LEDGER_SCHEMA: &str = "nika/arm-event@1";
@@ -95,6 +103,8 @@ pub struct HistoryEntry {
     pub fencing: Option<FencingToken>,
     /// Generation pinned by the firing.
     pub generation: Option<ArmGeneration>,
+    /// Shared execution-service identity, present on W04+ claims/receipts.
+    pub execution: Option<ExecutionLink>,
 }
 
 impl HistoryEntry {
@@ -112,6 +122,7 @@ impl HistoryEntry {
             slot_id: None,
             fencing: None,
             generation: None,
+            execution: None,
         }
     }
 }
@@ -128,6 +139,8 @@ pub struct Claim {
     pub deadline: Timestamp,
     /// Claim instant.
     pub decided_at: Timestamp,
+    /// Execution identity allocated before this claim became durable.
+    pub execution: Option<ExecutionLink>,
 }
 
 impl Claim {
@@ -139,6 +152,7 @@ impl Claim {
             generation: None,
             deadline,
             decided_at,
+            execution: None,
         }
     }
 }
@@ -166,6 +180,8 @@ pub struct Receipt {
     pub fencing: FencingToken,
     /// Generation copied from the claim.
     pub generation: Option<ArmGeneration>,
+    /// Execution identity copied from the claim.
+    pub execution: Option<ExecutionLink>,
 }
 
 impl Receipt {
@@ -189,6 +205,7 @@ impl Receipt {
             slot_id: claim.slot_id.clone(),
             fencing,
             generation: claim.generation.clone(),
+            execution: claim.execution.clone(),
         }
     }
 
@@ -216,6 +233,7 @@ impl Receipt {
             slot_id: Some(self.slot_id.clone()),
             fencing: Some(self.fencing),
             generation: self.generation.clone(),
+            execution: self.execution.clone(),
         }
     }
 }
@@ -250,6 +268,8 @@ pub struct Unsettled {
     pub deadline: Timestamp,
     /// Claim instant.
     pub claimed_at: Timestamp,
+    /// Execution that may have started before the crash.
+    pub execution: Option<ExecutionLink>,
 }
 
 /// The stable `last.json` projection.
@@ -268,6 +288,8 @@ pub struct LastRecord {
     pub kind: DecisionKind,
     /// Optional pinned generation.
     pub generation: Option<ArmGeneration>,
+    /// Exact execution and root trace identity of the terminal run.
+    pub execution: Option<ExecutionLink>,
 }
 
 struct Replay {
@@ -382,6 +404,7 @@ pub fn unsettled(text: &str) -> Option<impl Iterator<Item = Unsettled> + use<>> 
                     slot_id,
                     deadline,
                     claimed_at,
+                    execution: doc.get("payload").and_then(execution_link),
                 },
             ));
             continue;
@@ -561,6 +584,7 @@ impl Walker {
                             .and_then(|p| p.get("gen"))
                             .and_then(serde_json::Value::as_str)
                             .and_then(ArmGeneration::from_wire),
+                        execution: payload.and_then(execution_link),
                     });
                     self.last_projection = Some(group);
                 }
@@ -618,6 +642,7 @@ impl Walker {
                 exit,
                 kind: decision_kind(kind),
                 generation: None,
+                execution: None,
             });
             self.last_projection = Some(group);
         }
@@ -906,8 +931,18 @@ fn verify_payload(
         }
         "claimed" => {
             const KEYS: [&str; 4] = ["attempt", "deadline", "fencing", "gen"];
+            const EXECUTION_KEYS: [&str; 6] = [
+                "attempt",
+                "deadline",
+                "fencing",
+                "gen",
+                "execution_id",
+                "trace_id",
+            ];
+            let keys_valid = exact_keys(object, &KEYS)
+                || (exact_keys(object, &EXECUTION_KEYS) && execution_link(payload).is_some());
             (slot_id.is_some()
-                && exact_keys(object, &KEYS)
+                && keys_valid
                 && payload.get("attempt")?.as_u64() == Some(1)
                 && payload
                     .get("deadline")?
@@ -920,6 +955,17 @@ fn verify_payload(
         }
         "fired" | "skipped" | "paused" | "failed" | "disarmed" => {
             const KEYS: [&str; 7] = ["slot", "reason", "trace", "exit", "slots", "fencing", "gen"];
+            const EXECUTION_KEYS: [&str; 9] = [
+                "slot",
+                "reason",
+                "trace",
+                "exit",
+                "slots",
+                "fencing",
+                "gen",
+                "execution_id",
+                "trace_id",
+            ];
             const LEGACY_KEYS: [&str; 8] = [
                 "slot", "reason", "trace", "exit", "slots", "fencing", "gen", "legacy",
             ];
@@ -927,6 +973,9 @@ fn verify_payload(
             let semantic_slot = slot.is_string() || slot_id.is_some();
             let explicit_legacy = payload.get("legacy") == Some(&serde_json::Value::Bool(true));
             let keys_valid = exact_keys(object, &KEYS)
+                || (matches!(kind, "fired" | "paused" | "failed")
+                    && exact_keys(object, &EXECUTION_KEYS)
+                    && execution_link(payload).is_some())
                 || (matches!(kind, "fired" | "paused" | "failed")
                     && explicit_legacy
                     && exact_keys(object, &LEGACY_KEYS));
@@ -1044,6 +1093,7 @@ struct ClaimBinding {
     slot_id: String,
     fencing: u64,
     generation: Option<String>,
+    execution: Option<ExecutionLink>,
     settled: bool,
 }
 
@@ -1061,6 +1111,7 @@ impl LifecycleValidator {
             .get("gen")
             .and_then(serde_json::Value::as_str)
             .map(str::to_owned);
+        let execution = execution_link(payload);
         let accepted = match kind {
             "claimed" => {
                 let Some(slot_id) = slot_id else { return false };
@@ -1069,6 +1120,7 @@ impl LifecycleValidator {
                     slot_id: slot_id.to_owned(),
                     fencing,
                     generation,
+                    execution,
                     settled: false,
                 });
                 true
@@ -1093,6 +1145,7 @@ impl LifecycleValidator {
                     claim.slot_id == slot_id
                         && claim.fencing == fencing
                         && claim.generation == generation
+                        && claim.execution == execution
                 }) else {
                     return false;
                 };
@@ -1358,46 +1411,6 @@ pub fn json_str(raw: &str) -> String {
     out
 }
 
-/// Render the byte-stable `last.json` projection.
-#[must_use]
-pub fn render_last(record: &LastRecord) -> String {
-    let trace = record.trace.as_deref().map_or("null".to_owned(), json_str);
-    let exit = record.exit.unwrap_or(0);
-    let generation = record
-        .generation
-        .as_ref()
-        .map_or("null".to_owned(), |value| json_str(value.as_str()));
-    format!(
-        "{{\"slot\":\"{}\",\"fired_at\":\"{}\",\"trace\":{trace},\"exit\":{exit},\"kind\":\"{}\",\"gen\":{generation}}}\n",
-        record.slot,
-        record.fired_at,
-        record.kind.as_str()
-    )
-}
-
-/// Parse the byte-stable `last.json` projection.
-#[must_use]
-pub fn parse_last(text: &str) -> Option<LastRecord> {
-    let doc: serde_json::Value = serde_json::from_str(text).ok()?;
-    Some(LastRecord {
-        slot: doc.get("slot")?.as_str()?.parse().ok()?,
-        fired_at: doc.get("fired_at")?.as_str()?.parse().ok()?,
-        trace: doc
-            .get("trace")
-            .and_then(serde_json::Value::as_str)
-            .map(str::to_owned),
-        exit: doc
-            .get("exit")
-            .and_then(serde_json::Value::as_u64)
-            .and_then(|value| u8::try_from(value).ok()),
-        kind: DecisionKind::parse_projection(doc.get("kind")?.as_str()?)?,
-        generation: doc
-            .get("gen")
-            .and_then(serde_json::Value::as_str)
-            .and_then(ArmGeneration::from_wire),
-    })
-}
-
 /// Render the decision payload inside a versioned ledger envelope.
 #[must_use]
 pub fn decision_payload(entry: &HistoryEntry) -> String {
@@ -1419,8 +1432,9 @@ pub fn decision_payload(entry: &HistoryEntry) -> String {
         .generation
         .as_ref()
         .map_or("null".to_owned(), |value| json_str(value.as_str()));
+    let execution = render_execution_fields(entry.execution.as_ref());
     format!(
-        "{{\"slot\":{slot},\"reason\":{reason},\"trace\":{trace},\"exit\":{exit},\"slots\":{slots},\"fencing\":{fencing},\"gen\":{generation}}}"
+        "{{\"slot\":{slot},\"reason\":{reason},\"trace\":{trace},\"exit\":{exit},\"slots\":{slots},\"fencing\":{fencing},\"gen\":{generation}{execution}}}"
     )
 }
 
@@ -1436,7 +1450,11 @@ pub fn legacy_receipt_payload(entry: &HistoryEntry) -> Option<String> {
         (DecisionKind::Fired, Some(0)) | (DecisionKind::Paused, Some(4))
     ) || matches!(entry.kind, DecisionKind::Failed)
         && entry.exit.is_some_and(|exit| exit != 0 && exit != 4);
-    if entry.slot_id.is_some() || entry.fencing.is_some() || !kind_matches {
+    if entry.slot_id.is_some()
+        || entry.fencing.is_some()
+        || entry.execution.is_some()
+        || !kind_matches
+    {
         return None;
     }
     let mut payload = decision_payload(entry);
@@ -1445,19 +1463,6 @@ pub fn legacy_receipt_payload(entry: &HistoryEntry) -> Option<String> {
     }
     payload.push_str(",\"legacy\":true}");
     Some(payload)
-}
-
-/// Build the slot-bearing `last.json` projection from one decision.
-#[must_use]
-pub fn last_projection(entry: &HistoryEntry) -> Option<LastRecord> {
-    Some(LastRecord {
-        slot: entry.slot?,
-        fired_at: entry.decided_at,
-        trace: entry.trace.clone(),
-        exit: entry.exit,
-        kind: entry.kind,
-        generation: entry.generation.clone(),
-    })
 }
 
 /// Render the canonical claim payload whose sequence is its fencing token.
@@ -1470,8 +1475,9 @@ pub fn claim_payload(claim: &Claim, seq: u64) -> Option<String> {
         .generation
         .as_ref()
         .map_or("null".to_owned(), |value| json_str(value.as_str()));
+    let execution = render_execution_fields(claim.execution.as_ref());
     Some(format!(
-        "{{\"attempt\":1,\"deadline\":\"{}\",\"fencing\":{seq},\"gen\":{generation}}}",
+        "{{\"attempt\":1,\"deadline\":\"{}\",\"fencing\":{seq},\"gen\":{generation}{execution}}}",
         claim.deadline
     ))
 }

--- a/crates/nika-cadence/src/ledger/execution.rs
+++ b/crates/nika-cadence/src/ledger/execution.rs
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+use serde_json::Value;
+
+use super::json_str;
+
+/// Durable association between one ARM attempt and the shared execution
+/// service. The trace identity must be the execution UUID's exact bytes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct ExecutionLink {
+    execution_id: String,
+    trace_id: String,
+}
+
+impl ExecutionLink {
+    /// Construct a canonical `exe-<uuid>` / 32-lower-hex identity pair.
+    #[must_use]
+    pub fn new(execution_id: impl Into<String>, trace_id: impl Into<String>) -> Option<Self> {
+        let execution_id = execution_id.into();
+        let trace_id = trace_id.into();
+        pair_is_direct(&execution_id, &trace_id).then_some(Self {
+            execution_id,
+            trace_id,
+        })
+    }
+
+    /// Admitted execution identity.
+    #[must_use]
+    pub fn execution_id(&self) -> &str {
+        &self.execution_id
+    }
+
+    /// Direct root trace identity.
+    #[must_use]
+    pub fn trace_id(&self) -> &str {
+        &self.trace_id
+    }
+}
+
+pub(super) fn parse(payload: &Value) -> Option<ExecutionLink> {
+    match parse_optional(payload)? {
+        OptionalLink::Absent => None,
+        OptionalLink::Present(link) => Some(link),
+    }
+}
+
+/// Parse an optional link while distinguishing absence from malformed or
+/// one-sided identity fields.
+pub(super) fn parse_optional(payload: &Value) -> Option<OptionalLink> {
+    match (payload.get("execution_id"), payload.get("trace_id")) {
+        (None, None) => Some(OptionalLink::Absent),
+        (Some(execution_id), Some(trace_id)) => {
+            ExecutionLink::new(execution_id.as_str()?, trace_id.as_str()?)
+                .map(OptionalLink::Present)
+        }
+        _ => None,
+    }
+}
+
+pub(super) enum OptionalLink {
+    Absent,
+    Present(ExecutionLink),
+}
+
+impl OptionalLink {
+    pub(super) fn into_option(self) -> Option<ExecutionLink> {
+        match self {
+            Self::Absent => None,
+            Self::Present(link) => Some(link),
+        }
+    }
+}
+
+pub(super) fn render_fields(link: Option<&ExecutionLink>) -> String {
+    link.map_or_else(String::new, |link| {
+        format!(
+            ",\"execution_id\":{},\"trace_id\":{}",
+            json_str(link.execution_id()),
+            json_str(link.trace_id())
+        )
+    })
+}
+
+fn pair_is_direct(execution_id: &str, trace_id: &str) -> bool {
+    let Some(uuid) = execution_id.strip_prefix("exe-") else {
+        return false;
+    };
+    if uuid.len() != 36
+        || uuid.as_bytes().get(8) != Some(&b'-')
+        || uuid.as_bytes().get(13) != Some(&b'-')
+        || uuid.as_bytes().get(18) != Some(&b'-')
+        || uuid.as_bytes().get(23) != Some(&b'-')
+    {
+        return false;
+    }
+    let compact = uuid
+        .bytes()
+        .filter(|byte| *byte != b'-')
+        .collect::<Vec<_>>();
+    compact.len() == 32
+        && compact
+            .iter()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(byte))
+        && trace_id.as_bytes() == compact.as_slice()
+}

--- a/crates/nika-cadence/src/ledger/projection.rs
+++ b/crates/nika-cadence/src/ledger/projection.rs
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+use super::{
+    ArmGeneration, DecisionKind, HistoryEntry, LastRecord, json_str, optional_link,
+    render_execution_fields,
+};
+
+/// Render the byte-stable `last.json` projection.
+#[must_use]
+pub fn render_last(record: &LastRecord) -> String {
+    let trace = record.trace.as_deref().map_or("null".to_owned(), json_str);
+    let exit = record.exit.unwrap_or(0);
+    let generation = record
+        .generation
+        .as_ref()
+        .map_or("null".to_owned(), |value| json_str(value.as_str()));
+    let execution = render_execution_fields(record.execution.as_ref());
+    format!(
+        "{{\"slot\":\"{}\",\"fired_at\":\"{}\",\"trace\":{trace},\"exit\":{exit},\"kind\":\"{}\",\"gen\":{generation}{execution}}}\n",
+        record.slot,
+        record.fired_at,
+        record.kind.as_str()
+    )
+}
+
+/// Parse the byte-stable `last.json` projection.
+#[must_use]
+pub fn parse_last(text: &str) -> Option<LastRecord> {
+    let doc: serde_json::Value = serde_json::from_str(text).ok()?;
+    Some(LastRecord {
+        slot: doc.get("slot")?.as_str()?.parse().ok()?,
+        fired_at: doc.get("fired_at")?.as_str()?.parse().ok()?,
+        trace: doc
+            .get("trace")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_owned),
+        exit: doc
+            .get("exit")
+            .and_then(serde_json::Value::as_u64)
+            .and_then(|value| u8::try_from(value).ok()),
+        kind: DecisionKind::parse_projection(doc.get("kind")?.as_str()?)?,
+        generation: doc
+            .get("gen")
+            .and_then(serde_json::Value::as_str)
+            .and_then(ArmGeneration::from_wire),
+        execution: optional_link(&doc)?.into_option(),
+    })
+}
+
+/// Build the slot-bearing `last.json` projection from one decision.
+#[must_use]
+pub fn last_projection(entry: &HistoryEntry) -> Option<LastRecord> {
+    Some(LastRecord {
+        slot: entry.slot?,
+        fired_at: entry.decided_at,
+        trace: entry.trace.clone(),
+        exit: entry.exit,
+        kind: entry.kind,
+        generation: entry.generation.clone(),
+        execution: entry.execution.clone(),
+    })
+}

--- a/crates/nika-cadence/src/ledger/tests.rs
+++ b/crates/nika-cadence/src/ledger/tests.rs
@@ -532,6 +532,7 @@ fn json_and_decision_payload_are_canonical() {
         slot_id: None,
         fencing: Some(FencingToken::new(9)),
         generation: ArmGeneration::from_wire(&"a".repeat(64)),
+        execution: None,
     };
     assert_eq!(
         decision_payload(&entry),
@@ -546,6 +547,7 @@ fn json_and_decision_payload_are_canonical() {
         generation: entry.generation.clone(),
         deadline: ts("2026-08-20T03:00:00Z"),
         decided_at: ts("2026-08-19T03:02:00Z"),
+        execution: None,
     };
     assert_eq!(
         claim_payload(&claim, 9).expect("claim payload"),
@@ -600,6 +602,7 @@ fn legacy_receipt_adapter_accepts_only_consistent_bare_terminals() {
         slot_id: None,
         fencing: None,
         generation: None,
+        execution: None,
     };
     for (kind, exit, word) in [
         (DecisionKind::Fired, Some(0), "fired"),
@@ -630,6 +633,12 @@ fn legacy_receipt_adapter_accepts_only_consistent_bare_terminals() {
     assert!(legacy_receipt_payload(&named).is_none());
     named.slot_id = None;
     named.fencing = Some(FencingToken::new(1));
+    assert!(legacy_receipt_payload(&named).is_none());
+    named.fencing = None;
+    named.execution = ExecutionLink::new(
+        "exe-018f1f6e-7b8c-7d9e-8fab-0123456789ab",
+        "018f1f6e7b8c7d9e8fab0123456789ab",
+    );
     assert!(legacy_receipt_payload(&named).is_none());
 }
 
@@ -791,6 +800,7 @@ fn typed_receipt_derives_kind_and_binds_the_claim() {
         generation: ArmGeneration::from_wire(&"b".repeat(64)),
         deadline: ts("2026-08-20T03:00:00Z"),
         decided_at: ts("2026-08-19T03:01:00Z"),
+        execution: None,
     };
     for (exit, kind) in [
         (0, DecisionKind::Fired),
@@ -813,6 +823,82 @@ fn typed_receipt_derives_kind_and_binds_the_claim() {
         assert_eq!(entry.fencing, Some(FencingToken::new(7)));
         assert_eq!(entry.generation, claim.generation);
     }
+}
+
+#[test]
+fn execution_link_is_direct_strict_and_survives_claim_replay() {
+    let execution_id = "exe-018f1f6e-7b8c-7d9e-8fab-0123456789ab";
+    let trace_id = "018f1f6e7b8c7d9e8fab0123456789ab";
+    let link = ExecutionLink::new(execution_id, trace_id).expect("direct identity pair");
+    assert_eq!(link.execution_id(), execution_id);
+    assert_eq!(link.trace_id(), trace_id);
+    assert!(ExecutionLink::new(execution_id, "0".repeat(32)).is_none());
+    assert!(ExecutionLink::new("job-not-an-execution", trace_id).is_none());
+    assert!(
+        parse_last(
+            r#"{"slot":"2026-08-19T03:00:00Z","fired_at":"2026-08-19T03:02:00Z","trace":null,"exit":0,"kind":"fired","gen":null,"execution_id":"exe-018f1f6e-7b8c-7d9e-8fab-0123456789ab"}"#,
+        )
+        .is_none()
+    );
+
+    let mut claim = Claim::new(
+        SlotId::from_wire(&"a".repeat(64)).expect("slot id"),
+        ts("2026-08-20T03:00:00Z"),
+        ts("2026-08-19T03:01:00Z"),
+    );
+    claim.execution = Some(link.clone());
+    let claim_payload = claim_payload(&claim, 1).expect("claim payload");
+    let (claim_line, claim_hash) = ledger_line(
+        1,
+        claim.decided_at,
+        "claimed",
+        Some(claim.slot_id.as_str()),
+        &claim_payload,
+        None,
+    )
+    .expect("claim line");
+    let unsettled_claim = unsettled(&format!("{claim_line}\n"))
+        .expect("valid claim")
+        .next()
+        .expect("unsettled");
+    assert_eq!(unsettled_claim.execution, Some(link.clone()));
+
+    let receipt = Receipt::for_claim(
+        &claim,
+        FencingToken::new(1),
+        ts("2026-08-19T03:00:00Z"),
+        ts("2026-08-19T03:02:00Z"),
+        Some(".nika/traces/exact.ndjson".to_owned()),
+        0,
+        None,
+    );
+    let receipt_entry = receipt.history_entry();
+    let receipt_payload = decision_payload(&receipt_entry);
+    let (receipt_line, _) = ledger_line(
+        2,
+        receipt_entry.decided_at,
+        "fired",
+        Some(claim.slot_id.as_str()),
+        &receipt_payload,
+        Some(&claim_hash),
+    )
+    .expect("receipt line");
+    let text = format!("{claim_line}\n{receipt_line}\n");
+    assert_eq!(scan_chain(&text).2, 2);
+    assert!(unsettled(&text).expect("valid chain").next().is_none());
+
+    let forged = receipt_payload.replace(trace_id, &"0".repeat(32));
+    assert!(
+        ledger_line(
+            2,
+            receipt_entry.decided_at,
+            "fired",
+            Some(claim.slot_id.as_str()),
+            &forged,
+            Some(&claim_hash),
+        )
+        .is_none()
+    );
 }
 
 #[test]

--- a/crates/nika-cadence/src/lib.rs
+++ b/crates/nika-cadence/src/lib.rs
@@ -88,7 +88,9 @@ pub use firing::{
     ArmGeneration, Decision, FencingToken, FiringEvent, FiringPolicy, FiringState, SkipReason,
     SlotId, decide, fold, transition,
 };
-pub use ledger::{Claim, DecisionKind, HistoryEntry, LastRecord, RecordOutcome, Unsettled};
+pub use ledger::{
+    Claim, DecisionKind, ExecutionLink, HistoryEntry, LastRecord, RecordOutcome, Unsettled,
+};
 pub use next::{Shift, Slot, next_slots};
 pub use parse::{parse_registry, validate};
 pub use registry::{AfterSkip, ArmRegistry, Beat, Cadence, Locus, MissPolicy, Overlap};

--- a/crates/nika-cli/Cargo.toml
+++ b/crates/nika-cli/Cargo.toml
@@ -19,6 +19,7 @@ nika-vocab  = { path = "../nika-vocab", version = "0.113.0" }
 nika-cadence = { path = "../nika-cadence", version = "0.113.0" }  # the arm: grammar + the pure next-slot calculator (L4→L0)
 nika-arm     = { path = "../nika-arm", version = "0.113.0" }      # descriptor-rooted ARM custody + the one firer (L4→L4)
 nika-fs      = { path = "../nika-fs", version = "0.113.0" }       # descriptor-rooted sidecar ownership (L4→L1)
+nika-execution = { path = "../nika-execution", version = "0.113.0" } # shared owned-byte admission/execution boundary (L4→L3)
 jiff        = { workspace = true }  # the CLOCK — nika-cadence is pure and takes a Zoned; reading one is an L4 act  # the project file (ceiling — the --max-cost-usd flag's default rung · D-2026-08-11-N5)
 nika-check  = { path = "../nika-check", version = "0.113.0" }  # the ADR-092 check ladder (the check verb · run gates · fix loop)
 nika-graph = { path = "../nika-graph", version = "0.113.0" }   # the canonical projection (inspect --format json renders it)

--- a/crates/nika-cli/public-api.txt
+++ b/crates/nika-cli/public-api.txt
@@ -280,6 +280,7 @@ pub mod nika_cli::verbs::arm::emit
 pub fn nika_cli::verbs::arm::emit::disarm(label: &str, write: bool) -> nika_cli_host::output::VerbOutput
 pub fn nika_cli::verbs::arm::emit::run(args: &nika_cli::verbs::arm::args::ArmArgs, emit_target: nika_cli::verbs::arm::args::EmitTarget) -> nika_cli_host::output::VerbOutput
 pub mod nika_cli::verbs::arm::fire
+pub use nika_cli::verbs::arm::fire::ExecutionRunSeam
 pub use nika_cli::verbs::arm::fire::FireCtx
 pub use nika_cli::verbs::arm::fire::FireCtxError
 pub use nika_cli::verbs::arm::fire::FireVerdict

--- a/crates/nika-cli/src/verbs/arm/fire.rs
+++ b/crates/nika-cli/src/verbs/arm/fire.rs
@@ -101,22 +101,20 @@ fn parse_now(raw: Option<&str>) -> Result<Zoned, String> {
     }
 }
 
-pub(crate) fn prod_run(shot: &RunShot) -> RunUpshot {
+pub(crate) fn prod_run(
+    execution: nika_execution::ExecutionContext<'_>,
+    shot: &RunShot,
+) -> RunUpshot {
     debug_assert!(!shot.workflow().is_empty());
     debug_assert_eq!(shot.generation().as_str().len(), 64);
     let Ok(_room) = enter_room(shot.project(), shot.root()) else {
         return RunUpshot::new(exit::ENV, None);
     };
-    let Ok(source) = crate::verbs::RunSource::from_bytes(
-        shot.workflow().to_owned(),
-        shot.source().as_bytes().to_vec(),
-    ) else {
-        return RunUpshot::new(exit::ENV, None);
-    };
     let Ok(receipt) = run_quietly(|| {
-        verbs::run::run_checked_source(
-            source,
-            crate::Theme::new(false, true, false),
+        verbs::run::run_arm_context(
+            execution,
+            shot.workflow(),
+            shot.root().to_path_buf(),
             shot.ceiling(),
         )
     }) else {

--- a/crates/nika-cli/src/verbs/arm/fire.rs
+++ b/crates/nika-cli/src/verbs/arm/fire.rs
@@ -11,8 +11,8 @@ use jiff::{Timestamp, Zoned};
 use nika_vocab::project;
 
 pub use nika_arm::fire::{
-    FireCtx, FireCtxError, FireVerdict, RunSeam, RunShot, RunUpshot, Wait, WaitSeam, fire_beat,
-    labels,
+    ExecutionRunSeam, FireCtx, FireCtxError, FireVerdict, RunSeam, RunShot, RunUpshot, Wait,
+    WaitSeam, fire_beat, labels,
 };
 
 use super::args::FireArgs;
@@ -70,7 +70,7 @@ pub fn run(fire: &FireArgs) -> VerbOutput {
     let root = path
         .parent()
         .map_or_else(|| PathBuf::from("."), Path::to_path_buf);
-    let ctx = match FireCtx::new(
+    let ctx = match FireCtx::new_with_execution(
         root.clone(),
         registry,
         index,

--- a/crates/nika-cli/src/verbs/check/mod.rs
+++ b/crates/nika-cli/src/verbs/check/mod.rs
@@ -182,7 +182,7 @@ pub(crate) mod models_rung;
 mod project;
 use models_rung::{ModelFinding, ModelsAudit, pricing_section, unresolvable_models};
 
-use nika_display::check_render::render;
+use nika_display::check_render::{RepairTarget, render};
 #[cfg(test)]
 use nika_display::check_render::{permits, required_inputs};
 
@@ -355,22 +355,76 @@ pub(crate) fn run_source_with_profile(
     };
     let path = source.logical_path();
     let (wf, report) = overridden(wf, report, model_override);
+    let skills = super::resolve_workflow_skills(&wf, super::workflow_base(path));
+    render_checked_with_profile(
+        source.source(),
+        path,
+        source.repair_target(),
+        &wf,
+        &report,
+        &skills,
+        json,
+        native_strict,
+        profile,
+        theme,
+    )
+}
+
+/// Render a check verdict from bytes and semantic products already admitted by
+/// the execution service. This path never reopens `path` or resolves skills
+/// from the filesystem.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn run_admitted_pair(
+    source: &str,
+    path: &str,
+    repair_target: RepairTarget,
+    wf: &nika_schema::raw::RawWorkflow,
+    report: &nika_check::CheckReport,
+    skills: &nika_schema::ResolvedSkills,
+    json: bool,
+    theme: Theme,
+) -> VerbOutput {
+    render_checked_with_profile(
+        source,
+        path,
+        repair_target,
+        wf,
+        report,
+        skills,
+        json,
+        false,
+        Profile::Advisory,
+        theme,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn render_checked_with_profile(
+    source: &str,
+    path: &str,
+    repair_target: RepairTarget,
+    wf: &nika_schema::raw::RawWorkflow,
+    report: &nika_check::CheckReport,
+    skills: &nika_schema::ResolvedSkills,
+    json: bool,
+    native_strict: bool,
+    profile: Profile,
+    theme: Theme,
+) -> VerbOutput {
     // The declared-vs-used drift family (NIKA-DRIFT-001 · drift.rs) —
     // advisory in both projections, never an exit-code input.
-    let drift_hints = drift::scan(&wf);
-    let native_hints = native_hint_count(&report);
+    let drift_hints = drift::scan(wf);
+    let native_hints = native_hint_count(report);
     // The MODELS rung (#320): the ladder validated TOOLS but not MODELS —
     // the exact asymmetry a hallucinating agent hits. A `model:` this
     // binary cannot resolve is a FINDING (exit 2), never a green audit.
-    let models_audit = unresolvable_models(&report, &wf);
-    // SKILLS rung (#473 · MODELS pattern): a bad SKILL.md is a FINDING.
-    let skills = super::resolve_workflow_skills(&wf, super::workflow_base(path));
+    let models_audit = unresolvable_models(report, wf);
     let clean = report.is_clean() && models_audit.findings.is_empty() && skills.findings.is_empty();
     // The risk grade (P0-6): a pure projection of the report — uncapped
     // spend or wildcard grants never turn the verdict green by silence.
     // Advisory by default; the operational profile folds grade ≥ High
     // into the exit-2 verdict (the readiness gate).
-    let grade = nika_check::risk_grade(&report);
+    let grade = nika_check::risk_grade(report);
     let profile_clean = profile != Profile::Operational || grade < nika_check::RiskGrade::High;
     let strict_clean = clean && profile_clean && (!native_strict || native_hints == 0);
 
@@ -385,9 +439,9 @@ pub(crate) fn run_source_with_profile(
 
     if json {
         return json_verdict(
-            &report,
+            report,
             &models_audit,
-            &skills,
+            skills,
             &drift_hints,
             clean,
             strict_clean,
@@ -398,14 +452,14 @@ pub(crate) fn run_source_with_profile(
     }
 
     let mut text = render(
-        &report,
-        &wf,
-        source.source(),
+        report,
+        wf,
+        source,
         path,
-        source.repair_target(),
+        repair_target,
         theme,
         &models_audit,
-        &skills,
+        skills,
         &drift_hints,
         // THE verdict, computed once above — the footer shows it, the
         // exit code rides it, `--json` serializes it (P0-11: the human
@@ -421,7 +475,7 @@ pub(crate) fn run_source_with_profile(
         profile == Profile::Operational && clean && !profile_clean,
         grade,
     );
-    naming_note(&mut text, theme, path, &wf);
+    naming_note(&mut text, theme, path, wf);
     budget::footnote(&mut text, theme);
     // The `--ascii` byte contract (P1 · audit UX 2026-07-30): the finished
     // report folds through the ONE enforcement seam — the glyph twins stay

--- a/crates/nika-cli/src/verbs/run/child_runner.rs
+++ b/crates/nika-cli/src/verbs/run/child_runner.rs
@@ -47,10 +47,7 @@ use nika_runtime::compose::{RuntimeCapabilities, fs_boundary_of_permits, net_bou
 /// whose tasks it serves.
 pub(crate) struct ProdChildRunner {
     /// The complete immutable world admitted before the root run started.
-    /// `None` remains only for the stdin/ARM compatibility lane until W04.B.
-    snapshot: Option<ExecutionSnapshot>,
-    /// The calling workflow's host path on the compatibility lane.
-    parent_path: PathBuf,
+    snapshot: ExecutionSnapshot,
     /// The CALLING workflow's logical path inside that world.
     parent_logical: String,
     /// Presentation-only root used to preserve existing diagnostic paths.
@@ -60,17 +57,6 @@ pub(crate) struct ProdChildRunner {
 }
 
 impl ProdChildRunner {
-    pub(crate) fn new(parent_path: impl Into<PathBuf>, trace: bool) -> Self {
-        let parent_path = parent_path.into();
-        Self {
-            snapshot: None,
-            parent_logical: parent_path.to_string_lossy().into_owned(),
-            display_root: PathBuf::new(),
-            parent_path,
-            trace,
-        }
-    }
-
     pub(crate) fn admitted(
         snapshot: ExecutionSnapshot,
         parent_logical: impl Into<String>,
@@ -78,8 +64,7 @@ impl ProdChildRunner {
         trace: bool,
     ) -> Self {
         Self {
-            snapshot: Some(snapshot),
-            parent_path: PathBuf::new(),
+            snapshot,
             parent_logical: parent_logical.into(),
             display_root: display_root.into(),
             trace,
@@ -93,16 +78,7 @@ impl ProdChildRunner {
     fn load_child(
         &self,
         call: &ChildCall,
-    ) -> Result<
-        (
-            String,
-            PathBuf,
-            String,
-            RawWorkflow,
-            nika_check::CheckReport,
-        ),
-        ChildRunRefusal,
-    > {
+    ) -> Result<(String, String, RawWorkflow, nika_check::CheckReport), ChildRunRefusal> {
         if call.target.starts_with("registry:") {
             return Err(refusal(
                 "NIKA-COMP-001",
@@ -113,32 +89,20 @@ impl ProdChildRunner {
                 ),
             ));
         }
-        let (logical, path, source) = if let Some(snapshot) = &self.snapshot {
-            let logical =
-                resolve_logical(&self.parent_logical, &call.target).map_err(|detail| {
-                    refusal(
-                        "NIKA-COMP-001",
-                        format!("cannot resolve child `{}`: {detail}", call.target),
-                    )
-                })?;
-            let path = self.display_root.join(&logical);
-            let source = snapshot.text(&logical).ok_or_else(|| {
-                refusal(
-                    "NIKA-COMP-001",
-                    format!("captured world has no child `{}`", path.display()),
-                )
-            })?;
-            (logical, path, source.to_owned())
-        } else {
-            let path = resolve_against(&self.parent_path, &call.target);
-            let source = std::fs::read_to_string(&path).map_err(|error| {
-                refusal(
-                    "NIKA-COMP-001",
-                    format!("cannot read child `{}`: {error}", path.display()),
-                )
-            })?;
-            (path.to_string_lossy().into_owned(), path, source)
-        };
+        let logical = resolve_logical(&self.parent_logical, &call.target).map_err(|detail| {
+            refusal(
+                "NIKA-COMP-001",
+                format!("cannot resolve child `{}`: {detail}", call.target),
+            )
+        })?;
+        let path = self.display_root.join(&logical);
+        let source = self.snapshot.text(&logical).ok_or_else(|| {
+            refusal(
+                "NIKA-COMP-001",
+                format!("captured world has no child `{}`", path.display()),
+            )
+        })?;
+        let source = source.to_owned();
         let wf = nika_schema::parse(&source, FileId::new(0), ParseMode::Strict).map_err(|e| {
             refusal(
                 "NIKA-COMP-001",
@@ -147,18 +111,12 @@ impl ProdChildRunner {
         })?;
         // The child clears the SAME gate a standalone run clears — its
         // own composed check (grandchildren judged from ITS root).
-        let report = if let Some(snapshot) = &self.snapshot {
-            nika_check::check_composed(&wf, &logical, &mut |p| {
-                snapshot
-                    .text(p)
-                    .map(str::to_owned)
-                    .ok_or_else(|| format!("captured world has no unit `{p}`"))
-            })
-        } else {
-            nika_check::check_composed(&wf, &logical, &mut |p| {
-                std::fs::read_to_string(p).map_err(|error| error.to_string())
-            })
-        };
+        let report = nika_check::check_composed(&wf, &logical, &mut |p| {
+            self.snapshot
+                .text(p)
+                .map(str::to_owned)
+                .ok_or_else(|| format!("captured world has no unit `{p}`"))
+        });
         if !report.is_clean() {
             let (code, detail) = first_finding(&report);
             return Err(refusal(
@@ -166,7 +124,7 @@ impl ProdChildRunner {
                 format!("child `{}` fails its own check: {detail}", path.display()),
             ));
         }
-        Ok((logical, path, source, wf, report))
+        Ok((logical, source, wf, report))
     }
 }
 
@@ -276,67 +234,9 @@ pub(crate) fn admitted_closure_digests(
     out
 }
 
-pub(crate) fn closure_digests(wf: &RawWorkflow, file: &Path) -> BTreeMap<String, String> {
-    let mut out = BTreeMap::new();
-    for target in workflow_targets_of(wf) {
-        let resolved = resolve_against(file, &target);
-        let mut stack = Vec::new();
-        if let Some(digest) = closure_digest_fs(&resolved, &mut stack, 1) {
-            out.insert(target, digest);
-        }
-    }
-    out
-}
-
-fn closure_digest_fs(path: &Path, stack: &mut Vec<PathBuf>, depth: u32) -> Option<String> {
-    if depth > nika_runtime::child::MAX_RUN_DEPTH {
-        return None;
-    }
-    let identity = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
-    if stack.contains(&identity) {
-        return None;
-    }
-    let source = std::fs::read_to_string(path).ok()?;
-    let wf = nika_schema::parse(&source, FileId::new(0), ParseMode::Strict).ok()?;
-    stack.push(identity);
-    let mut children = BTreeMap::new();
-    for target in workflow_targets_of(&wf) {
-        if target.starts_with("registry:") {
-            stack.pop();
-            return None;
-        }
-        let digest = closure_digest_fs(&resolve_against(path, &target), stack, depth + 1);
-        let Some(digest) = digest else {
-            stack.pop();
-            return None;
-        };
-        children.insert(target, digest);
-    }
-    stack.pop();
-    let mut fold = String::from("nika-child-closure:v1\u{0}");
-    fold.push_str(&sha256_hex(source.as_bytes()));
-    for (target, digest) in &children {
-        fold.push('\u{0}');
-        fold.push_str(target);
-        fold.push('\u{0}');
-        fold.push_str(digest);
-    }
-    Some(sha256_hex(fold.as_bytes()))
-}
-
-fn resolve_against(parent: &Path, target: &str) -> PathBuf {
-    let target = Path::new(target);
-    if target.is_absolute() {
-        return target.to_path_buf();
-    }
-    parent
-        .parent()
-        .unwrap_or_else(|| Path::new(""))
-        .join(target)
-}
-
 /// Every static `workflow:` target `wf`'s tasks carry (main verbs +
-/// `on_finally` minis) — the resolution roots of [`closure_digests`].
+/// `on_finally` minis) — the resolution roots of
+/// [`admitted_closure_digests`].
 fn workflow_targets_of(wf: &RawWorkflow) -> Vec<String> {
     fn of(action: &nika_schema::raw::RawAction) -> Option<String> {
         match action {
@@ -433,7 +333,7 @@ impl ChildRunner for ProdChildRunner {
         call: ChildCall,
     ) -> Pin<Box<dyn Future<Output = Result<ChildOutcome, ChildRunRefusal>> + 'a>> {
         Box::pin(async move {
-            let (logical, path, source, wf, report) = self.load_child(&call)?;
+            let (logical, source, wf, report) = self.load_child(&call)?;
             // Compose the child runtime — the child's OWN envelope model;
             // capabilities from the INTERSECTED boundary (laws 3/4).
             let child_permits = effective_permits(
@@ -467,28 +367,22 @@ impl ChildRunner for ProdChildRunner {
             // depth rides to the child so ITS dispatch gate sees the
             // truth (NIKA-SEC-003 · fail-closed).
             .with_run_depth(call.depth);
-            let runtime = if let Some(snapshot) = &self.snapshot {
-                let mut reader = |authored: &str| {
-                    let skill = resolve_logical(&logical, authored)?;
-                    snapshot
-                        .text(&skill)
-                        .map(str::to_owned)
-                        .ok_or_else(|| format!("captured world has no unit `{skill}`"))
-                };
-                runtime
-                    .with_skills(nika_schema::resolve_skills(&wf, &mut reader).texts)
-                    .with_child_runner(Arc::new(ProdChildRunner::admitted(
-                        snapshot.clone(),
-                        &logical,
-                        &self.display_root,
-                        self.trace,
-                    )))
-                    .with_child_closures(admitted_closure_digests(&wf, snapshot, &logical))
-            } else {
-                runtime
-                    .with_child_runner(Arc::new(ProdChildRunner::new(&path, self.trace)))
-                    .with_child_closures(closure_digests(&wf, &path))
+            let mut reader = |authored: &str| {
+                let skill = resolve_logical(&logical, authored)?;
+                self.snapshot
+                    .text(&skill)
+                    .map(str::to_owned)
+                    .ok_or_else(|| format!("captured world has no unit `{skill}`"))
             };
+            let runtime = runtime
+                .with_skills(nika_schema::resolve_skills(&wf, &mut reader).texts)
+                .with_child_runner(Arc::new(ProdChildRunner::admitted(
+                    self.snapshot.clone(),
+                    &logical,
+                    &self.display_root,
+                    self.trace,
+                )))
+                .with_child_closures(admitted_closure_digests(&wf, &self.snapshot, &logical));
             let mut sink = if self.trace {
                 TraceFileSink::new(nika_dap::store::TRACE_DIR)
             } else {
@@ -578,7 +472,7 @@ mod tests {
             parent_permits: None,
         };
 
-        let (_, _, source, _, _) = runner.load_child(&call).expect("captured child");
+        let (_, source, _, _) = runner.load_child(&call).expect("captured child");
         assert_eq!(source, admitted_child);
     }
 

--- a/crates/nika-cli/src/verbs/run/child_runner.rs
+++ b/crates/nika-cli/src/verbs/run/child_runner.rs
@@ -37,6 +37,7 @@ use nika_schema::types::Permits;
 use nika_schema::{FileId, ParseMode};
 
 use nika_event::source_id::sha256_hex;
+use nika_execution::ExecutionSnapshot;
 
 use nika_dap::journal::TraceFileSink;
 use nika_runtime::RunSeams;
@@ -45,16 +46,42 @@ use nika_runtime::compose::{RuntimeCapabilities, fs_boundary_of_permits, net_bou
 /// The production runner — one per composed runtime, rooted at the file
 /// whose tasks it serves.
 pub(crate) struct ProdChildRunner {
-    /// The CALLING workflow's own path (targets resolve against its dir).
+    /// The complete immutable world admitted before the root run started.
+    /// `None` remains only for the stdin/ARM compatibility lane until W04.B.
+    snapshot: Option<ExecutionSnapshot>,
+    /// The calling workflow's host path on the compatibility lane.
     parent_path: PathBuf,
+    /// The CALLING workflow's logical path inside that world.
+    parent_logical: String,
+    /// Presentation-only root used to preserve existing diagnostic paths.
+    display_root: PathBuf,
     /// Whether child runs keep trace files (`--no-trace-file` inherits).
     trace: bool,
 }
 
 impl ProdChildRunner {
     pub(crate) fn new(parent_path: impl Into<PathBuf>, trace: bool) -> Self {
+        let parent_path = parent_path.into();
         Self {
-            parent_path: parent_path.into(),
+            snapshot: None,
+            parent_logical: parent_path.to_string_lossy().into_owned(),
+            display_root: PathBuf::new(),
+            parent_path,
+            trace,
+        }
+    }
+
+    pub(crate) fn admitted(
+        snapshot: ExecutionSnapshot,
+        parent_logical: impl Into<String>,
+        display_root: impl Into<PathBuf>,
+        trace: bool,
+    ) -> Self {
+        Self {
+            snapshot: Some(snapshot),
+            parent_path: PathBuf::new(),
+            parent_logical: parent_logical.into(),
+            display_root: display_root.into(),
             trace,
         }
     }
@@ -66,7 +93,16 @@ impl ProdChildRunner {
     fn load_child(
         &self,
         call: &ChildCall,
-    ) -> Result<(PathBuf, String, RawWorkflow, nika_check::CheckReport), ChildRunRefusal> {
+    ) -> Result<
+        (
+            String,
+            PathBuf,
+            String,
+            RawWorkflow,
+            nika_check::CheckReport,
+        ),
+        ChildRunRefusal,
+    > {
         if call.target.starts_with("registry:") {
             return Err(refusal(
                 "NIKA-COMP-001",
@@ -77,13 +113,32 @@ impl ProdChildRunner {
                 ),
             ));
         }
-        let path = resolve_against(&self.parent_path, &call.target);
-        let source = std::fs::read_to_string(&path).map_err(|e| {
-            refusal(
-                "NIKA-COMP-001",
-                format!("cannot read child `{}`: {e}", path.display()),
-            )
-        })?;
+        let (logical, path, source) = if let Some(snapshot) = &self.snapshot {
+            let logical =
+                resolve_logical(&self.parent_logical, &call.target).map_err(|detail| {
+                    refusal(
+                        "NIKA-COMP-001",
+                        format!("cannot resolve child `{}`: {detail}", call.target),
+                    )
+                })?;
+            let path = self.display_root.join(&logical);
+            let source = snapshot.text(&logical).ok_or_else(|| {
+                refusal(
+                    "NIKA-COMP-001",
+                    format!("captured world has no child `{}`", path.display()),
+                )
+            })?;
+            (logical, path, source.to_owned())
+        } else {
+            let path = resolve_against(&self.parent_path, &call.target);
+            let source = std::fs::read_to_string(&path).map_err(|error| {
+                refusal(
+                    "NIKA-COMP-001",
+                    format!("cannot read child `{}`: {error}", path.display()),
+                )
+            })?;
+            (path.to_string_lossy().into_owned(), path, source)
+        };
         let wf = nika_schema::parse(&source, FileId::new(0), ParseMode::Strict).map_err(|e| {
             refusal(
                 "NIKA-COMP-001",
@@ -92,10 +147,18 @@ impl ProdChildRunner {
         })?;
         // The child clears the SAME gate a standalone run clears — its
         // own composed check (grandchildren judged from ITS root).
-        let root = path.to_string_lossy().into_owned();
-        let report = nika_check::check_composed(&wf, &root, &mut |p| {
-            std::fs::read_to_string(p).map_err(|e| e.to_string())
-        });
+        let report = if let Some(snapshot) = &self.snapshot {
+            nika_check::check_composed(&wf, &logical, &mut |p| {
+                snapshot
+                    .text(p)
+                    .map(str::to_owned)
+                    .ok_or_else(|| format!("captured world has no unit `{p}`"))
+            })
+        } else {
+            nika_check::check_composed(&wf, &logical, &mut |p| {
+                std::fs::read_to_string(p).map_err(|error| error.to_string())
+            })
+        };
         if !report.is_clean() {
             let (code, detail) = first_finding(&report);
             return Err(refusal(
@@ -103,8 +166,51 @@ impl ProdChildRunner {
                 format!("child `{}` fails its own check: {detail}", path.display()),
             ));
         }
-        Ok((path, source, wf, report))
+        Ok((logical, path, source, wf, report))
     }
+}
+
+fn resolve_logical(parent: &str, target: &str) -> Result<String, String> {
+    let target = Path::new(target);
+    if target.is_absolute() {
+        return Err("absolute paths are outside the admitted project".to_owned());
+    }
+    let mut parts: Vec<String> = Path::new(parent)
+        .parent()
+        .into_iter()
+        .flat_map(Path::components)
+        .filter_map(|component| match component {
+            std::path::Component::Normal(part) => part.to_str().map(ToOwned::to_owned),
+            _ => None,
+        })
+        .collect();
+    for component in target.components() {
+        match component {
+            std::path::Component::Normal(part) => {
+                let part = part
+                    .to_str()
+                    .ok_or_else(|| "path is not valid UTF-8".to_owned())?;
+                parts.push(part.to_owned());
+            }
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                parts
+                    .pop()
+                    .ok_or_else(|| "path escapes the admitted project".to_owned())?;
+            }
+            std::path::Component::RootDir | std::path::Component::Prefix(_) => {
+                return Err("path escapes the admitted project".to_owned());
+            }
+        }
+    }
+    if parts.is_empty() {
+        return Err("path resolves to the project root".to_owned());
+    }
+    Ok(parts.join("/"))
+}
+
+pub(super) fn resolve_admitted(parent: &str, target: &str) -> Result<String, String> {
+    resolve_logical(parent, target)
 }
 
 /// The child's effective capability boundary — `child ∩ parent` (laws
@@ -152,16 +258,81 @@ fn refusal(code: &str, message: String) -> ChildRunRefusal {
 /// bound (cycle · depth · registry) simply gets NO entry — the
 /// referencing task is then not resume-eligible: it re-runs live,
 /// never wrong-skips (the honest direction, the skills #473 law).
+pub(crate) fn admitted_closure_digests(
+    wf: &RawWorkflow,
+    snapshot: &ExecutionSnapshot,
+    parent_logical: &str,
+) -> BTreeMap<String, String> {
+    let mut out = BTreeMap::new();
+    for target in workflow_targets_of(wf) {
+        let Ok(resolved) = resolve_logical(parent_logical, &target) else {
+            continue;
+        };
+        let mut stack = Vec::new();
+        if let Some(digest) = closure_digest(snapshot, &resolved, &mut stack, 1) {
+            out.insert(target, digest);
+        }
+    }
+    out
+}
+
 pub(crate) fn closure_digests(wf: &RawWorkflow, file: &Path) -> BTreeMap<String, String> {
     let mut out = BTreeMap::new();
     for target in workflow_targets_of(wf) {
         let resolved = resolve_against(file, &target);
         let mut stack = Vec::new();
-        if let Some(digest) = closure_digest(&resolved, &mut stack, 1) {
+        if let Some(digest) = closure_digest_fs(&resolved, &mut stack, 1) {
             out.insert(target, digest);
         }
     }
     out
+}
+
+fn closure_digest_fs(path: &Path, stack: &mut Vec<PathBuf>, depth: u32) -> Option<String> {
+    if depth > nika_runtime::child::MAX_RUN_DEPTH {
+        return None;
+    }
+    let identity = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    if stack.contains(&identity) {
+        return None;
+    }
+    let source = std::fs::read_to_string(path).ok()?;
+    let wf = nika_schema::parse(&source, FileId::new(0), ParseMode::Strict).ok()?;
+    stack.push(identity);
+    let mut children = BTreeMap::new();
+    for target in workflow_targets_of(&wf) {
+        if target.starts_with("registry:") {
+            stack.pop();
+            return None;
+        }
+        let digest = closure_digest_fs(&resolve_against(path, &target), stack, depth + 1);
+        let Some(digest) = digest else {
+            stack.pop();
+            return None;
+        };
+        children.insert(target, digest);
+    }
+    stack.pop();
+    let mut fold = String::from("nika-child-closure:v1\u{0}");
+    fold.push_str(&sha256_hex(source.as_bytes()));
+    for (target, digest) in &children {
+        fold.push('\u{0}');
+        fold.push_str(target);
+        fold.push('\u{0}');
+        fold.push_str(digest);
+    }
+    Some(sha256_hex(fold.as_bytes()))
+}
+
+fn resolve_against(parent: &Path, target: &str) -> PathBuf {
+    let target = Path::new(target);
+    if target.is_absolute() {
+        return target.to_path_buf();
+    }
+    parent
+        .parent()
+        .unwrap_or_else(|| Path::new(""))
+        .join(target)
 }
 
 /// Every static `workflow:` target `wf`'s tasks carry (main verbs +
@@ -190,24 +361,32 @@ fn workflow_targets_of(wf: &RawWorkflow) -> Vec<String> {
 /// `def_hash` (sha256 of the child's exact bytes). `None` = the
 /// closure cannot be drawn honestly (unreadable · unparseable · a
 /// registry target · a cycle · past the run depth bound).
-fn closure_digest(path: &Path, stack: &mut Vec<PathBuf>, depth: u32) -> Option<String> {
+fn closure_digest(
+    snapshot: &ExecutionSnapshot,
+    logical: &str,
+    stack: &mut Vec<String>,
+    depth: u32,
+) -> Option<String> {
     if depth > nika_runtime::child::MAX_RUN_DEPTH {
         return None;
     }
-    let identity = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
-    if stack.contains(&identity) {
+    if stack.iter().any(|identity| identity == logical) {
         return None;
     }
-    let source = std::fs::read_to_string(path).ok()?;
-    let wf = nika_schema::parse(&source, FileId::new(0), ParseMode::Strict).ok()?;
-    stack.push(identity);
+    let source = snapshot.text(logical)?;
+    let wf = nika_schema::parse(source, FileId::new(0), ParseMode::Strict).ok()?;
+    stack.push(logical.to_owned());
     let mut children = BTreeMap::new();
     for target in workflow_targets_of(&wf) {
         if target.starts_with("registry:") {
             stack.pop();
             return None;
         }
-        let digest = closure_digest(&resolve_against(path, &target), stack, depth + 1);
+        let Ok(resolved) = resolve_logical(logical, &target) else {
+            stack.pop();
+            return None;
+        };
+        let digest = closure_digest(snapshot, &resolved, stack, depth + 1);
         let Some(digest) = digest else {
             stack.pop();
             return None;
@@ -224,16 +403,6 @@ fn closure_digest(path: &Path, stack: &mut Vec<PathBuf>, depth: u32) -> Option<S
         fold.push_str(digest);
     }
     Some(sha256_hex(fold.as_bytes()))
-}
-
-/// Resolve `target` against the DIRECTORY of `parent` (the same law the
-/// static lane applies lexically — here on the real filesystem path).
-fn resolve_against(parent: &Path, target: &str) -> PathBuf {
-    let t = Path::new(target);
-    if t.is_absolute() {
-        return t.to_path_buf();
-    }
-    parent.parent().unwrap_or_else(|| Path::new("")).join(t)
 }
 
 /// The first failed task's error of a settled child run — the honest
@@ -264,7 +433,7 @@ impl ChildRunner for ProdChildRunner {
         call: ChildCall,
     ) -> Pin<Box<dyn Future<Output = Result<ChildOutcome, ChildRunRefusal>> + 'a>> {
         Box::pin(async move {
-            let (path, source, wf, report) = self.load_child(&call)?;
+            let (logical, path, source, wf, report) = self.load_child(&call)?;
             // Compose the child runtime — the child's OWN envelope model;
             // capabilities from the INTERSECTED boundary (laws 3/4).
             let child_permits = effective_permits(
@@ -297,9 +466,29 @@ impl ChildRunner for ProdChildRunner {
             .with_source_sha256(sha256_hex(source.as_bytes()))
             // depth rides to the child so ITS dispatch gate sees the
             // truth (NIKA-SEC-003 · fail-closed).
-            .with_run_depth(call.depth)
-            // grandchildren resolve against the CHILD's path.
-            .with_child_runner(Arc::new(ProdChildRunner::new(&path, self.trace)));
+            .with_run_depth(call.depth);
+            let runtime = if let Some(snapshot) = &self.snapshot {
+                let mut reader = |authored: &str| {
+                    let skill = resolve_logical(&logical, authored)?;
+                    snapshot
+                        .text(&skill)
+                        .map(str::to_owned)
+                        .ok_or_else(|| format!("captured world has no unit `{skill}`"))
+                };
+                runtime
+                    .with_skills(nika_schema::resolve_skills(&wf, &mut reader).texts)
+                    .with_child_runner(Arc::new(ProdChildRunner::admitted(
+                        snapshot.clone(),
+                        &logical,
+                        &self.display_root,
+                        self.trace,
+                    )))
+                    .with_child_closures(admitted_closure_digests(&wf, snapshot, &logical))
+            } else {
+                runtime
+                    .with_child_runner(Arc::new(ProdChildRunner::new(&path, self.trace)))
+                    .with_child_closures(closure_digests(&wf, &path))
+            };
             let mut sink = if self.trace {
                 TraceFileSink::new(nika_dap::store::TRACE_DIR)
             } else {
@@ -351,6 +540,47 @@ mod tests {
     //! ABSENT parent block caps at ∅ (EPERM-style: the refusal is proven,
     //! not supposed).
     use super::*;
+
+    #[test]
+    fn admitted_runner_keeps_the_captured_child_after_disk_mutation() {
+        let dir = tempfile::tempdir().expect("temp project");
+        let root = dir.path().join("root.nika.yaml");
+        let child = dir.path().join("child.nika.yaml");
+        std::fs::write(
+            &root,
+            "nika: root\nmodel: mock/echo\npermits: {}\ntasks:\n  call:\n    invoke: { workflow: \"./child.nika.yaml\" }\n",
+        )
+        .expect("root fixture");
+        let admitted_child = "nika: child\nmodel: mock/echo\npermits: {}\ntasks:\n  answer:\n    infer: { prompt: \"admitted\" }\noutputs:\n  answer: ${{ tasks.answer.output }}\n";
+        std::fs::write(&child, admitted_child).expect("child fixture");
+        let project = nika_fs::OwnedDir::open(dir.path()).expect("held project");
+        let admitted = nika_execution::ExecutionService::default()
+            .admit(&project, Path::new("root.nika.yaml"))
+            .expect("admitted world");
+
+        std::fs::write(
+            &child,
+            "nika: changed\nmodel: mock/echo\npermits: {}\ntasks:\n  answer:\n    infer: { prompt: \"mutated\" }\n",
+        )
+        .expect("mutated child");
+        let runner = ProdChildRunner::admitted(
+            admitted.snapshot().clone(),
+            "root.nika.yaml",
+            dir.path(),
+            false,
+        );
+        let call = ChildCall {
+            target: "./child.nika.yaml".to_owned(),
+            args: BTreeMap::new(),
+            depth: 1,
+            remaining_budget_usd: None,
+            deadline: None,
+            parent_permits: None,
+        };
+
+        let (_, _, source, _, _) = runner.load_child(&call).expect("captured child");
+        assert_eq!(source, admitted_child);
+    }
 
     #[test]
     fn absent_parent_caps_every_child_at_zero() {

--- a/crates/nika-cli/src/verbs/run/dry_run.rs
+++ b/crates/nika-cli/src/verbs/run/dry_run.rs
@@ -13,7 +13,7 @@ use crate::Theme;
 pub(super) fn swap(
     wf: &RawWorkflow,
     model: &str,
-) -> Result<(RawWorkflow, CheckReport), Box<CheckReport>> {
+) -> Result<(RawWorkflow, CheckReport), Box<(RawWorkflow, CheckReport)>> {
     let swapped = crate::verbs::with_model_override(wf, model);
     let mut report = nika_check::check(&swapped);
     crate::verbs::stamp_judged_semantic(&swapped, &mut report);
@@ -21,28 +21,45 @@ pub(super) fn swap(
     if report.is_clean() && models.findings.is_empty() {
         Ok((swapped, report))
     } else {
-        Err(Box::new(report))
+        Err(Box::new((swapped, report)))
     }
 }
 
 /// Preview the overridden pair, or emit the same refusal as `nika check`.
-#[allow(clippy::fn_params_excessive_bools)]
+#[allow(clippy::fn_params_excessive_bools, clippy::too_many_arguments)]
 pub(super) fn lane(
     file: &str,
+    source: &str,
     wf: &RawWorkflow,
     report: &CheckReport,
+    skills: &nika_schema::ResolvedSkills,
+    repair_target: nika_display::check_render::RepairTarget,
     model_override: Option<&str>,
     json: bool,
     theme: Theme,
     output_json: bool,
 ) -> RunVerdict {
     if let Some(model) = model_override {
-        if let Ok((wf, report)) = swap(wf, model) {
-            return RunVerdict::bare(verdict(file, &wf, &report, json, theme));
+        match swap(wf, model) {
+            Ok((wf, report)) => {
+                return RunVerdict::bare(verdict(file, &wf, &report, json, theme));
+            }
+            Err(refused) => {
+                let (wf, report) = *refused;
+                let out = crate::verbs::check::run_admitted_pair(
+                    source,
+                    file,
+                    repair_target,
+                    &wf,
+                    &report,
+                    skills,
+                    json,
+                    theme,
+                );
+                super::epilogue::emit_diagnostic(&out.text, output_json);
+                return RunVerdict::bare(out.code);
+            }
         }
-        let out = crate::verbs::check::run(file, json, false, Some(model), theme);
-        super::epilogue::emit_diagnostic(&out.text, output_json);
-        return RunVerdict::bare(out.code);
     }
     RunVerdict::bare(verdict(file, wf, report, json, theme))
 }

--- a/crates/nika-cli/src/verbs/run/example.rs
+++ b/crates/nika-cli/src/verbs/run/example.rs
@@ -115,7 +115,6 @@ pub fn example(
         false, // examples are engine-staged content — unsigned-tolerant
         false, // examples are one-shot runs, not the outer TTY thread
         None,
-        None,
     );
     // The example's own envelope model — what we suggest overriding when a
     // run fails offline. A parse miss leaves it empty (the infer tip then

--- a/crates/nika-cli/src/verbs/run/execution_adapter.rs
+++ b/crates/nika-cli/src/verbs/run/execution_adapter.rs
@@ -131,7 +131,7 @@ pub(super) fn run_admitted(
         max_cost_usd,
         interruptible,
     };
-    let verdict = service.execute(admitted, move |context| {
+    let verdict = service.execute_with(admitted, move |context| {
         run_admitted_context(context, &request, display_root)
     });
     verdict.into_outcome()

--- a/crates/nika-cli/src/verbs/run/execution_adapter.rs
+++ b/crates/nika-cli/src/verbs/run/execution_adapter.rs
@@ -11,6 +11,8 @@ use super::*;
 pub(super) struct AdmittedWorld {
     pub(super) snapshot: nika_execution::ExecutionSnapshot,
     pub(super) display_root: std::path::PathBuf,
+    pub(super) execution_id: nika_types::id::ExecutionId,
+    pub(super) trace_id: nika_types::id::TraceId,
 }
 
 impl AdmittedWorld {
@@ -21,6 +23,8 @@ impl AdmittedWorld {
         Self {
             snapshot: context.snapshot().clone(),
             display_root,
+            execution_id: context.execution_id(),
+            trace_id: context.trace_id(),
         }
     }
 }

--- a/crates/nika-cli/src/verbs/run/execution_adapter.rs
+++ b/crates/nika-cli/src/verbs/run/execution_adapter.rs
@@ -1,0 +1,361 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! CLI and ARM adapters for the shared owned-byte execution service.
+
+#![allow(clippy::wildcard_imports)]
+
+use super::*;
+
+#[derive(Clone)]
+pub(super) struct AdmittedWorld {
+    pub(super) snapshot: nika_execution::ExecutionSnapshot,
+    pub(super) display_root: std::path::PathBuf,
+}
+
+impl AdmittedWorld {
+    fn from_context(
+        context: nika_execution::ExecutionContext<'_>,
+        display_root: std::path::PathBuf,
+    ) -> Self {
+        Self {
+            snapshot: context.snapshot().clone(),
+            display_root,
+        }
+    }
+}
+
+#[allow(clippy::struct_excessive_bools)]
+struct CliExecutionRequest<'a> {
+    file: &'a str,
+    json: bool,
+    output_json: bool,
+    theme: Theme,
+    mode: RenderMode,
+    dry_run: bool,
+    model_override: Option<&'a str>,
+    access_pin: Option<&'a str>,
+    vars: &'a [String],
+    resume: Option<&'a ResumeRequest>,
+    no_trace_file: bool,
+    task_filter: Option<&'a str>,
+    no_outputs: bool,
+    max_cost_usd: Option<f64>,
+    interruptible: bool,
+}
+
+/// ARM's in-process adapter over exact service-admitted bytes; it never reopens
+/// workflows, scans a latest trace, shells to the CLI, or crosses HTTP.
+pub(crate) fn run_arm_context(
+    context: nika_execution::ExecutionContext<'_>,
+    file: &str,
+    display_root: std::path::PathBuf,
+    max_cost_usd: f64,
+) -> RunVerdict {
+    run_start_gc(false, false);
+    let request = CliExecutionRequest {
+        file,
+        json: false,
+        output_json: false,
+        theme: Theme::new(false, true, false),
+        mode: RenderMode::Plain,
+        dry_run: false,
+        model_override: None,
+        access_pin: None,
+        vars: &[],
+        resume: None,
+        no_trace_file: false,
+        task_filter: None,
+        no_outputs: false,
+        max_cost_usd: Some(max_cost_usd),
+        interruptible: false,
+    };
+    run_admitted_context(context, &request, display_root)
+}
+
+#[allow(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
+pub(super) fn run_admitted(
+    file: &str,
+    preview: &crate::verbs::RunSource,
+    (json, output_json): (bool, bool),
+    theme: Theme,
+    mode: RenderMode,
+    dry_run: bool,
+    model_override: Option<&str>,
+    access_pin: Option<&str>,
+    vars: &[String],
+    resume: Option<&ResumeRequest>,
+    no_trace_file: bool,
+    task_filter: Option<&str>,
+    no_outputs: bool,
+    max_cost_usd: Option<f64>,
+    interruptible: bool,
+) -> RunVerdict {
+    let (project, root, display_root) = match execution_project(file) {
+        Ok(parts) => parts,
+        Err(error) => {
+            epilogue::emit_diagnostic(&format!("nika run: environment: {error}"), output_json);
+            return RunVerdict::bare(exit::ENV);
+        }
+    };
+    let service = nika_execution::ExecutionService::default();
+    let admitted = match admit_source(&service, &project, &root, preview) {
+        Ok(admitted) => admitted,
+        Err(error) => return admission_refusal(&error, output_json),
+    };
+    if admitted.snapshot().text(admitted.snapshot().root()) != Some(preview.source()) {
+        epilogue::emit_diagnostic(
+            "nika run: execution admission: workflow changed during admission; retry the run",
+            output_json,
+        );
+        return RunVerdict::bare(exit::ENV);
+    }
+    let request = CliExecutionRequest {
+        file,
+        json,
+        output_json,
+        theme,
+        mode,
+        dry_run,
+        model_override,
+        access_pin,
+        vars,
+        resume,
+        no_trace_file,
+        task_filter,
+        no_outputs,
+        max_cost_usd,
+        interruptible,
+    };
+    let verdict = service.execute(admitted, move |context| {
+        run_admitted_context(context, &request, display_root)
+    });
+    verdict.into_outcome()
+}
+
+pub(super) fn admit_source(
+    service: &nika_execution::ExecutionService,
+    project: &nika_fs::OwnedDir,
+    root: &std::path::Path,
+    source: &crate::verbs::RunSource,
+) -> Result<nika_execution::AdmittedExecution, nika_execution::ExecutionError> {
+    if source.logical_path() == "-" {
+        service.admit_root_bytes(project, root, source.source().as_bytes())
+    } else {
+        service.admit(project, root)
+    }
+}
+
+fn run_admitted_context(
+    context: nika_execution::ExecutionContext<'_>,
+    request: &CliExecutionRequest<'_>,
+    display_root: std::path::PathBuf,
+) -> RunVerdict {
+    let world = AdmittedWorld::from_context(context, display_root);
+    let (wf, report, skills) = match admitted_program(context, request, &world.snapshot) {
+        Ok(program) => program,
+        Err(verdict) => return *verdict,
+    };
+    let inputs = match inputs::validated_var_overrides(request.vars, &wf, request.output_json) {
+        Ok(map) => map,
+        Err(code) => return RunVerdict::bare(code),
+    };
+    if request.dry_run {
+        return dry_run::lane(
+            request.file,
+            &wf,
+            &report,
+            request.model_override,
+            request.json,
+            request.theme,
+            request.output_json,
+        );
+    }
+    if let Err(code) = budget::preflight(
+        &wf,
+        &report,
+        request.model_override,
+        request.max_cost_usd,
+        request.output_json,
+    ) {
+        return RunVerdict::bare(code);
+    }
+    let Some(source) = admitted_root_source(&world.snapshot) else {
+        return admitted_root_refusal(request.output_json);
+    };
+    let setup = match resume_setup(
+        request.resume,
+        &wf,
+        source,
+        request.model_override,
+        request.output_json,
+    ) {
+        Ok(setup) => setup,
+        Err(code) => return RunVerdict::bare(code),
+    };
+    let runtime = match composed_runtime(
+        &wf,
+        source,
+        request.model_override,
+        request.access_pin,
+        inputs,
+        setup,
+        request.max_cost_usd,
+        skills.clone(),
+        (request.no_trace_file, request.output_json),
+        &report,
+        &world,
+    ) {
+        Ok(runtime) => runtime,
+        Err(code) => return RunVerdict::bare(code),
+    };
+    announce_access_pin(
+        request.access_pin,
+        (request.json, request.output_json),
+        request.mode,
+        &report,
+    );
+    execute_and_ask(
+        &runtime,
+        (request.file, source),
+        (&wf, &report),
+        request.resume.is_some_and(|resume| resume.trace.is_some()),
+        request.vars,
+        request.model_override,
+        request.access_pin,
+        request.max_cost_usd,
+        &skills,
+        request.theme,
+        request.mode,
+        (
+            request.json,
+            request.output_json,
+            request.no_trace_file,
+            request.no_outputs,
+        ),
+        request.interruptible,
+        &world,
+    )
+}
+
+fn admitted_program(
+    context: nika_execution::ExecutionContext<'_>,
+    request: &CliExecutionRequest<'_>,
+    snapshot: &nika_execution::ExecutionSnapshot,
+) -> Result<(RawWorkflow, CheckReport, BTreeMap<String, String>), Box<RunVerdict>> {
+    let mut report = context.check().clone();
+    crate::verbs::stamp_judged_semantic(context.workflow(), &mut report);
+    let (wf, report) = match apply_task_scope(
+        context.workflow().clone(),
+        report,
+        request.task_filter,
+        request.output_json,
+    ) {
+        Ok(pair) => pair,
+        Err(code) => return Err(Box::new(RunVerdict::bare(code))),
+    };
+    let skills = match admitted_skills(&wf, snapshot) {
+        Ok(skills) => skills,
+        Err(error) => {
+            epilogue::emit_diagnostic(&format!("nika run: {error}"), request.output_json);
+            return Err(Box::new(RunVerdict::bare(exit::FILE)));
+        }
+    };
+    Ok((wf, report, skills))
+}
+
+fn admitted_root_source(snapshot: &nika_execution::ExecutionSnapshot) -> Option<&str> {
+    snapshot.text(snapshot.root())
+}
+
+fn admitted_root_refusal(output_json: bool) -> RunVerdict {
+    epilogue::emit_diagnostic(
+        "nika run: execution admission lost its root unit",
+        output_json,
+    );
+    RunVerdict::bare(exit::ENV)
+}
+
+fn execution_project(
+    file: &str,
+) -> Result<(nika_fs::OwnedDir, std::path::PathBuf, std::path::PathBuf), String> {
+    let cwd = std::env::current_dir().map_err(|error| error.to_string())?;
+    let path = std::path::Path::new(file);
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        cwd.join(path)
+    };
+    let absolute = lexical_path(&absolute);
+    let (display_root, root) = absolute.strip_prefix(&cwd).map_or_else(
+        |_| {
+            let parent = absolute
+                .parent()
+                .ok_or_else(|| format!("`{file}` has no project directory"))?;
+            let name = absolute
+                .file_name()
+                .ok_or_else(|| format!("`{file}` has no workflow filename"))?;
+            Ok::<_, String>((parent.to_path_buf(), std::path::PathBuf::from(name)))
+        },
+        |relative| Ok((cwd.clone(), relative.to_path_buf())),
+    )?;
+    let project = nika_fs::OwnedDir::open(&display_root)
+        .map_err(|error| format!("cannot hold project `{}`: {error}", display_root.display()))?;
+    Ok((project, root, display_root))
+}
+
+fn lexical_path(path: &std::path::Path) -> std::path::PathBuf {
+    let mut normalized = std::path::PathBuf::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
+            std::path::Component::RootDir => {
+                normalized.push(std::path::Path::new(std::path::MAIN_SEPARATOR_STR));
+            }
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                normalized.pop();
+            }
+            std::path::Component::Normal(part) => normalized.push(part),
+        }
+    }
+    normalized
+}
+
+fn admitted_skills(
+    workflow: &RawWorkflow,
+    snapshot: &nika_execution::ExecutionSnapshot,
+) -> Result<BTreeMap<String, String>, String> {
+    let owner = snapshot.root();
+    let mut reader = |authored: &str| {
+        let logical = child_runner::resolve_admitted(owner, authored)?;
+        snapshot
+            .text(&logical)
+            .map(str::to_owned)
+            .ok_or_else(|| format!("captured world has no unit `{logical}`"))
+    };
+    let resolved = nika_schema::resolve_skills(workflow, &mut reader);
+    if resolved.findings.is_empty() {
+        Ok(resolved.texts)
+    } else {
+        Err(resolved
+            .findings
+            .iter()
+            .map(nika_schema::SkillFinding::row)
+            .collect::<Vec<_>>()
+            .join(" | "))
+    }
+}
+
+fn admission_refusal(error: &nika_execution::ExecutionError, output_json: bool) -> RunVerdict {
+    let code = if matches!(error, nika_execution::ExecutionError::Io { .. }) {
+        exit::ENV
+    } else {
+        exit::FILE
+    };
+    epilogue::emit_diagnostic(
+        &format!("nika run: execution admission: {error}"),
+        output_json,
+    );
+    RunVerdict::bare(code)
+}

--- a/crates/nika-cli/src/verbs/run/execution_adapter.rs
+++ b/crates/nika-cli/src/verbs/run/execution_adapter.rs
@@ -32,6 +32,7 @@ impl AdmittedWorld {
 #[allow(clippy::struct_excessive_bools)]
 struct CliExecutionRequest<'a> {
     file: &'a str,
+    repair_target: nika_display::check_render::RepairTarget,
     json: bool,
     output_json: bool,
     theme: Theme,
@@ -59,6 +60,7 @@ pub(crate) fn run_arm_context(
     run_start_gc(false, false);
     let request = CliExecutionRequest {
         file,
+        repair_target: nika_display::check_render::RepairTarget::WorkspaceFile,
         json: false,
         output_json: false,
         theme: Theme::new(false, true, false),
@@ -116,6 +118,7 @@ pub(super) fn run_admitted(
     }
     let request = CliExecutionRequest {
         file,
+        repair_target: preview.repair_target(),
         json,
         output_json,
         theme,
@@ -131,9 +134,9 @@ pub(super) fn run_admitted(
         max_cost_usd,
         interruptible,
     };
-    let verdict = service.execute_with(admitted, move |context| {
-        run_admitted_context(context, &request, display_root)
-    });
+    let session = service.begin(admitted);
+    let outcome = run_admitted_context(session.context(), &request, display_root);
+    let verdict = session.complete(outcome);
     verdict.into_outcome()
 }
 
@@ -164,11 +167,17 @@ fn run_admitted_context(
         Ok(map) => map,
         Err(code) => return RunVerdict::bare(code),
     };
+    let Some(source) = admitted_root_source(&world.snapshot) else {
+        return admitted_root_refusal(request.output_json);
+    };
     if request.dry_run {
         return dry_run::lane(
             request.file,
+            source,
             &wf,
             &report,
+            context.skills(),
+            request.repair_target,
             request.model_override,
             request.json,
             request.theme,
@@ -184,9 +193,6 @@ fn run_admitted_context(
     ) {
         return RunVerdict::bare(code);
     }
-    let Some(source) = admitted_root_source(&world.snapshot) else {
-        return admitted_root_refusal(request.output_json);
-    };
     let setup = match resume_setup(
         request.resume,
         &wf,
@@ -362,4 +368,53 @@ fn admission_refusal(error: &nika_execution::ExecutionError, output_json: bool) 
         output_json,
     );
     RunVerdict::bare(code)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn invalid_dry_run_override_does_not_reopen_root() {
+        let directory = tempfile::tempdir().expect("execution project");
+        let root = directory.path().join("root.nika.yaml");
+        std::fs::write(
+            &root,
+            "nika: root\nmodel: mock/echo\npermits: {}\ntasks:\n  greet:\n    infer: { prompt: hi }\n",
+        )
+        .expect("original workflow");
+        let project = nika_fs::OwnedDir::open(directory.path()).expect("held project");
+        let service = nika_execution::ExecutionService::default();
+        let admitted = service
+            .admit(&project, std::path::Path::new("root.nika.yaml"))
+            .expect("original world admits");
+
+        std::fs::write(&root, "nika: replacement\nceiling: 0.50\n")
+            .expect("replace visible pathname after admission");
+        let file = root.to_string_lossy();
+        let request = CliExecutionRequest {
+            file: &file,
+            repair_target: nika_display::check_render::RepairTarget::WorkspaceFile,
+            json: false,
+            output_json: false,
+            theme: Theme::new(false, true, false),
+            mode: RenderMode::Plain,
+            dry_run: true,
+            model_override: Some("nonexistent/model"),
+            access_pin: None,
+            vars: &[],
+            resume: None,
+            no_trace_file: true,
+            task_filter: None,
+            no_outputs: false,
+            max_cost_usd: None,
+            interruptible: false,
+        };
+        let session = service.begin(admitted);
+        let outcome =
+            run_admitted_context(session.context(), &request, directory.path().to_path_buf());
+        let verdict = session.complete(outcome);
+
+        assert_eq!(verdict.into_outcome().code, exit::FILE);
+    }
 }

--- a/crates/nika-cli/src/verbs/run/extinction_tests.rs
+++ b/crates/nika-cli/src/verbs/run/extinction_tests.rs
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! W04.C structural extinction ratchets.
+
+const RUN: &str = include_str!("mod.rs");
+const EXECUTION_ADAPTER: &str = include_str!("execution_adapter.rs");
+const PROVENANCE: &str = include_str!("provenance.rs");
+const CHILD_RUNNER: &str = include_str!("child_runner.rs");
+const CLI_CARGO: &str = include_str!("../../../Cargo.toml");
+const EXECUTION_CARGO: &str = include_str!("../../../../nika-execution/Cargo.toml");
+const ARM_CARGO: &str = include_str!("../../../../nika-arm/Cargo.toml");
+const ARM_FIRE: &str = include_str!("../../../../nika-arm/src/fire.rs");
+
+#[test]
+fn every_production_run_uses_the_execution_service_world() {
+    assert!(EXECUTION_ADAPTER.contains("ExecutionService::default"));
+    assert!(EXECUTION_ADAPTER.contains("admit_root_bytes"));
+    for source in [RUN, EXECUTION_ADAPTER, PROVENANCE] {
+        assert!(!source.contains("captured: Option<"));
+        assert!(!source.contains("has_captured_source"));
+        assert!(!source.contains("world: Option<&AdmittedWorld>"));
+    }
+}
+
+#[test]
+fn child_execution_has_no_post_admission_filesystem_reader() {
+    assert!(!CHILD_RUNNER.contains("std::fs::read_to_string"));
+    assert!(!CHILD_RUNNER.contains("snapshot: Option<"));
+    assert!(!CHILD_RUNNER.contains("ProdChildRunner::new"));
+    assert!(!CHILD_RUNNER.contains("closure_digest_fs"));
+    assert!(!CHILD_RUNNER.contains("fn resolve_against"));
+}
+
+#[test]
+fn dependency_direction_stays_toward_the_execution_service() {
+    assert!(CLI_CARGO.contains("nika-execution"));
+    assert!(ARM_CARGO.contains("nika-execution"));
+    assert!(!EXECUTION_CARGO.contains("nika-cli"));
+    assert!(!ARM_CARGO.contains("nika-cli"));
+}
+
+#[test]
+fn arm_adapter_has_no_process_http_or_latest_trace_bridge() {
+    assert!(ARM_FIRE.contains("ExecutionService"));
+    for forbidden in [
+        "std::process::Command",
+        "Command::new",
+        "localhost",
+        "127.0.0.1",
+        "latest_trace",
+        "read_dir(",
+    ] {
+        assert!(
+            !ARM_FIRE.contains(forbidden),
+            "ARM execution bridge contains forbidden token `{forbidden}`"
+        );
+    }
+}
+
+#[test]
+fn stdin_bytes_enter_the_same_admitted_world_without_a_temp_file() {
+    let root = b"nika: stdin\npermits:\n  tools: [\"nika:jq\"]\ntasks:\n  value:\n    invoke:\n      tool: nika:jq\n      args: { input: 1, expression: \".\" }\n";
+    let directory = tempfile::tempdir().expect("stdin project");
+    let project = nika_fs::OwnedDir::open(directory.path()).expect("held stdin project");
+    let source = crate::verbs::RunSource::from_bytes("-", root.to_vec()).expect("UTF-8 source");
+    let service = nika_execution::ExecutionService::default();
+
+    let admitted = super::execution_adapter::admit_source(
+        &service,
+        &project,
+        std::path::Path::new("-"),
+        &source,
+    )
+    .expect("admitted stdin");
+
+    assert!(!directory.path().join("-").exists());
+    assert_eq!(admitted.snapshot().root(), "-");
+    assert_eq!(admitted.snapshot().bytes("-"), Some(root.as_slice()));
+}

--- a/crates/nika-cli/src/verbs/run/extinction_tests.rs
+++ b/crates/nika-cli/src/verbs/run/extinction_tests.rs
@@ -5,10 +5,12 @@
 
 const RUN: &str = include_str!("mod.rs");
 const EXECUTION_ADAPTER: &str = include_str!("execution_adapter.rs");
+const DRY_RUN: &str = include_str!("dry_run.rs");
 const PROVENANCE: &str = include_str!("provenance.rs");
 const CHILD_RUNNER: &str = include_str!("child_runner.rs");
 const CLI_CARGO: &str = include_str!("../../../Cargo.toml");
 const EXECUTION_CARGO: &str = include_str!("../../../../nika-execution/Cargo.toml");
+const EXECUTION_SERVICE: &str = include_str!("../../../../nika-execution/src/service.rs");
 const ARM_CARGO: &str = include_str!("../../../../nika-arm/Cargo.toml");
 const ARM_FIRE: &str = include_str!("../../../../nika-arm/src/fire.rs");
 
@@ -21,6 +23,20 @@ fn every_production_run_uses_the_execution_service_world() {
         assert!(!source.contains("has_captured_source"));
         assert!(!source.contains("world: Option<&AdmittedWorld>"));
     }
+}
+
+#[test]
+fn execution_service_does_not_accept_a_capability_capturing_runner() {
+    assert!(!EXECUTION_SERVICE.contains("execute_with"));
+    assert!(!EXECUTION_SERVICE.contains("FnOnce"));
+    assert!(EXECUTION_SERVICE.contains("It is not a process sandbox"));
+}
+
+#[test]
+fn dry_run_refusals_render_the_admitted_pair_without_path_reentry() {
+    assert!(!DRY_RUN.contains("check::run("));
+    assert!(DRY_RUN.contains("check::run_admitted_pair"));
+    assert!(EXECUTION_ADAPTER.contains("admitted_root_source(&world.snapshot)"));
 }
 
 #[test]

--- a/crates/nika-cli/src/verbs/run/mod.rs
+++ b/crates/nika-cli/src/verbs/run/mod.rs
@@ -45,7 +45,7 @@ fn sensitive_journey(report: &nika_check::CheckReport) -> bool {
 
 mod example;
 pub use example::example;
-use sink::{TraceNote, TraceSurface, surface_trace};
+use sink::{ExecutionSink, TraceNote, TraceSurface, surface_trace};
 
 mod budget;
 mod ceiling;
@@ -392,7 +392,8 @@ fn execute_and_ask(
         theme,
         mode,
         resumed,
-        trace_sink(no_trace_file),
+        trace_sink(no_trace_file, world.execution_id, world.trace_id),
+        world.execution_id,
         !no_outputs,
         model_override,
         &carry,
@@ -494,7 +495,8 @@ fn answered_leg(
         theme,
         mode,
         true,
-        trace_sink(no_trace_file),
+        trace_sink(no_trace_file, world.execution_id, world.trace_id),
+        world.execution_id,
         outputs,
         model_override,
         &carry,
@@ -857,6 +859,7 @@ async fn execute(
     mode: RenderMode,
     resumed: bool,
     trace: TraceFileSink,
+    execution: nika_types::id::ExecutionId,
     outputs: bool,
     model_override: Option<&str>,
     carry: &str,
@@ -874,6 +877,7 @@ async fn execute(
             theme,
             resumed,
             trace,
+            execution,
             carry,
         )
         .await
@@ -885,6 +889,7 @@ async fn execute(
             stamper.as_mut(),
             resumed,
             trace,
+            execution,
             carry,
         )
         .await
@@ -898,6 +903,7 @@ async fn execute(
             theme,
             (mode, resumed, outputs),
             trace,
+            execution,
             model_override,
             carry,
         )
@@ -921,14 +927,16 @@ async fn execute_output_json_lane(
     theme: Theme,
     resumed: bool,
     trace: TraceFileSink,
+    execution: nika_types::id::ExecutionId,
     carry: &str,
 ) -> RunVerdict {
     let mut fold = FoldSink::new(std::io::stderr().lock(), theme, RenderMode::Plain);
     fold.set_plan(plan_waves(wf, report));
     fold.set_trace_recorded(!trace.is_disabled());
-    let mut tee = Tee::new(fold, trace);
-    let (code, outcome) = drive(runtime, wf, report, stamper, &mut tee).await;
-    let (mut sink, mut trace) = tee.into_parts();
+    let tee = Tee::new(fold, trace);
+    let mut events = ExecutionSink::new(tee, execution);
+    let (code, outcome) = drive(runtime, wf, report, stamper, &mut events).await;
+    let (mut sink, mut trace) = events.into_inner().into_parts();
     sink.print_final();
     // Pause delivery is journaled before the seal (ADR-111).
     if let (Some(p), Some(pause)) = (
@@ -998,11 +1006,13 @@ async fn execute_json_lane(
     stamper: &mut dyn Stamper,
     resumed: bool,
     trace: TraceFileSink,
+    execution: nika_types::id::ExecutionId,
     carry: &str,
 ) -> RunVerdict {
-    let mut tee = Tee::new(JsonSink::new(std::io::stdout().lock()), trace);
-    let (code, outcome) = drive(runtime, wf, report, stamper, &mut tee).await;
-    let (sink, mut trace) = tee.into_parts();
+    let tee = Tee::new(JsonSink::new(std::io::stdout().lock()), trace);
+    let mut events = ExecutionSink::new(tee, execution);
+    let (code, outcome) = drive(runtime, wf, report, stamper, &mut events).await;
+    let (sink, mut trace) = events.into_inner().into_parts();
     if let (Some(p), Some(pause)) = (
         trace.path().map(std::path::Path::to_path_buf),
         outcome.paused.as_ref(),
@@ -1055,6 +1065,7 @@ async fn execute_fold_lane(
     theme: Theme,
     (mode, resumed, outputs): (RenderMode, bool, bool),
     trace: TraceFileSink,
+    execution: nika_types::id::ExecutionId,
     model_override: Option<&str>,
     carry: &str,
 ) -> RunVerdict {
@@ -1074,11 +1085,12 @@ async fn execute_fold_lane(
     });
     let ticker = pulse.clone().map(heartbeat::spawn_ticker);
     let beat = heartbeat::HeartbeatSink::new(pulse);
-    let mut tee = Tee::new(
+    let tee = Tee::new(
         Tee::new(sink::FoldHandle(std::sync::Arc::clone(&fold)), beat),
         trace,
     );
-    let (code, outcome) = drive(runtime, wf, report, stamper, &mut tee).await;
+    let mut events = ExecutionSink::new(tee, execution);
+    let (code, outcome) = drive(runtime, wf, report, stamper, &mut events).await;
     // The run settled: stop riders before the epilogue.
     if let Some(ticker) = &ticker {
         ticker.abort();
@@ -1086,7 +1098,7 @@ async fn execute_fold_lane(
     if let Some(spinner) = &spinner {
         spinner.abort();
     }
-    let (_inner, mut trace) = tee.into_parts();
+    let (_inner, mut trace) = events.into_inner().into_parts();
     if let (Some(p), Some(pause)) = (
         trace.path().map(std::path::Path::to_path_buf),
         outcome.paused.as_ref(),
@@ -1297,12 +1309,17 @@ where
 /// The run journal (spec §3.3) — composed like the other seams;
 /// `execute` receives the sink, never a flag. The directory constant
 /// is the store scan's (one constant, one home).
-fn trace_sink(no_trace_file: bool) -> TraceFileSink {
-    if no_trace_file {
+fn trace_sink(
+    no_trace_file: bool,
+    execution: nika_types::id::ExecutionId,
+    trace: nika_types::id::TraceId,
+) -> TraceFileSink {
+    let sink = if no_trace_file {
         TraceFileSink::disabled()
     } else {
         TraceFileSink::new(nika_dap::store::TRACE_DIR)
-    }
+    };
+    sink.for_execution(execution, trace)
 }
 
 #[cfg(test)]

--- a/crates/nika-cli/src/verbs/run/mod.rs
+++ b/crates/nika-cli/src/verbs/run/mod.rs
@@ -113,6 +113,43 @@ struct PausedLeg {
     trace: std::path::PathBuf,
 }
 
+#[derive(Clone)]
+struct AdmittedWorld {
+    snapshot: nika_execution::ExecutionSnapshot,
+    display_root: std::path::PathBuf,
+}
+
+impl AdmittedWorld {
+    fn from_context(
+        context: nika_execution::ExecutionContext<'_>,
+        display_root: std::path::PathBuf,
+    ) -> Self {
+        Self {
+            snapshot: context.snapshot().clone(),
+            display_root,
+        }
+    }
+}
+
+#[allow(clippy::struct_excessive_bools)]
+struct CliExecutionRequest<'a> {
+    file: &'a str,
+    json: bool,
+    output_json: bool,
+    theme: Theme,
+    mode: RenderMode,
+    dry_run: bool,
+    model_override: Option<&'a str>,
+    access_pin: Option<&'a str>,
+    vars: &'a [String],
+    resume: Option<&'a ResumeRequest>,
+    no_trace_file: bool,
+    task_filter: Option<&'a str>,
+    no_outputs: bool,
+    max_cost_usd: Option<f64>,
+    interruptible: bool,
+}
+
 impl RunVerdict {
     /// A verdict that carries no task failure (pre-run refusals · lanes
     /// that never reached the runtime).
@@ -298,12 +335,14 @@ fn run_verdict(
         Ok(pair) => pair,
         Err(verdict) => return *verdict,
     };
+    let has_captured_source = captured.is_some();
     let (source, wf, report) =
         match provenance::capture_checked_source(file, captured, repair_target, output_json) {
             Ok(checked) => checked,
             Err(verdict) => return *verdict,
         };
-    let file = source.logical_path();
+    let file_owned = source.logical_path().to_owned();
+    let file = file_owned.as_str();
     let source_text = source.source();
     if require_signature && let Err(code) = require_signature_gate(&source, output_json) {
         return RunVerdict::bare(code);
@@ -313,6 +352,25 @@ fn run_verdict(
             Ok(triple) => triple,
             Err(code) => return RunVerdict::bare(code),
         };
+    if !has_captured_source && file != "-" {
+        return run_admitted(
+            file,
+            &source,
+            (json, output_json),
+            theme,
+            mode,
+            dry_run,
+            model_override,
+            access_pin,
+            vars,
+            resume,
+            no_trace_file,
+            task_filter,
+            no_outputs,
+            max_cost_usd,
+            interruptible,
+        );
+    }
     let inputs = match inputs::validated_var_overrides(vars, &wf, output_json) {
         Ok(map) => map,
         Err(code) => return RunVerdict::bare(code),
@@ -338,6 +396,7 @@ fn run_verdict(
         skills.clone(),
         (no_trace_file, output_json),
         &report,
+        None,
     ) {
         Ok(rt) => rt,
         Err(code) => return RunVerdict::bare(code),
@@ -357,7 +416,270 @@ fn run_verdict(
         mode,
         (json, output_json, no_trace_file, no_outputs),
         interruptible,
+        None,
     )
+}
+
+#[allow(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
+fn run_admitted(
+    file: &str,
+    preview: &crate::verbs::RunSource,
+    (json, output_json): (bool, bool),
+    theme: Theme,
+    mode: RenderMode,
+    dry_run: bool,
+    model_override: Option<&str>,
+    access_pin: Option<&str>,
+    vars: &[String],
+    resume: Option<&ResumeRequest>,
+    no_trace_file: bool,
+    task_filter: Option<&str>,
+    no_outputs: bool,
+    max_cost_usd: Option<f64>,
+    interruptible: bool,
+) -> RunVerdict {
+    let (project, root, display_root) = match execution_project(file) {
+        Ok(parts) => parts,
+        Err(error) => {
+            epilogue::emit_diagnostic(&format!("nika run: environment: {error}"), output_json);
+            return RunVerdict::bare(exit::ENV);
+        }
+    };
+    let service = nika_execution::ExecutionService::default();
+    let admitted = match service.admit(&project, &root) {
+        Ok(admitted) => admitted,
+        Err(error) => return admission_refusal(&error, output_json),
+    };
+    if admitted.snapshot().text(admitted.snapshot().root()) != Some(preview.source()) {
+        epilogue::emit_diagnostic(
+            "nika run: execution admission: workflow changed during admission; retry the run",
+            output_json,
+        );
+        return RunVerdict::bare(exit::ENV);
+    }
+    let request = CliExecutionRequest {
+        file,
+        json,
+        output_json,
+        theme,
+        mode,
+        dry_run,
+        model_override,
+        access_pin,
+        vars,
+        resume,
+        no_trace_file,
+        task_filter,
+        no_outputs,
+        max_cost_usd,
+        interruptible,
+    };
+    let verdict = service.execute(admitted, move |context| {
+        run_admitted_context(context, &request, display_root)
+    });
+    verdict.into_outcome()
+}
+
+fn run_admitted_context(
+    context: nika_execution::ExecutionContext<'_>,
+    request: &CliExecutionRequest<'_>,
+    display_root: std::path::PathBuf,
+) -> RunVerdict {
+    let world = AdmittedWorld::from_context(context, display_root);
+    let mut report = context.check().clone();
+    crate::verbs::stamp_judged_semantic(context.workflow(), &mut report);
+    let (wf, report) = match apply_task_scope(
+        context.workflow().clone(),
+        report,
+        request.task_filter,
+        request.output_json,
+    ) {
+        Ok(pair) => pair,
+        Err(code) => return RunVerdict::bare(code),
+    };
+    let skills = match admitted_skills(&wf, &world.snapshot) {
+        Ok(skills) => skills,
+        Err(error) => {
+            epilogue::emit_diagnostic(&format!("nika run: {error}"), request.output_json);
+            return RunVerdict::bare(exit::FILE);
+        }
+    };
+    let inputs = match inputs::validated_var_overrides(request.vars, &wf, request.output_json) {
+        Ok(map) => map,
+        Err(code) => return RunVerdict::bare(code),
+    };
+    if request.dry_run {
+        return dry_run::lane(
+            request.file,
+            &wf,
+            &report,
+            request.model_override,
+            request.json,
+            request.theme,
+            request.output_json,
+        );
+    }
+    if let Err(code) = budget::preflight(
+        &wf,
+        &report,
+        request.model_override,
+        request.max_cost_usd,
+        request.output_json,
+    ) {
+        return RunVerdict::bare(code);
+    }
+    let Some(source) = admitted_root_source(&world.snapshot) else {
+        return admitted_root_refusal(request.output_json);
+    };
+    let setup = match resume_setup(
+        request.resume,
+        &wf,
+        source,
+        request.model_override,
+        request.output_json,
+    ) {
+        Ok(setup) => setup,
+        Err(code) => return RunVerdict::bare(code),
+    };
+    let runtime = match composed_runtime(
+        &wf,
+        (request.file, source),
+        request.model_override,
+        request.access_pin,
+        inputs,
+        setup,
+        request.max_cost_usd,
+        skills.clone(),
+        (request.no_trace_file, request.output_json),
+        &report,
+        Some(&world),
+    ) {
+        Ok(runtime) => runtime,
+        Err(code) => return RunVerdict::bare(code),
+    };
+    announce_access_pin(
+        request.access_pin,
+        (request.json, request.output_json),
+        request.mode,
+        &report,
+    );
+    execute_and_ask(
+        &runtime,
+        (request.file, source),
+        (&wf, &report),
+        request.resume.is_some_and(|resume| resume.trace.is_some()),
+        request.vars,
+        request.model_override,
+        request.access_pin,
+        request.max_cost_usd,
+        &skills,
+        request.theme,
+        request.mode,
+        (
+            request.json,
+            request.output_json,
+            request.no_trace_file,
+            request.no_outputs,
+        ),
+        request.interruptible,
+        Some(&world),
+    )
+}
+
+fn admitted_root_source(snapshot: &nika_execution::ExecutionSnapshot) -> Option<&str> {
+    snapshot.text(snapshot.root())
+}
+
+fn admitted_root_refusal(output_json: bool) -> RunVerdict {
+    epilogue::emit_diagnostic(
+        "nika run: execution admission lost its root unit",
+        output_json,
+    );
+    RunVerdict::bare(exit::ENV)
+}
+
+fn execution_project(
+    file: &str,
+) -> Result<(nika_fs::OwnedDir, std::path::PathBuf, std::path::PathBuf), String> {
+    let cwd = std::env::current_dir().map_err(|error| error.to_string())?;
+    let path = std::path::Path::new(file);
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        cwd.join(path)
+    };
+    let absolute = lexical_path(&absolute);
+    let (display_root, root) = absolute.strip_prefix(&cwd).map_or_else(
+        |_| {
+            let parent = absolute
+                .parent()
+                .ok_or_else(|| format!("`{file}` has no project directory"))?;
+            let name = absolute
+                .file_name()
+                .ok_or_else(|| format!("`{file}` has no workflow filename"))?;
+            Ok::<_, String>((parent.to_path_buf(), std::path::PathBuf::from(name)))
+        },
+        |relative| Ok((cwd.clone(), relative.to_path_buf())),
+    )?;
+    let project = nika_fs::OwnedDir::open(&display_root)
+        .map_err(|error| format!("cannot hold project `{}`: {error}", display_root.display()))?;
+    Ok((project, root, display_root))
+}
+
+fn lexical_path(path: &std::path::Path) -> std::path::PathBuf {
+    let mut normalized = std::path::PathBuf::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
+            std::path::Component::RootDir => {
+                normalized.push(std::path::Path::new(std::path::MAIN_SEPARATOR_STR));
+            }
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                normalized.pop();
+            }
+            std::path::Component::Normal(part) => normalized.push(part),
+        }
+    }
+    normalized
+}
+
+fn admitted_skills(
+    workflow: &RawWorkflow,
+    snapshot: &nika_execution::ExecutionSnapshot,
+) -> Result<BTreeMap<String, String>, String> {
+    let owner = snapshot.root();
+    let mut reader = |authored: &str| {
+        let logical = child_runner::resolve_admitted(owner, authored)?;
+        snapshot
+            .text(&logical)
+            .map(str::to_owned)
+            .ok_or_else(|| format!("captured world has no unit `{logical}`"))
+    };
+    let resolved = nika_schema::resolve_skills(workflow, &mut reader);
+    if resolved.findings.is_empty() {
+        Ok(resolved.texts)
+    } else {
+        Err(resolved
+            .findings
+            .iter()
+            .map(nika_schema::SkillFinding::row)
+            .collect::<Vec<_>>()
+            .join(" | "))
+    }
+}
+
+fn admission_refusal(error: &nika_execution::ExecutionError, output_json: bool) -> RunVerdict {
+    let code = if matches!(error, nika_execution::ExecutionError::Io { .. }) {
+        exit::ENV
+    } else {
+        exit::FILE
+    };
+    epilogue::emit_diagnostic(
+        &format!("nika run: execution admission: {error}"),
+        output_json,
+    );
+    RunVerdict::bare(code)
 }
 
 /// The access announce (D-2026-08-04-N1 · P2.6 + R-4): a pinned path is
@@ -427,6 +749,7 @@ fn execute_and_ask(
     mode: RenderMode,
     (json, output_json, no_trace_file, no_outputs): (bool, bool, bool, bool),
     interruptible: bool,
+    world: Option<&AdmittedWorld>,
 ) -> RunVerdict {
     let rt = match executor(output_json) {
         Ok(rt) => rt,
@@ -486,6 +809,7 @@ fn execute_and_ask(
             mode,
             (json, output_json, no_trace_file, !no_outputs),
             &rt,
+            world,
         );
     }
     verdict
@@ -510,6 +834,7 @@ fn answered_leg(
     mode: RenderMode,
     (json, output_json, no_trace_file, outputs): (bool, bool, bool, bool),
     rt: &tokio::runtime::Runtime,
+    world: Option<&AdmittedWorld>,
 ) -> RunVerdict {
     let inputs = match inputs::validated_var_overrides(vars, wf, output_json) {
         Ok(map) => map,
@@ -530,6 +855,7 @@ fn answered_leg(
         skills.clone(),
         (no_trace_file, output_json),
         report,
+        world,
     ) {
         Ok(rt) => rt,
         Err(code) => return RunVerdict::bare(code),
@@ -656,6 +982,7 @@ fn composed_runtime(
     skills: BTreeMap<String, String>,
     (no_trace_file, output_json): (bool, bool),
     report: &nika_check::CheckReport,
+    world: Option<&AdmittedWorld>,
 ) -> Result<ProdRuntime, u8> {
     let ResumeSetup {
         plan: resume_plan,
@@ -677,12 +1004,31 @@ fn composed_runtime(
     // jitter seed — the stamper half is picked at the drive site).
     match production_runtime(default_model, caps, wf.run.as_ref().map(|s| &s.value)) {
         Ok(rt) => {
-            let rt = rt
-                // The child seam (spec 14) — children resolve against THIS file.
-                .with_child_runner(std::sync::Arc::new(child_runner::ProdChildRunner::new(
+            let rt = if let Some(world) = world {
+                rt.with_child_runner(std::sync::Arc::new(
+                    child_runner::ProdChildRunner::admitted(
+                        world.snapshot.clone(),
+                        world.snapshot.root(),
+                        &world.display_root,
+                        !no_trace_file,
+                    ),
+                ))
+                .with_child_closures(child_runner::admitted_closure_digests(
+                    wf,
+                    &world.snapshot,
+                    world.snapshot.root(),
+                ))
+            } else {
+                rt.with_child_runner(std::sync::Arc::new(child_runner::ProdChildRunner::new(
                     file,
                     !no_trace_file,
                 )))
+                .with_child_closures(child_runner::closure_digests(
+                    wf,
+                    std::path::Path::new(file),
+                ))
+            };
+            let rt = rt
                 .with_var_overrides(overrides)
                 // F-P13 · the input origins (NEP-0014 law 2) — the boot
                 // manifest journals where every bound input came from.
@@ -706,13 +1052,6 @@ fn composed_runtime(
                 // #473 · composer-resolved SKILL.md texts (`## Skills`
                 // injection + the referencing tasks' resume identity).
                 .with_skills(skills)
-                // Spec 14 law 10 (def_hash tier) · the child closure
-                // digests join the caller's resume identity — an edited
-                // child re-runs instead of serving the old cached output.
-                .with_child_closures(child_runner::closure_digests(
-                    wf,
-                    std::path::Path::new(file),
-                ))
                 // #409 · the override joins the resume identity of every
                 // model-less infer/agent task (the model they RUN on).
                 .with_model_override(model_override.map(ToOwned::to_owned))

--- a/crates/nika-cli/src/verbs/run/mod.rs
+++ b/crates/nika-cli/src/verbs/run/mod.rs
@@ -257,33 +257,33 @@ pub fn run(
     .code
 }
 
-pub(crate) fn run_checked_source(
-    source: crate::verbs::RunSource,
-    theme: Theme,
+/// ARM's in-process adapter over exact service-admitted bytes; it never reopens
+/// workflows, scans a latest trace, shells to the CLI, or crosses HTTP.
+pub(crate) fn run_arm_context(
+    context: nika_execution::ExecutionContext<'_>,
+    file: &str,
+    display_root: std::path::PathBuf,
     max_cost_usd: f64,
 ) -> RunVerdict {
-    let file = source.logical_path().to_owned();
-    run_verdict(
-        &file,
-        false,
-        None,
-        theme,
-        RenderMode::Plain,
-        false,
-        None,
-        None,
-        &[],
-        None,
-        false,
-        None,
-        false,
-        Some(max_cost_usd),
-        false,
-        false,
-        false,
-        Some(source),
-        None,
-    )
+    run_start_gc(false, false);
+    let request = CliExecutionRequest {
+        file,
+        json: false,
+        output_json: false,
+        theme: Theme::new(false, true, false),
+        mode: RenderMode::Plain,
+        dry_run: false,
+        model_override: None,
+        access_pin: None,
+        vars: &[],
+        resume: None,
+        no_trace_file: false,
+        task_filter: None,
+        no_outputs: false,
+        max_cost_usd: Some(max_cost_usd),
+        interruptible: false,
+    };
+    run_admitted_context(context, &request, display_root)
 }
 
 /// Resolve output/ceiling and run the opportunistic trace collection.

--- a/crates/nika-cli/src/verbs/run/mod.rs
+++ b/crates/nika-cli/src/verbs/run/mod.rs
@@ -51,6 +51,9 @@ mod budget;
 mod ceiling;
 mod dry_run;
 mod epilogue;
+mod execution_adapter;
+#[cfg(test)]
+mod extinction_tests;
 mod provenance;
 pub use provenance::run_with_repair_target;
 mod heartbeat;
@@ -86,6 +89,8 @@ use nika_schema::raw::RawWorkflow;
 
 use crate::Theme;
 use crate::verbs::exit;
+pub(crate) use execution_adapter::run_arm_context;
+use execution_adapter::{AdmittedWorld, run_admitted};
 
 /// Opportunistic bounded trace collection. Dry-run and explicit opt-out are
 /// effect-free; maintenance failure never blocks workflow execution.
@@ -111,43 +116,6 @@ pub(crate) struct RunVerdict {
 struct PausedLeg {
     pause: nika_runtime::WorkflowPause,
     trace: std::path::PathBuf,
-}
-
-#[derive(Clone)]
-struct AdmittedWorld {
-    snapshot: nika_execution::ExecutionSnapshot,
-    display_root: std::path::PathBuf,
-}
-
-impl AdmittedWorld {
-    fn from_context(
-        context: nika_execution::ExecutionContext<'_>,
-        display_root: std::path::PathBuf,
-    ) -> Self {
-        Self {
-            snapshot: context.snapshot().clone(),
-            display_root,
-        }
-    }
-}
-
-#[allow(clippy::struct_excessive_bools)]
-struct CliExecutionRequest<'a> {
-    file: &'a str,
-    json: bool,
-    output_json: bool,
-    theme: Theme,
-    mode: RenderMode,
-    dry_run: bool,
-    model_override: Option<&'a str>,
-    access_pin: Option<&'a str>,
-    vars: &'a [String],
-    resume: Option<&'a ResumeRequest>,
-    no_trace_file: bool,
-    task_filter: Option<&'a str>,
-    no_outputs: bool,
-    max_cost_usd: Option<f64>,
-    interruptible: bool,
 }
 
 impl RunVerdict {
@@ -252,38 +220,8 @@ pub fn run(
         require_signature,
         false,
         None,
-        None,
     )
     .code
-}
-
-/// ARM's in-process adapter over exact service-admitted bytes; it never reopens
-/// workflows, scans a latest trace, shells to the CLI, or crosses HTTP.
-pub(crate) fn run_arm_context(
-    context: nika_execution::ExecutionContext<'_>,
-    file: &str,
-    display_root: std::path::PathBuf,
-    max_cost_usd: f64,
-) -> RunVerdict {
-    run_start_gc(false, false);
-    let request = CliExecutionRequest {
-        file,
-        json: false,
-        output_json: false,
-        theme: Theme::new(false, true, false),
-        mode: RenderMode::Plain,
-        dry_run: false,
-        model_override: None,
-        access_pin: None,
-        vars: &[],
-        resume: None,
-        no_trace_file: false,
-        task_filter: None,
-        no_outputs: false,
-        max_cost_usd: Some(max_cost_usd),
-        interruptible: false,
-    };
-    run_admitted_context(context, &request, display_root)
 }
 
 /// Resolve output/ceiling and run the opportunistic trace collection.
@@ -328,139 +266,31 @@ fn run_verdict(
     no_gc: bool,
     require_signature: bool,
     interruptible: bool,
-    captured: Option<crate::verbs::RunSource>,
     repair_target: Option<nika_display::check_render::RepairTarget>,
 ) -> RunVerdict {
     let (output_json, max_cost_usd) = match preflight(output, max_cost_usd, no_gc, dry_run) {
         Ok(pair) => pair,
         Err(verdict) => return *verdict,
     };
-    let has_captured_source = captured.is_some();
     let (source, wf, report) =
-        match provenance::capture_checked_source(file, captured, repair_target, output_json) {
+        match provenance::capture_checked_source(file, repair_target, output_json) {
             Ok(checked) => checked,
             Err(verdict) => return *verdict,
         };
     let file_owned = source.logical_path().to_owned();
     let file = file_owned.as_str();
-    let source_text = source.source();
     if require_signature && let Err(code) = require_signature_gate(&source, output_json) {
         return RunVerdict::bare(code);
     }
-    let (wf, report, skills) =
+    let (_wf, _report, _skills) =
         match scoped_clean_gate(wf, report, task_filter, &source, json, theme, output_json) {
             Ok(triple) => triple,
             Err(code) => return RunVerdict::bare(code),
         };
-    if !has_captured_source && file != "-" {
-        return run_admitted(
-            file,
-            &source,
-            (json, output_json),
-            theme,
-            mode,
-            dry_run,
-            model_override,
-            access_pin,
-            vars,
-            resume,
-            no_trace_file,
-            task_filter,
-            no_outputs,
-            max_cost_usd,
-            interruptible,
-        );
-    }
-    let inputs = match inputs::validated_var_overrides(vars, &wf, output_json) {
-        Ok(map) => map,
-        Err(code) => return RunVerdict::bare(code),
-    };
-    if dry_run {
-        return dry_run::lane(file, &wf, &report, model_override, json, theme, output_json);
-    }
-    if let Err(code) = budget::preflight(&wf, &report, model_override, max_cost_usd, output_json) {
-        return RunVerdict::bare(code);
-    }
-    let setup = match resume_setup(resume, &wf, source_text, model_override, output_json) {
-        Ok(setup) => setup,
-        Err(code) => return RunVerdict::bare(code),
-    };
-    let runtime = match composed_runtime(
-        &wf,
-        (file, source_text),
-        model_override,
-        access_pin,
-        inputs,
-        setup,
-        max_cost_usd,
-        skills.clone(),
-        (no_trace_file, output_json),
-        &report,
-        None,
-    ) {
-        Ok(rt) => rt,
-        Err(code) => return RunVerdict::bare(code),
-    };
-    announce_access_pin(access_pin, (json, output_json), mode, &report);
-    execute_and_ask(
-        &runtime,
-        (file, source_text),
-        (&wf, &report),
-        resume.is_some_and(|r| r.trace.is_some()),
-        vars,
-        model_override,
-        access_pin,
-        max_cost_usd,
-        &skills,
-        theme,
-        mode,
-        (json, output_json, no_trace_file, no_outputs),
-        interruptible,
-        None,
-    )
-}
-
-#[allow(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
-fn run_admitted(
-    file: &str,
-    preview: &crate::verbs::RunSource,
-    (json, output_json): (bool, bool),
-    theme: Theme,
-    mode: RenderMode,
-    dry_run: bool,
-    model_override: Option<&str>,
-    access_pin: Option<&str>,
-    vars: &[String],
-    resume: Option<&ResumeRequest>,
-    no_trace_file: bool,
-    task_filter: Option<&str>,
-    no_outputs: bool,
-    max_cost_usd: Option<f64>,
-    interruptible: bool,
-) -> RunVerdict {
-    let (project, root, display_root) = match execution_project(file) {
-        Ok(parts) => parts,
-        Err(error) => {
-            epilogue::emit_diagnostic(&format!("nika run: environment: {error}"), output_json);
-            return RunVerdict::bare(exit::ENV);
-        }
-    };
-    let service = nika_execution::ExecutionService::default();
-    let admitted = match service.admit(&project, &root) {
-        Ok(admitted) => admitted,
-        Err(error) => return admission_refusal(&error, output_json),
-    };
-    if admitted.snapshot().text(admitted.snapshot().root()) != Some(preview.source()) {
-        epilogue::emit_diagnostic(
-            "nika run: execution admission: workflow changed during admission; retry the run",
-            output_json,
-        );
-        return RunVerdict::bare(exit::ENV);
-    }
-    let request = CliExecutionRequest {
+    run_admitted(
         file,
-        json,
-        output_json,
+        &source,
+        (json, output_json),
         theme,
         mode,
         dry_run,
@@ -473,213 +303,7 @@ fn run_admitted(
         no_outputs,
         max_cost_usd,
         interruptible,
-    };
-    let verdict = service.execute(admitted, move |context| {
-        run_admitted_context(context, &request, display_root)
-    });
-    verdict.into_outcome()
-}
-
-fn run_admitted_context(
-    context: nika_execution::ExecutionContext<'_>,
-    request: &CliExecutionRequest<'_>,
-    display_root: std::path::PathBuf,
-) -> RunVerdict {
-    let world = AdmittedWorld::from_context(context, display_root);
-    let mut report = context.check().clone();
-    crate::verbs::stamp_judged_semantic(context.workflow(), &mut report);
-    let (wf, report) = match apply_task_scope(
-        context.workflow().clone(),
-        report,
-        request.task_filter,
-        request.output_json,
-    ) {
-        Ok(pair) => pair,
-        Err(code) => return RunVerdict::bare(code),
-    };
-    let skills = match admitted_skills(&wf, &world.snapshot) {
-        Ok(skills) => skills,
-        Err(error) => {
-            epilogue::emit_diagnostic(&format!("nika run: {error}"), request.output_json);
-            return RunVerdict::bare(exit::FILE);
-        }
-    };
-    let inputs = match inputs::validated_var_overrides(request.vars, &wf, request.output_json) {
-        Ok(map) => map,
-        Err(code) => return RunVerdict::bare(code),
-    };
-    if request.dry_run {
-        return dry_run::lane(
-            request.file,
-            &wf,
-            &report,
-            request.model_override,
-            request.json,
-            request.theme,
-            request.output_json,
-        );
-    }
-    if let Err(code) = budget::preflight(
-        &wf,
-        &report,
-        request.model_override,
-        request.max_cost_usd,
-        request.output_json,
-    ) {
-        return RunVerdict::bare(code);
-    }
-    let Some(source) = admitted_root_source(&world.snapshot) else {
-        return admitted_root_refusal(request.output_json);
-    };
-    let setup = match resume_setup(
-        request.resume,
-        &wf,
-        source,
-        request.model_override,
-        request.output_json,
-    ) {
-        Ok(setup) => setup,
-        Err(code) => return RunVerdict::bare(code),
-    };
-    let runtime = match composed_runtime(
-        &wf,
-        (request.file, source),
-        request.model_override,
-        request.access_pin,
-        inputs,
-        setup,
-        request.max_cost_usd,
-        skills.clone(),
-        (request.no_trace_file, request.output_json),
-        &report,
-        Some(&world),
-    ) {
-        Ok(runtime) => runtime,
-        Err(code) => return RunVerdict::bare(code),
-    };
-    announce_access_pin(
-        request.access_pin,
-        (request.json, request.output_json),
-        request.mode,
-        &report,
-    );
-    execute_and_ask(
-        &runtime,
-        (request.file, source),
-        (&wf, &report),
-        request.resume.is_some_and(|resume| resume.trace.is_some()),
-        request.vars,
-        request.model_override,
-        request.access_pin,
-        request.max_cost_usd,
-        &skills,
-        request.theme,
-        request.mode,
-        (
-            request.json,
-            request.output_json,
-            request.no_trace_file,
-            request.no_outputs,
-        ),
-        request.interruptible,
-        Some(&world),
     )
-}
-
-fn admitted_root_source(snapshot: &nika_execution::ExecutionSnapshot) -> Option<&str> {
-    snapshot.text(snapshot.root())
-}
-
-fn admitted_root_refusal(output_json: bool) -> RunVerdict {
-    epilogue::emit_diagnostic(
-        "nika run: execution admission lost its root unit",
-        output_json,
-    );
-    RunVerdict::bare(exit::ENV)
-}
-
-fn execution_project(
-    file: &str,
-) -> Result<(nika_fs::OwnedDir, std::path::PathBuf, std::path::PathBuf), String> {
-    let cwd = std::env::current_dir().map_err(|error| error.to_string())?;
-    let path = std::path::Path::new(file);
-    let absolute = if path.is_absolute() {
-        path.to_path_buf()
-    } else {
-        cwd.join(path)
-    };
-    let absolute = lexical_path(&absolute);
-    let (display_root, root) = absolute.strip_prefix(&cwd).map_or_else(
-        |_| {
-            let parent = absolute
-                .parent()
-                .ok_or_else(|| format!("`{file}` has no project directory"))?;
-            let name = absolute
-                .file_name()
-                .ok_or_else(|| format!("`{file}` has no workflow filename"))?;
-            Ok::<_, String>((parent.to_path_buf(), std::path::PathBuf::from(name)))
-        },
-        |relative| Ok((cwd.clone(), relative.to_path_buf())),
-    )?;
-    let project = nika_fs::OwnedDir::open(&display_root)
-        .map_err(|error| format!("cannot hold project `{}`: {error}", display_root.display()))?;
-    Ok((project, root, display_root))
-}
-
-fn lexical_path(path: &std::path::Path) -> std::path::PathBuf {
-    let mut normalized = std::path::PathBuf::new();
-    for component in path.components() {
-        match component {
-            std::path::Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
-            std::path::Component::RootDir => {
-                normalized.push(std::path::Path::new(std::path::MAIN_SEPARATOR_STR));
-            }
-            std::path::Component::CurDir => {}
-            std::path::Component::ParentDir => {
-                normalized.pop();
-            }
-            std::path::Component::Normal(part) => normalized.push(part),
-        }
-    }
-    normalized
-}
-
-fn admitted_skills(
-    workflow: &RawWorkflow,
-    snapshot: &nika_execution::ExecutionSnapshot,
-) -> Result<BTreeMap<String, String>, String> {
-    let owner = snapshot.root();
-    let mut reader = |authored: &str| {
-        let logical = child_runner::resolve_admitted(owner, authored)?;
-        snapshot
-            .text(&logical)
-            .map(str::to_owned)
-            .ok_or_else(|| format!("captured world has no unit `{logical}`"))
-    };
-    let resolved = nika_schema::resolve_skills(workflow, &mut reader);
-    if resolved.findings.is_empty() {
-        Ok(resolved.texts)
-    } else {
-        Err(resolved
-            .findings
-            .iter()
-            .map(nika_schema::SkillFinding::row)
-            .collect::<Vec<_>>()
-            .join(" | "))
-    }
-}
-
-fn admission_refusal(error: &nika_execution::ExecutionError, output_json: bool) -> RunVerdict {
-    let code = if matches!(error, nika_execution::ExecutionError::Io { .. }) {
-        exit::ENV
-    } else {
-        exit::FILE
-    };
-    epilogue::emit_diagnostic(
-        &format!("nika run: execution admission: {error}"),
-        output_json,
-    );
-    RunVerdict::bare(code)
 }
 
 /// The access announce (D-2026-08-04-N1 · P2.6 + R-4): a pinned path is
@@ -749,7 +373,7 @@ fn execute_and_ask(
     mode: RenderMode,
     (json, output_json, no_trace_file, no_outputs): (bool, bool, bool, bool),
     interruptible: bool,
-    world: Option<&AdmittedWorld>,
+    world: &AdmittedWorld,
 ) -> RunVerdict {
     let rt = match executor(output_json) {
         Ok(rt) => rt,
@@ -834,7 +458,7 @@ fn answered_leg(
     mode: RenderMode,
     (json, output_json, no_trace_file, outputs): (bool, bool, bool, bool),
     rt: &tokio::runtime::Runtime,
-    world: Option<&AdmittedWorld>,
+    world: &AdmittedWorld,
 ) -> RunVerdict {
     let inputs = match inputs::validated_var_overrides(vars, wf, output_json) {
         Ok(map) => map,
@@ -846,7 +470,7 @@ fn answered_leg(
     };
     let runtime = match composed_runtime(
         wf,
-        (file, source),
+        source,
         model_override,
         access_pin,
         inputs,
@@ -973,7 +597,7 @@ fn output_mode(output: Option<&str>) -> Result<bool, u8> {
 #[allow(clippy::too_many_arguments)]
 fn composed_runtime(
     wf: &RawWorkflow,
-    (file, source): (&str, &str),
+    source: &str,
     model_override: Option<&str>,
     access_pin: Option<&str>,
     inputs: inputs::ValidatedInputs,
@@ -982,7 +606,7 @@ fn composed_runtime(
     skills: BTreeMap<String, String>,
     (no_trace_file, output_json): (bool, bool),
     report: &nika_check::CheckReport,
-    world: Option<&AdmittedWorld>,
+    world: &AdmittedWorld,
 ) -> Result<ProdRuntime, u8> {
     let ResumeSetup {
         plan: resume_plan,
@@ -1004,8 +628,8 @@ fn composed_runtime(
     // jitter seed — the stamper half is picked at the drive site).
     match production_runtime(default_model, caps, wf.run.as_ref().map(|s| &s.value)) {
         Ok(rt) => {
-            let rt = if let Some(world) = world {
-                rt.with_child_runner(std::sync::Arc::new(
+            let rt = rt
+                .with_child_runner(std::sync::Arc::new(
                     child_runner::ProdChildRunner::admitted(
                         world.snapshot.clone(),
                         world.snapshot.root(),
@@ -1018,17 +642,6 @@ fn composed_runtime(
                     &world.snapshot,
                     world.snapshot.root(),
                 ))
-            } else {
-                rt.with_child_runner(std::sync::Arc::new(child_runner::ProdChildRunner::new(
-                    file,
-                    !no_trace_file,
-                )))
-                .with_child_closures(child_runner::closure_digests(
-                    wf,
-                    std::path::Path::new(file),
-                ))
-            };
-            let rt = rt
                 .with_var_overrides(overrides)
                 // F-P13 · the input origins (NEP-0014 law 2) — the boot
                 // manifest journals where every bound input came from.
@@ -1059,8 +672,7 @@ fn composed_runtime(
                 .with_access_pin(access_pin.map(ToOwned::to_owned))
                 .with_boot_access_fields(boot_access)
                 .with_access_probes(nika_cli_host::probe::access_probes_with_harness())
-                // The run's identity: the journal names the definition it
-                // recorded (sha256 of the exact bytes this composer read).
+                // The journal names the exact definition bytes this composer read.
                 .with_source_sha256(sha256_hex(source.as_bytes()));
             // A CRLF/BOM source ALSO records its LF normal form, so drift
             // checks can tell a re-encode from an edit. LF sources skip

--- a/crates/nika-cli/src/verbs/run/provenance.rs
+++ b/crates/nika-cli/src/verbs/run/provenance.rs
@@ -46,7 +46,6 @@ pub fn run_with_repair_target(
         no_gc,
         require_signature,
         false,
-        None,
         Some(repair_target),
     )
     .code
@@ -54,19 +53,13 @@ pub fn run_with_repair_target(
 
 pub(super) fn capture_checked_source(
     file: &str,
-    captured: Option<crate::verbs::RunSource>,
     repair_target: Option<nika_display::check_render::RepairTarget>,
     output_json: bool,
 ) -> Result<(crate::verbs::RunSource, RawWorkflow, CheckReport), Box<RunVerdict>> {
-    let source = captured
+    let source = repair_target
         .map_or_else(
-            || {
-                repair_target.map_or_else(
-                    || crate::verbs::RunSource::capture(file),
-                    |target| crate::verbs::RunSource::capture_with_repair_target(file, target),
-                )
-            },
-            Ok,
+            || crate::verbs::RunSource::capture(file),
+            |target| crate::verbs::RunSource::capture_with_repair_target(file, target),
         )
         .map_err(|out| {
             epilogue::emit_diagnostic(&refusal_text(&out), output_json);

--- a/crates/nika-cli/src/verbs/run/sink.rs
+++ b/crates/nika-cli/src/verbs/run/sink.rs
@@ -8,6 +8,7 @@ use std::io::Write;
 
 use nika_event::Event;
 use nika_runtime::EventSink;
+use nika_types::id::ExecutionId;
 
 use nika_dap::journal::TraceFileSink;
 
@@ -70,6 +71,32 @@ pub(super) type SharedFold<W> = std::sync::Arc<std::sync::Mutex<FoldSink<W>>>;
 /// poisoned lock (another holder panicked) goes silent: the render is
 /// best-effort by contract, the verdict never rides here.
 pub(super) struct FoldHandle<W: Write>(pub(super) SharedFold<W>);
+
+/// Root-execution decorator for every projection of the runtime stream.
+///
+/// Event IDs remain minted by the runtime stamper. This seam only attaches
+/// the already-admitted execution identity before the event fans out to the
+/// human, JSON, and journal lanes.
+pub(super) struct ExecutionSink<S> {
+    inner: S,
+    execution: ExecutionId,
+}
+
+impl<S> ExecutionSink<S> {
+    pub(super) const fn new(inner: S, execution: ExecutionId) -> Self {
+        Self { inner, execution }
+    }
+
+    pub(super) fn into_inner(self) -> S {
+        self.inner
+    }
+}
+
+impl<S: EventSink> EventSink for ExecutionSink<S> {
+    fn emit(&mut self, event: Event) {
+        self.inner.emit(event.with_execution(self.execution));
+    }
+}
 
 impl<W: Write> EventSink for FoldHandle<W> {
     fn emit(&mut self, event: Event) {

--- a/crates/nika-cli/src/verbs/run/tests.rs
+++ b/crates/nika-cli/src/verbs/run/tests.rs
@@ -29,7 +29,6 @@ fn registry_run_refusal_keeps_copy_guidance_and_never_names_cache_as_fixable() {
     let cache_path = path.to_string_lossy().into_owned();
     let (source, _wf, report) = super::provenance::capture_checked_source(
         &cache_path,
-        None,
         Some(nika_display::check_render::RepairTarget::RegistryArtifact),
         false,
     )

--- a/crates/nika-cli/src/verbs/run/thread.rs
+++ b/crates/nika-cli/src/verbs/run/thread.rs
@@ -33,7 +33,6 @@ pub(crate) fn run_in_thread(file: &str, theme: Theme) -> ThreadRun {
         false,
         true,
         None,
-        None,
     );
     ThreadRun {
         answer: verdict

--- a/crates/nika-cli/src/verbs/serve.rs
+++ b/crates/nika-cli/src/verbs/serve.rs
@@ -7,7 +7,7 @@
 #![allow(clippy::disallowed_macros, clippy::print_stdout, clippy::print_stderr)]
 use super::arm::{
     self,
-    fire::{FireCtx, RunSeam, Wait, WaitSeam, fire_beat, labels},
+    fire::{ExecutionRunSeam, FireCtx, Wait, WaitSeam, fire_beat, labels},
     state::ArmState,
 };
 use super::{VerbOutput, exit};
@@ -72,7 +72,7 @@ fn go(args: &ServeArgs) -> Result<VerbOutput, VerbOutput> {
     let root = path
         .parent()
         .map_or_else(|| PathBuf::from("."), Path::to_path_buf);
-    let run: RunSeam = std::rc::Rc::new(arm::fire::prod_run);
+    let run: ExecutionRunSeam = std::rc::Rc::new(arm::fire::prod_run);
     serve(&root, registry, args, until.as_ref(), &clock(now), &run).map_err(fail)?;
     Ok(VerbOutput::ok(String::new()))
 }
@@ -215,10 +215,10 @@ fn fire_due(
     index: usize,
     now: &Zoned,
     wait: WaitSeam,
-    run: &RunSeam,
+    run: &ExecutionRunSeam,
     stop: &std::rc::Rc<std::cell::Cell<bool>>,
 ) -> (ArmRegistry, bool) {
-    let ctx = match FireCtx::new(
+    let ctx = match FireCtx::new_with_execution(
         root.to_path_buf(),
         reg,
         index,
@@ -294,7 +294,7 @@ fn serve(
     args: &ServeArgs,
     until: Option<&Zoned>,
     clock: &Clock,
-    run: &RunSeam,
+    run: &ExecutionRunSeam,
 ) -> Result<(), String> {
     let rt = std::rc::Rc::new(
         tokio::runtime::Builder::new_current_thread()
@@ -347,6 +347,8 @@ fn serve(
             .map(|(beat, label)| {
                 if beat.locus() == Locus::Cloud {
                     Ok(None)
+                } else if args.dry {
+                    state.peek_last_fired(label)
                 } else {
                     state.last_fired(label)
                 }
@@ -495,17 +497,17 @@ mod tests {
 
     /// The run seam that must NEVER fire — the skip-only ticks (the
     /// reload + refusal tests) prove their point by never calling it.
-    fn never_run() -> RunSeam {
+    fn never_run() -> ExecutionRunSeam {
         std::rc::Rc::new(|_, _| panic!("this tick runs nothing"))
     }
 
     /// A run stub that counts its shots (the real in-process run
     /// chdirs — parallel tests race on the process CWD, so the seam is
     /// stubbed; the binary tests own the real ground).
-    fn stub_run() -> (std::rc::Rc<std::cell::Cell<u32>>, RunSeam) {
+    fn stub_run() -> (std::rc::Rc<std::cell::Cell<u32>>, ExecutionRunSeam) {
         let count = std::rc::Rc::new(std::cell::Cell::new(0u32));
         let seen = std::rc::Rc::clone(&count);
-        let seam: RunSeam = std::rc::Rc::new(move |_, _: &RunShot| {
+        let seam: ExecutionRunSeam = std::rc::Rc::new(move |_, _: &RunShot| {
             seen.set(seen.get() + 1);
             RunUpshot::new(exit::OK, None)
         });

--- a/crates/nika-cli/src/verbs/serve.rs
+++ b/crates/nika-cli/src/verbs/serve.rs
@@ -413,8 +413,9 @@ mod tests {
     }
 
     fn write_workflow(root: &Path, name: &str) {
+        let id = name.strip_suffix(".nika.yaml").unwrap_or(name);
         let body = format!(
-            "nika: {name}\npermits: {{ exec: true }}\ntasks:\n  ok:\n    exec: {{ shell: \"true\" }}\n"
+            "nika: {id}\npermits: {{ exec: true }}\ntasks:\n  ok:\n    exec: {{ shell: \"true\" }}\n"
         );
         std::fs::write(root.join("workflows").join(name), body).expect("workflow");
     }
@@ -495,7 +496,7 @@ mod tests {
     /// The run seam that must NEVER fire — the skip-only ticks (the
     /// reload + refusal tests) prove their point by never calling it.
     fn never_run() -> RunSeam {
-        std::rc::Rc::new(|_| panic!("this tick runs nothing"))
+        std::rc::Rc::new(|_, _| panic!("this tick runs nothing"))
     }
 
     /// A run stub that counts its shots (the real in-process run
@@ -504,7 +505,7 @@ mod tests {
     fn stub_run() -> (std::rc::Rc<std::cell::Cell<u32>>, RunSeam) {
         let count = std::rc::Rc::new(std::cell::Cell::new(0u32));
         let seen = std::rc::Rc::clone(&count);
-        let seam: RunSeam = std::rc::Rc::new(move |_: &RunShot| {
+        let seam: RunSeam = std::rc::Rc::new(move |_, _: &RunShot| {
             seen.set(seen.get() + 1);
             RunUpshot::new(exit::OK, None)
         });

--- a/crates/nika-cli/src/verbs/serve.rs
+++ b/crates/nika-cli/src/verbs/serve.rs
@@ -288,6 +288,22 @@ fn race_sleep_or_signal(
 /// the span races ctrl-c/SIGTERM on the runtime — the loop's thread
 /// never blocks, and a broken wait sets the stop flag the loop checks
 /// after each fire.
+fn signal_runtime() -> Result<std::rc::Rc<tokio::runtime::Runtime>, String> {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map(std::rc::Rc::new)
+        .map_err(|error| format!("serve · the signal runtime refused: {error}"))
+}
+
+fn next_sleep_seconds(registry: &ArmRegistry, now: &Zoned) -> Result<i64, String> {
+    let next = nika_cadence::earliest_next(registry, now)
+        .map_err(|error| format!("serve · a validated registry refuses: {error}"))?;
+    Ok(next.map_or(60, |(_, slot)| {
+        (slot.at.timestamp().as_second() - now.timestamp().as_second()).clamp(1, 60)
+    }))
+}
+
 fn serve(
     root: &Path,
     mut reg: ArmRegistry,
@@ -296,12 +312,7 @@ fn serve(
     clock: &Clock,
     run: &ExecutionRunSeam,
 ) -> Result<(), String> {
-    let rt = std::rc::Rc::new(
-        tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .map_err(|e| format!("serve · the signal runtime refused: {e}"))?,
-    );
+    let rt = signal_runtime()?;
     #[cfg(unix)]
     let term: TermCell = std::rc::Rc::new(std::cell::RefCell::new(rt.block_on(async {
         tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()).ok()
@@ -375,11 +386,7 @@ fn serve(
         if args.once {
             return Ok(());
         }
-        let next = nika_cadence::earliest_next(&reg, &now)
-            .map_err(|e| format!("serve · a validated registry refuses: {e}"))?;
-        let secs = next.map_or(60, |(_, s)| {
-            (s.at.timestamp().as_second() - now.timestamp().as_second()).clamp(1, 60)
-        });
+        let secs = next_sleep_seconds(&reg, &now)?;
         #[cfg(unix)]
         let heard = race_sleep_or_signal(&rt, clock, &term, secs);
         #[cfg(not(unix))]

--- a/crates/nika-cli/tests/arm_fire.rs
+++ b/crates/nika-cli/tests/arm_fire.rs
@@ -107,6 +107,44 @@ tasks:
     agent: { prompt: "apply the skill", skills: ["skill.md"] }
 "#;
 
+/// A dynamically-computed write target passes static audit but is refused at
+/// the real fs boundary because it is outside the declared write set.
+const FORBIDDEN_WRITE: &str = r#"
+nika: forbidden-write
+permits:
+  fs:
+    write: ["./allowed.txt"]
+  tools: ["nika:jq", "nika:write"]
+tasks:
+  target:
+    invoke:
+      tool: "nika:jq"
+      args: { input: {}, expression: '"./forbidden.txt"' }
+  write:
+    with: { path: "${{ tasks.target.output }}" }
+    invoke:
+      tool: "nika:write"
+      args: { path: "${{ with.path }}", content: "must-not-land" }
+"#;
+
+const CAPTURED_WORLD_PARENT: &str = r#"
+nika: captured-world-parent
+model: mock/echo
+permits:
+  exec: true
+  fs:
+    read: ["skill.md"]
+tasks:
+  hold:
+    exec: { shell: "sleep 1" }
+  child:
+    after: { hold: success }
+    invoke: { workflow: "./child.nika.yaml" }
+  review:
+    after: { child: success }
+    agent: { prompt: "apply captured guidance", skills: ["skill.md"] }
+"#;
+
 /// Daily 03:00 UTC, skip the misses.
 const DAILY_3AM: &str = concat!(
     "nika: proj\n",
@@ -256,7 +294,152 @@ fn fire_runs_a_due_beat_and_records_it() {
         "the receipt fences the claim's seq: {hist}"
     );
     assert_eq!(receipt["slot_id"], claim["slot_id"], "{hist}");
+    let execution = claim["payload"]["execution_id"]
+        .as_str()
+        .expect("claim execution id");
+    let trace_id = claim["payload"]["trace_id"]
+        .as_str()
+        .expect("claim trace id");
+    assert_eq!(receipt["payload"]["execution_id"], execution);
+    assert_eq!(receipt["payload"]["trace_id"], trace_id);
+    let raw = std::fs::read_to_string(dir.join(trace)).expect("physical journal");
+    let recovered = nika_dap::recover::recover_events(&raw, trace).expect("typed trace events");
+    let first_execution = recovered.events[0]
+        .execution
+        .expect("the first root event carries service execution identity");
+    assert_eq!(first_execution.to_string(), execution);
+    let execution_uuid = execution
+        .strip_prefix("exe-")
+        .expect("typed execution prefix");
+    assert_eq!(trace_id, execution_uuid.replace('-', ""));
+    let trace_suffix = &trace_id[trace_id.len() - 4..];
+    assert!(
+        trace.ends_with(&format!("-{trace_suffix}.ndjson")),
+        "the typed trace ID addresses the physical journal: {trace}"
+    );
+    assert!(
+        recovered
+            .events
+            .iter()
+            .all(|event| event.execution == Some(first_execution)),
+        "every root event carries the admitted execution identity"
+    );
     assert_eq!(traces(&dir).len(), 1, "one fresh run = one trace (N2)");
+}
+
+#[test]
+fn direct_cli_projects_one_execution_identity_to_json_and_physical_trace() {
+    let dir = project(
+        "direct-execution-identity",
+        DAILY_3AM,
+        &[("doctor.nika.yaml", TRUE)],
+    );
+    let out = bin()
+        .args([
+            "run",
+            "workflows/doctor.nika.yaml",
+            "--json",
+            "--color",
+            "never",
+        ])
+        .current_dir(&dir)
+        .output()
+        .expect("spawn direct run");
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "direct run: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let frames = String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .map(|line| serde_json::from_str::<serde_json::Value>(line).expect("json event"))
+        .collect::<Vec<_>>();
+    let projected = frames[0]["execution"].clone();
+    assert!(
+        !projected.is_null(),
+        "the direct CLI projects execution identity"
+    );
+    assert!(
+        frames.iter().all(|frame| frame["execution"] == projected),
+        "every JSON projection carries the same execution"
+    );
+
+    let journals = traces(&dir);
+    assert_eq!(journals.len(), 1);
+    let trace = format!(".nika/traces/{}", journals[0]);
+    let raw = std::fs::read_to_string(dir.join(&trace)).expect("physical trace");
+    let recovered = nika_dap::recover::recover_events(&raw, &trace).expect("typed trace");
+    let execution = recovered.events[0].execution.expect("journal execution");
+    assert!(
+        recovered
+            .events
+            .iter()
+            .all(|event| event.execution == Some(execution))
+    );
+    let simple = execution.uuid.as_simple().to_string();
+    assert!(trace.ends_with(&format!("-{}.ndjson", &simple[simple.len() - 4..])));
+}
+
+#[test]
+fn forbidden_effect_fails_without_side_effect_and_keeps_exact_trace_identity() {
+    let dir = project(
+        "forbidden-effect",
+        DAILY_3AM,
+        &[("doctor.nika.yaml", FORBIDDEN_WRITE)],
+    );
+    let out = bin()
+        .args(["arm", "fire", "doctor", "--now", "2026-08-19T03:02:00Z"])
+        .current_dir(&dir)
+        .output()
+        .expect("spawn forbidden fire");
+    assert_eq!(out.status.code(), Some(1), "runtime denial maps to exit 1");
+    let line = assert_one_line(&out);
+    assert!(line.starts_with("failed doctor ·"), "{line}");
+    assert!(
+        !dir.join("forbidden.txt").exists(),
+        "the denied effect leaves zero bytes"
+    );
+
+    let hist = history(&dir, "doctor");
+    let docs = hist
+        .lines()
+        .map(|line| serde_json::from_str::<serde_json::Value>(line).expect("ledger json"))
+        .collect::<Vec<_>>();
+    assert_eq!(docs.len(), 2, "durable claim then terminal receipt: {hist}");
+    assert_eq!(docs[1]["kind"], "failed");
+    assert_eq!(docs[1]["payload"]["exit"], 1);
+    assert_eq!(
+        docs[1]["payload"]["execution_id"],
+        docs[0]["payload"]["execution_id"]
+    );
+    assert_eq!(
+        docs[1]["payload"]["trace_id"],
+        docs[0]["payload"]["trace_id"]
+    );
+    let trace = docs[1]["payload"]["trace"]
+        .as_str()
+        .expect("failed receipt trace");
+    let raw = std::fs::read_to_string(dir.join(trace)).expect("failed trace exists");
+    let recovered = nika_dap::recover::recover_events(&raw, trace).expect("typed failed trace");
+    let execution = docs[0]["payload"]["execution_id"]
+        .as_str()
+        .expect("claim execution");
+    assert!(recovered.events.iter().all(|event| {
+        event
+            .execution
+            .is_some_and(|id| id.to_string() == execution)
+    }));
+    assert!(
+        recovered.events.iter().any(|event| {
+            event.kind == nika_event::EventKind::PermitChecked
+                && event.fields.iter().any(|field| {
+                    field.key == "decision"
+                        && field.value == nika_types::resource::Value::String("deny".to_owned())
+                })
+        }),
+        "the real denial is journaled"
+    );
 }
 
 #[cfg(unix)]
@@ -413,6 +596,57 @@ fn fire_keeps_pinned_parent_bytes_and_their_original_relative_child_base() {
         replacement,
         "the successful run came from the captured bytes, not a second file read"
     );
+}
+
+#[test]
+fn actual_arm_runner_uses_captured_child_and_skill_after_durable_claim() {
+    let registry = DAILY_3AM.replace("doctor.nika.yaml", "parent.nika.yaml");
+    let dir = project(
+        "captured-child-skill-mutation",
+        &registry,
+        &[
+            ("parent.nika.yaml", CAPTURED_WORLD_PARENT),
+            ("child.nika.yaml", RELATIVE_CHILD),
+            (
+                "skill.md",
+                "---\nname: captured\ndescription: captured guidance\n---\nOriginal.\n",
+            ),
+        ],
+    );
+    let child = bin()
+        .args(["arm", "fire", "parent", "--now", "2026-08-19T03:02:00Z"])
+        .current_dir(&dir)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn captured-world fire");
+    let history_path = dir.join(".nika/arm/parent/history.ndjson");
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    while !std::fs::read_to_string(&history_path)
+        .is_ok_and(|text| text.contains("\"kind\":\"claimed\""))
+    {
+        assert!(std::time::Instant::now() < deadline, "claim did not land");
+        std::thread::sleep(std::time::Duration::from_millis(5));
+    }
+    std::fs::write(
+        dir.join("workflows/child.nika.yaml"),
+        "not: a valid nika workflow\n",
+    )
+    .expect("mutate child after claim");
+    std::fs::write(dir.join("workflows/skill.md"), "invalid replacement")
+        .expect("mutate skill after claim");
+
+    let out = child
+        .wait_with_output()
+        .expect("captured-world fire settles");
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "only the admitted child+skill bytes may run: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let line = assert_one_line(&out);
+    assert!(line.starts_with("fired parent ·"), "{line}");
 }
 
 #[test]

--- a/crates/nika-cli/tests/serve.rs
+++ b/crates/nika-cli/tests/serve.rs
@@ -73,6 +73,40 @@ fn history(dir: &std::path::Path, label: &str) -> String {
         .unwrap_or_default()
 }
 
+fn tree_snapshot(root: &std::path::Path) -> Vec<(std::path::PathBuf, Option<Vec<u8>>)> {
+    fn walk(
+        base: &std::path::Path,
+        at: &std::path::Path,
+        out: &mut Vec<(std::path::PathBuf, Option<Vec<u8>>)>,
+    ) {
+        let mut entries = std::fs::read_dir(at)
+            .expect("snapshot directory")
+            .collect::<Result<Vec<_>, _>>()
+            .expect("snapshot entries");
+        entries.sort_by_key(std::fs::DirEntry::file_name);
+        for entry in entries {
+            let path = entry.path();
+            let relative = path
+                .strip_prefix(base)
+                .expect("snapshot relative")
+                .to_owned();
+            if entry.file_type().expect("snapshot type").is_dir() {
+                out.push((relative, None));
+                walk(base, &path, out);
+            } else {
+                out.push((
+                    relative,
+                    Some(std::fs::read(&path).expect("snapshot bytes")),
+                ));
+            }
+        }
+    }
+
+    let mut out = Vec::new();
+    walk(root, root, &mut out);
+    out
+}
+
 #[test]
 fn serve_once_fires_what_is_due_and_exits_zero() {
     let dir = project("once", DAILY_3AM, &[("doctor.nika.yaml", TRUE)]);
@@ -111,8 +145,48 @@ fn serve_once_dry_reports_due_beat_without_state_trace_or_effect() {
         "would fire doctor · slot 2026-08-19T03:00:00Z\n"
     );
     assert!(history(&dir, "doctor").is_empty(), "zero ledger rows");
-    assert!(!dir.join(".nika/traces").exists(), "zero trace directory");
+    assert!(
+        !dir.join(".nika").exists(),
+        "a fresh dry project stays byte-for-byte absent"
+    );
     assert!(!dir.join("should-not-exist").exists(), "zero effects");
+}
+
+#[test]
+fn serve_once_dry_keeps_an_existing_sidecar_byte_identical() {
+    let dir = project(
+        "once-dry-existing",
+        DAILY_3AM,
+        &[("doctor.nika.yaml", TRUE)],
+    );
+    let seed = bin()
+        .args(["arm", "fire", "doctor", "--now", "2026-08-18T03:02:00Z"])
+        .current_dir(&dir)
+        .output()
+        .expect("seed real firing");
+    assert_eq!(
+        seed.status.code(),
+        Some(0),
+        "seed stderr: {}",
+        String::from_utf8_lossy(&seed.stderr)
+    );
+    let before = tree_snapshot(&dir.join(".nika"));
+
+    let dry = bin()
+        .args(["serve", "--once", "--dry", "--now", "2026-08-19T03:02:00Z"])
+        .current_dir(&dir)
+        .output()
+        .expect("dry serve over existing state");
+    assert_eq!(dry.status.code(), Some(0));
+    assert_eq!(
+        String::from_utf8_lossy(&dry.stdout),
+        "would fire doctor · slot 2026-08-19T03:00:00Z\n"
+    );
+    assert_eq!(
+        tree_snapshot(&dir.join(".nika")),
+        before,
+        "dry-run does not create a lock, repair a cache, or alter one byte"
+    );
 }
 
 #[test]

--- a/crates/nika-cli/tests/serve.rs
+++ b/crates/nika-cli/tests/serve.rs
@@ -39,6 +39,8 @@ fn project(tag: &str, registry: &str, workflows: &[(&str, &str)]) -> std::path::
 const TRUE: &str =
     "nika: armed-true\npermits: { exec: true }\ntasks:\n  ok:\n    exec: { shell: \"true\" }\n";
 
+const TOUCH: &str = "nika: dry-only\npermits: { exec: true }\ntasks:\n  effect:\n    exec: { shell: \"touch should-not-exist\" }\n";
+
 /// Daily 03:00 UTC, skip the misses.
 const DAILY_3AM: &str = concat!(
     "nika: proj\n",
@@ -93,6 +95,24 @@ fn serve_once_fires_what_is_due_and_exits_zero() {
     let last = last_json(&dir, "doctor").expect("last.json");
     assert_eq!(last["kind"], "fired");
     assert_eq!(last["slot"], "2026-08-19T03:00:00Z");
+}
+
+#[test]
+fn serve_once_dry_reports_due_beat_without_state_trace_or_effect() {
+    let dir = project("once-dry", DAILY_3AM, &[("doctor.nika.yaml", TOUCH)]);
+    let out = bin()
+        .args(["serve", "--once", "--dry", "--now", "2026-08-19T03:02:00Z"])
+        .current_dir(&dir)
+        .output()
+        .expect("spawn dry serve");
+    assert_eq!(out.status.code(), Some(0));
+    assert_eq!(
+        String::from_utf8_lossy(&out.stdout),
+        "would fire doctor · slot 2026-08-19T03:00:00Z\n"
+    );
+    assert!(history(&dir, "doctor").is_empty(), "zero ledger rows");
+    assert!(!dir.join(".nika/traces").exists(), "zero trace directory");
+    assert!(!dir.join("should-not-exist").exists(), "zero effects");
 }
 
 #[test]

--- a/crates/nika-dap/public-api.txt
+++ b/crates/nika-dap/public-api.txt
@@ -1757,6 +1757,7 @@ pub fn nika_dap::journal::TraceFileSink::chain_head(&self) -> &str
 pub fn nika_dap::journal::TraceFileSink::chain_len(&self) -> usize
 pub fn nika_dap::journal::TraceFileSink::disabled() -> Self
 pub fn nika_dap::journal::TraceFileSink::finalize(&mut self)
+pub fn nika_dap::journal::TraceFileSink::for_execution(self, execution: nika_types::id::ExecutionId, trace: nika_types::id::TraceId) -> Self
 pub fn nika_dap::journal::TraceFileSink::into_error(self) -> core::option::Option<core::io::error::Error>
 pub fn nika_dap::journal::TraceFileSink::is_disabled(&self) -> bool
 pub fn nika_dap::journal::TraceFileSink::new(dir: impl core::convert::Into<std::path::PathBuf>) -> Self

--- a/crates/nika-dap/src/journal.rs
+++ b/crates/nika-dap/src/journal.rs
@@ -27,7 +27,7 @@ use std::path::{Path, PathBuf};
 
 use nika_event::Event;
 use nika_runtime::EventSink;
-use nika_types::id::EventId;
+use nika_types::id::{EventId, ExecutionId, TraceId};
 use nika_types::timestamp::Timestamp;
 use uuid::Uuid;
 
@@ -150,9 +150,9 @@ enum Lane {
     /// (`try` stages a temp file) — emit is a no-op by design,
     /// so the caller keeps ONE code path whether journaling or not.
     Disabled,
-    /// Enabled but not yet on disk — the file is NAMED from the first
-    /// event's identity (its `UUIDv7` id carries the run's mint time),
-    /// so nothing can open before the stream starts.
+    /// Enabled but not yet on disk — the file is named lazily from the
+    /// service trace identity when bound, or the first event's identity for
+    /// legacy callers, so nothing can open before the stream starts.
     Pending,
     /// Open and appending one NDJSON line per event.
     Open(BufWriter<File>),
@@ -166,10 +166,10 @@ enum Lane {
 /// only the ones piped through `--json`.
 ///
 /// Three constraints shape it:
-/// - **Lazy open** — file creation waits for the FIRST emit: the name
-///   needs the first event's `UUIDv7` id + wall timestamp, and a run
-///   that never starts (audit refusal · composition failure) must not
-///   litter an empty file.
+/// - **Lazy open** — file creation waits for the FIRST emit: the name uses
+///   the bound typed trace ID (legacy callers fall back to event identity)
+///   plus the event timestamp, and a run that never starts (audit refusal ·
+///   composition failure) must not litter an empty file.
 /// - **Infallible** (the [`EventSink`] contract) — an fs error (read-only
 ///   checkout · disk full) is buffered, never panics, never changes the
 ///   run's verdict or its primary bytes; the caller surfaces it AFTER
@@ -182,6 +182,12 @@ pub struct TraceFileSink {
     /// `TRACE_DIR` in production · a temp dir under test). Meaningless
     /// when disabled.
     dir: PathBuf,
+    /// Service-minted root identity. When present, every journaled event is
+    /// stamped with this execution and the physical journal is named from
+    /// the corresponding typed trace identity rather than inferred from an
+    /// arbitrary first event.
+    execution: Option<ExecutionId>,
+    trace: Option<TraceId>,
     lane: Lane,
     /// The opened file's path (`None` until the lazy open · stays `None`
     /// when disabled or when the open itself failed).
@@ -201,6 +207,8 @@ impl TraceFileSink {
     pub fn new(dir: impl Into<PathBuf>) -> Self {
         Self {
             dir: dir.into(),
+            execution: None,
+            trace: None,
             lane: Lane::Pending,
             path: None,
             error: None,
@@ -215,12 +223,27 @@ impl TraceFileSink {
     pub fn disabled() -> Self {
         Self {
             dir: PathBuf::new(),
+            execution: None,
+            trace: None,
             lane: Lane::Disabled,
             path: None,
             error: None,
             chain: ChainState::genesis(),
             written: 0,
         }
+    }
+
+    /// Bind this journal to one service-admitted root execution.
+    ///
+    /// The two IDs stay distinct types even though the execution UUID bytes
+    /// deterministically seed the W3C root trace ID. The trace ID addresses
+    /// the file; the execution ID annotates every event written to it.
+    #[must_use]
+    pub fn for_execution(mut self, execution: ExecutionId, trace: TraceId) -> Self {
+        debug_assert_eq!(TraceId::from(execution), trace);
+        self.execution = Some(execution);
+        self.trace = Some(trace);
+        self
     }
 
     /// The journal file's path, once the lazy open happened.
@@ -279,14 +302,17 @@ impl TraceFileSink {
         }
     }
 
-    /// Create the directory + the journal file, named from the first
-    /// event's identity.
+    /// Create the directory + the journal file, addressed by the bound trace
+    /// identity or, for a legacy caller, the first event's identity.
     ///
     /// Execution identity names the journal directly. Legacy events fall
     /// back to run identity, then event identity, without a timestamp scan.
     fn open(&mut self, first: &Event) -> std::io::Result<()> {
         std::fs::create_dir_all(&self.dir)?;
-        let id = journal_identity(first);
+        let id = self.trace.map_or_else(
+            || journal_identity(first),
+            |trace| Uuid::from_bytes(trace.bytes),
+        );
         let path = self.dir.join(trace_file_name(first.timestamp, id));
         // `create_new` refuses to clobber: two runs in the same SECOND can
         // share the 4-hex short id (16 random bits — a real risk under a
@@ -331,7 +357,10 @@ fn journal_identity(first: &Event) -> Uuid {
 }
 
 impl EventSink for TraceFileSink {
-    fn emit(&mut self, event: Event) {
+    fn emit(&mut self, mut event: Event) {
+        if let Some(execution) = self.execution {
+            event.execution = Some(execution);
+        }
         if self.error.is_some() {
             return; // already broken · stop touching a dead lane
         }
@@ -567,6 +596,30 @@ mod tests {
             .with_run(RunId::from_bytes([2; 16]))
             .with_execution(ExecutionId::from_bytes([3; 16]));
         assert_eq!(journal_identity(&event), Uuid::from_bytes([3; 16]));
+    }
+
+    #[test]
+    fn bound_trace_identity_names_and_stamps_the_journal() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let execution = ExecutionId::from_bytes([0x3a; 16]);
+        let trace = TraceId::from(execution);
+        let mut sink = TraceFileSink::new(tmp.path()).for_execution(execution, trace);
+        let event = demo::success().into_iter().next().expect("demo event");
+
+        sink.emit(event);
+
+        let path = sink.path().expect("bound journal path");
+        assert!(
+            path.file_name()
+                .and_then(std::ffi::OsStr::to_str)
+                .is_some_and(|name| name.ends_with("-3a3a.ndjson")),
+            "the typed trace identity addresses the physical journal: {}",
+            path.display()
+        );
+        let raw = std::fs::read_to_string(path).expect("journal bytes");
+        let recovered = crate::recover::recover_events(&raw, &path.display().to_string())
+            .expect("typed event stream");
+        assert_eq!(recovered.events[0].execution, Some(execution));
     }
 
     /// Lazy open: a sink that never receives an event leaves ZERO fs

--- a/crates/nika-execution/public-api.txt
+++ b/crates/nika-execution/public-api.txt
@@ -242,7 +242,8 @@ impl nika_execution::ExecutionService
 pub fn nika_execution::ExecutionService::admit(&self, project: &nika_fs::owned_dir::OwnedDir, root: &std::path::Path) -> core::result::Result<nika_execution::AdmittedExecution, nika_execution::ExecutionError>
 pub fn nika_execution::ExecutionService::admit_root_bytes(&self, project: &nika_fs::owned_dir::OwnedDir, root: &std::path::Path, root_bytes: &[u8]) -> core::result::Result<nika_execution::AdmittedExecution, nika_execution::ExecutionError>
 pub fn nika_execution::ExecutionService::admit_with_imports<I, P>(&self, project: &nika_fs::owned_dir::OwnedDir, root: &std::path::Path, imports: I) -> core::result::Result<nika_execution::AdmittedExecution, nika_execution::ExecutionError> where I: core::iter::traits::collect::IntoIterator<Item = P>, P: core::convert::AsRef<std::path::Path>
-pub fn nika_execution::ExecutionService::execute<T, F>(&self, admitted: nika_execution::AdmittedExecution, runner: F) -> nika_execution::ExecutionVerdict<T> where F: for<'a> core::ops::function::FnOnce(nika_execution::ExecutionContext<'a>) -> T
+pub fn nika_execution::ExecutionService::execute<T>(&self, admitted: nika_execution::AdmittedExecution, runner: for<'a> fn(nika_execution::ExecutionContext<'a>) -> T) -> nika_execution::ExecutionVerdict<T>
+pub fn nika_execution::ExecutionService::execute_with<T, F>(&self, admitted: nika_execution::AdmittedExecution, runner: F) -> nika_execution::ExecutionVerdict<T> where F: for<'a> core::ops::function::FnOnce(nika_execution::ExecutionContext<'a>) -> T
 pub const fn nika_execution::ExecutionService::new(limits: nika_execution::SnapshotLimits) -> Self
 impl core::clone::Clone for nika_execution::ExecutionService
 pub fn nika_execution::ExecutionService::clone(&self) -> nika_execution::ExecutionService

--- a/crates/nika-execution/public-api.txt
+++ b/crates/nika-execution/public-api.txt
@@ -242,8 +242,8 @@ impl nika_execution::ExecutionService
 pub fn nika_execution::ExecutionService::admit(&self, project: &nika_fs::owned_dir::OwnedDir, root: &std::path::Path) -> core::result::Result<nika_execution::AdmittedExecution, nika_execution::ExecutionError>
 pub fn nika_execution::ExecutionService::admit_root_bytes(&self, project: &nika_fs::owned_dir::OwnedDir, root: &std::path::Path, root_bytes: &[u8]) -> core::result::Result<nika_execution::AdmittedExecution, nika_execution::ExecutionError>
 pub fn nika_execution::ExecutionService::admit_with_imports<I, P>(&self, project: &nika_fs::owned_dir::OwnedDir, root: &std::path::Path, imports: I) -> core::result::Result<nika_execution::AdmittedExecution, nika_execution::ExecutionError> where I: core::iter::traits::collect::IntoIterator<Item = P>, P: core::convert::AsRef<std::path::Path>
+pub fn nika_execution::ExecutionService::begin(&self, admitted: nika_execution::AdmittedExecution) -> nika_execution::ExecutionSession
 pub fn nika_execution::ExecutionService::execute<T>(&self, admitted: nika_execution::AdmittedExecution, runner: for<'a> fn(nika_execution::ExecutionContext<'a>) -> T) -> nika_execution::ExecutionVerdict<T>
-pub fn nika_execution::ExecutionService::execute_with<T, F>(&self, admitted: nika_execution::AdmittedExecution, runner: F) -> nika_execution::ExecutionVerdict<T> where F: for<'a> core::ops::function::FnOnce(nika_execution::ExecutionContext<'a>) -> T
 pub const fn nika_execution::ExecutionService::new(limits: nika_execution::SnapshotLimits) -> Self
 impl core::clone::Clone for nika_execution::ExecutionService
 pub fn nika_execution::ExecutionService::clone(&self) -> nika_execution::ExecutionService
@@ -283,6 +283,33 @@ impl<T> outref::AsOut<T> for nika_execution::ExecutionService where T: core::mar
 pub fn nika_execution::ExecutionService::as_out(&mut self) -> outref::Out<'_, T>
 impl<T> typenum::type_operators::Same for nika_execution::ExecutionService
 pub type nika_execution::ExecutionService::Output = T
+#[non_exhaustive] pub struct nika_execution::ExecutionSession
+impl nika_execution::ExecutionSession
+pub fn nika_execution::ExecutionSession::complete<T>(self, outcome: T) -> nika_execution::ExecutionVerdict<T>
+pub const fn nika_execution::ExecutionSession::context(&self) -> nika_execution::ExecutionContext<'_>
+impl core::fmt::Debug for nika_execution::ExecutionSession
+pub fn nika_execution::ExecutionSession::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<D> owo_colors::OwoColorize for nika_execution::ExecutionSession
+impl<T, U> core::convert::Into<U> for nika_execution::ExecutionSession where U: core::convert::From<T>
+pub fn nika_execution::ExecutionSession::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_execution::ExecutionSession where U: core::convert::Into<T>
+pub type nika_execution::ExecutionSession::Error = core::convert::Infallible
+pub fn nika_execution::ExecutionSession::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_execution::ExecutionSession where U: core::convert::TryFrom<T>
+pub type nika_execution::ExecutionSession::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_execution::ExecutionSession::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for nika_execution::ExecutionSession where T: 'static + ?core::marker::Sized
+pub fn nika_execution::ExecutionSession::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_execution::ExecutionSession where T: ?core::marker::Sized
+pub fn nika_execution::ExecutionSession::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_execution::ExecutionSession where T: ?core::marker::Sized
+pub fn nika_execution::ExecutionSession::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for nika_execution::ExecutionSession
+pub fn nika_execution::ExecutionSession::from(t: T) -> T
+impl<T> nika_error::traits::AsAny for nika_execution::ExecutionSession where T: 'static
+pub fn nika_execution::ExecutionSession::as_any(&self) -> &(dyn core::any::Any + 'static)
+impl<T> typenum::type_operators::Same for nika_execution::ExecutionSession
+pub type nika_execution::ExecutionSession::Output = T
 #[non_exhaustive] pub struct nika_execution::ExecutionSnapshot
 impl nika_execution::ExecutionSnapshot
 pub fn nika_execution::ExecutionSnapshot::bytes(&self, logical_path: &str) -> core::option::Option<&[u8]>

--- a/crates/nika-execution/public-api.txt
+++ b/crates/nika-execution/public-api.txt
@@ -240,8 +240,9 @@ pub type nika_execution::ExecutionContext<'a>::Output = T
 #[non_exhaustive] pub struct nika_execution::ExecutionService
 impl nika_execution::ExecutionService
 pub fn nika_execution::ExecutionService::admit(&self, project: &nika_fs::owned_dir::OwnedDir, root: &std::path::Path) -> core::result::Result<nika_execution::AdmittedExecution, nika_execution::ExecutionError>
+pub fn nika_execution::ExecutionService::admit_root_bytes(&self, project: &nika_fs::owned_dir::OwnedDir, root: &std::path::Path, root_bytes: &[u8]) -> core::result::Result<nika_execution::AdmittedExecution, nika_execution::ExecutionError>
 pub fn nika_execution::ExecutionService::admit_with_imports<I, P>(&self, project: &nika_fs::owned_dir::OwnedDir, root: &std::path::Path, imports: I) -> core::result::Result<nika_execution::AdmittedExecution, nika_execution::ExecutionError> where I: core::iter::traits::collect::IntoIterator<Item = P>, P: core::convert::AsRef<std::path::Path>
-pub fn nika_execution::ExecutionService::execute<T>(&self, admitted: nika_execution::AdmittedExecution, runner: for<'a> fn(nika_execution::ExecutionContext<'a>) -> T) -> nika_execution::ExecutionVerdict<T>
+pub fn nika_execution::ExecutionService::execute<T, F>(&self, admitted: nika_execution::AdmittedExecution, runner: F) -> nika_execution::ExecutionVerdict<T> where F: for<'a> core::ops::function::FnOnce(nika_execution::ExecutionContext<'a>) -> T
 pub const fn nika_execution::ExecutionService::new(limits: nika_execution::SnapshotLimits) -> Self
 impl core::clone::Clone for nika_execution::ExecutionService
 pub fn nika_execution::ExecutionService::clone(&self) -> nika_execution::ExecutionService
@@ -285,6 +286,7 @@ pub type nika_execution::ExecutionService::Output = T
 impl nika_execution::ExecutionSnapshot
 pub fn nika_execution::ExecutionSnapshot::bytes(&self, logical_path: &str) -> core::option::Option<&[u8]>
 pub fn nika_execution::ExecutionSnapshot::capture(project: &nika_fs::owned_dir::OwnedDir, root: &std::path::Path, limits: nika_execution::SnapshotLimits) -> core::result::Result<Self, nika_execution::ExecutionError>
+pub fn nika_execution::ExecutionSnapshot::capture_root_bytes(project: &nika_fs::owned_dir::OwnedDir, root: &std::path::Path, root_bytes: &[u8], limits: nika_execution::SnapshotLimits) -> core::result::Result<Self, nika_execution::ExecutionError>
 pub fn nika_execution::ExecutionSnapshot::capture_with_imports<I, P>(project: &nika_fs::owned_dir::OwnedDir, root: &std::path::Path, imports: I, limits: nika_execution::SnapshotLimits) -> core::result::Result<Self, nika_execution::ExecutionError> where I: core::iter::traits::collect::IntoIterator<Item = P>, P: core::convert::AsRef<std::path::Path>
 pub fn nika_execution::ExecutionSnapshot::digest(&self) -> &str
 pub const fn nika_execution::ExecutionSnapshot::format_version(&self) -> u32

--- a/crates/nika-execution/src/lib.rs
+++ b/crates/nika-execution/src/lib.rs
@@ -11,7 +11,9 @@ mod service;
 mod snapshot;
 
 pub use error::ExecutionError;
-pub use service::{AdmittedExecution, ExecutionContext, ExecutionService, ExecutionVerdict};
+pub use service::{
+    AdmittedExecution, ExecutionContext, ExecutionService, ExecutionSession, ExecutionVerdict,
+};
 pub use snapshot::{
     CapturedUnit, ExecutionSnapshot, SNAPSHOT_FORMAT_VERSION, SnapshotLimits, SnapshotUnitKind,
 };

--- a/crates/nika-execution/src/service.rs
+++ b/crates/nika-execution/src/service.rs
@@ -40,6 +40,24 @@ impl ExecutionService {
         Self::admit_snapshot(snapshot)
     }
 
+    /// Admit root bytes already captured by an interface, with transitive
+    /// dependencies resolved from the held project directory.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExecutionError`] under the same fail-closed conditions as
+    /// [`Self::admit`].
+    pub fn admit_root_bytes(
+        &self,
+        project: &OwnedDir,
+        root: &Path,
+        root_bytes: &[u8],
+    ) -> Result<AdmittedExecution, ExecutionError> {
+        let snapshot =
+            ExecutionSnapshot::capture_root_bytes(project, root, root_bytes, self.limits)?;
+        Self::admit_snapshot(snapshot)
+    }
+
     /// Admit a workflow world with explicit project-level imports.
     ///
     /// # Errors

--- a/crates/nika-execution/src/service.rs
+++ b/crates/nika-execution/src/service.rs
@@ -66,11 +66,10 @@ impl ExecutionService {
     /// The runner receives no root capability and no mutable pathname. Its
     /// outcome may itself be a `Result`, preserving the caller's typed runtime
     /// verdict without widening this infrastructure boundary.
-    pub fn execute<T>(
-        &self,
-        admitted: AdmittedExecution,
-        runner: for<'a> fn(ExecutionContext<'a>) -> T,
-    ) -> ExecutionVerdict<T> {
+    pub fn execute<T, F>(&self, admitted: AdmittedExecution, runner: F) -> ExecutionVerdict<T>
+    where
+        F: for<'a> FnOnce(ExecutionContext<'a>) -> T,
+    {
         let AdmittedExecution {
             execution_id,
             trace_id,
@@ -464,5 +463,39 @@ mod tests {
         .into_iter()
         .filter_map(|path| cx.snapshot().text(path).map(str::to_owned))
         .collect()
+    }
+
+    #[test]
+    fn execution_runner_captures_an_adapter_request_without_widening_context() {
+        let workflow = b"nika: root\npermits:\n  tools: [\"nika:jq\"]\ntasks:\n  value:\n    invoke:\n      tool: nika:jq\n      args: { input: 1, expression: \".\" }\n";
+        let source = CountingSource {
+            reads: RefCell::new(Vec::new()),
+            files: BTreeMap::from([("root.nika.yaml".to_owned(), workflow.to_vec())]),
+        };
+        let snapshot = ExecutionSnapshot::capture_from(
+            &source,
+            Path::new("root.nika.yaml"),
+            std::iter::empty::<&Path>(),
+            SnapshotLimits::default(),
+        )
+        .expect("capture");
+        let admitted = ExecutionService::admit_snapshot(snapshot).expect("admit captured world");
+        let execution_id = admitted.execution_id();
+        let trace_id = admitted.trace_id();
+        let digest = admitted.snapshot().digest().to_owned();
+        let captured_digest = digest.clone();
+        let adapter_request = String::from("model=mock/echo;max_cost_usd=0");
+
+        let verdict = ExecutionService::default().execute(admitted, move |context| {
+            assert_eq!(context.execution_id(), execution_id);
+            assert_eq!(context.trace_id(), trace_id);
+            assert_eq!(context.snapshot().digest(), captured_digest);
+            adapter_request
+        });
+
+        assert_eq!(verdict.execution_id(), execution_id);
+        assert_eq!(verdict.trace_id(), trace_id);
+        assert_eq!(verdict.snapshot_digest(), digest);
+        assert_eq!(verdict.outcome(), "model=mock/echo;max_cost_usd=0");
     }
 }

--- a/crates/nika-execution/src/service.rs
+++ b/crates/nika-execution/src/service.rs
@@ -79,12 +79,25 @@ impl ExecutionService {
         Self::admit_snapshot(snapshot)
     }
 
-    /// Execute through a runner that can observe only the admitted world.
+    /// Execute through the original function-pointer runner seam.
+    ///
+    /// Kept as the stable compatibility surface. Adapters that need to move
+    /// request state into the runner use [`Self::execute_with`].
+    pub fn execute<T>(
+        &self,
+        admitted: AdmittedExecution,
+        runner: for<'a> fn(ExecutionContext<'a>) -> T,
+    ) -> ExecutionVerdict<T> {
+        self.execute_with(admitted, runner)
+    }
+
+    /// Execute through a runner that can observe only the admitted world and
+    /// can own adapter request state.
     ///
     /// The runner receives no root capability and no mutable pathname. Its
     /// outcome may itself be a `Result`, preserving the caller's typed runtime
     /// verdict without widening this infrastructure boundary.
-    pub fn execute<T, F>(&self, admitted: AdmittedExecution, runner: F) -> ExecutionVerdict<T>
+    pub fn execute_with<T, F>(&self, admitted: AdmittedExecution, runner: F) -> ExecutionVerdict<T>
     where
         F: for<'a> FnOnce(ExecutionContext<'a>) -> T,
     {
@@ -504,7 +517,7 @@ mod tests {
         let captured_digest = digest.clone();
         let adapter_request = String::from("model=mock/echo;max_cost_usd=0");
 
-        let verdict = ExecutionService::default().execute(admitted, move |context| {
+        let verdict = ExecutionService::default().execute_with(admitted, move |context| {
             assert_eq!(context.execution_id(), execution_id);
             assert_eq!(context.trace_id(), trace_id);
             assert_eq!(context.snapshot().digest(), captured_digest);

--- a/crates/nika-execution/src/service.rs
+++ b/crates/nika-execution/src/service.rs
@@ -81,26 +81,30 @@ impl ExecutionService {
 
     /// Execute through the original function-pointer runner seam.
     ///
-    /// Kept as the stable compatibility surface. Adapters that need to move
-    /// request state into the runner use [`Self::execute_with`].
+    /// This convenience surface supplies only [`ExecutionContext`] to the
+    /// runner. It is not a process sandbox: the runner remains trusted code
+    /// and can use ambient capabilities it obtains elsewhere.
     pub fn execute<T>(
         &self,
         admitted: AdmittedExecution,
         runner: for<'a> fn(ExecutionContext<'a>) -> T,
     ) -> ExecutionVerdict<T> {
-        self.execute_with(admitted, runner)
+        let session = self.begin(admitted);
+        let outcome = runner(session.context());
+        session.complete(outcome)
     }
 
-    /// Execute through a runner that can observe only the admitted world and
-    /// can own adapter request state.
+    /// Begin one execution session over an admitted immutable world.
     ///
-    /// The runner receives no root capability and no mutable pathname. Its
-    /// outcome may itself be a `Result`, preserving the caller's typed runtime
-    /// verdict without widening this infrastructure boundary.
-    pub fn execute_with<T, F>(&self, admitted: AdmittedExecution, runner: F) -> ExecutionVerdict<T>
-    where
-        F: for<'a> FnOnce(ExecutionContext<'a>) -> T,
-    {
+    /// Interface adapters keep their request state outside this boundary,
+    /// borrow the capability-free [`ExecutionContext`] through
+    /// [`ExecutionSession::context`], then return their typed result through
+    /// [`ExecutionSession::complete`]. The split makes the service's custody
+    /// claim precise: it supplies no filesystem capability or mutable
+    /// workflow pathname. It does not claim to sandbox trusted in-process
+    /// adapter code from ambient operating-system APIs.
+    #[must_use]
+    pub fn begin(&self, admitted: AdmittedExecution) -> ExecutionSession {
         let AdmittedExecution {
             execution_id,
             trace_id,
@@ -109,19 +113,13 @@ impl ExecutionService {
             check,
             skills,
         } = admitted;
-        let outcome = runner(ExecutionContext {
+        ExecutionSession {
             execution_id,
             trace_id,
-            snapshot: &snapshot,
-            workflow: &workflow,
-            check: &check,
-            skills: &skills,
-        });
-        ExecutionVerdict {
-            execution_id,
-            trace_id,
-            snapshot_digest: snapshot.digest().to_owned(),
-            outcome,
+            snapshot,
+            workflow,
+            check,
+            skills,
         }
     }
 
@@ -283,6 +281,58 @@ impl<'a> ExecutionContext<'a> {
     #[must_use]
     pub const fn skills(self) -> &'a ResolvedSkills {
         self.skills
+    }
+}
+
+/// Owned execution session held between admission and a typed verdict.
+///
+/// The session owns the immutable definition world. Interface-specific
+/// request state and effect capabilities deliberately remain outside it.
+#[non_exhaustive]
+pub struct ExecutionSession {
+    execution_id: ExecutionId,
+    trace_id: TraceId,
+    snapshot: ExecutionSnapshot,
+    workflow: RawWorkflow,
+    check: CheckReport,
+    skills: ResolvedSkills,
+}
+
+impl std::fmt::Debug for ExecutionSession {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ExecutionSession")
+            .field("execution_id", &self.execution_id)
+            .field("trace_id", &self.trace_id)
+            .field("snapshot_digest", &self.snapshot.digest())
+            .finish_non_exhaustive()
+    }
+}
+
+impl ExecutionSession {
+    /// Borrow the complete admitted definition world without a filesystem
+    /// capability, root path, or reader callback.
+    #[must_use]
+    pub const fn context(&self) -> ExecutionContext<'_> {
+        ExecutionContext {
+            execution_id: self.execution_id,
+            trace_id: self.trace_id,
+            snapshot: &self.snapshot,
+            workflow: &self.workflow,
+            check: &self.check,
+            skills: &self.skills,
+        }
+    }
+
+    /// Consume the session and bind one typed adapter result to its exact
+    /// execution, trace, and snapshot identities.
+    #[must_use]
+    pub fn complete<T>(self, outcome: T) -> ExecutionVerdict<T> {
+        ExecutionVerdict {
+            execution_id: self.execution_id,
+            trace_id: self.trace_id,
+            snapshot_digest: self.snapshot.digest().to_owned(),
+            outcome,
+        }
     }
 }
 
@@ -497,7 +547,7 @@ mod tests {
     }
 
     #[test]
-    fn execution_runner_captures_an_adapter_request_without_widening_context() {
+    fn execution_session_keeps_adapter_request_outside_the_context() {
         let workflow = b"nika: root\npermits:\n  tools: [\"nika:jq\"]\ntasks:\n  value:\n    invoke:\n      tool: nika:jq\n      args: { input: 1, expression: \".\" }\n";
         let source = CountingSource {
             reads: RefCell::new(Vec::new()),
@@ -514,15 +564,13 @@ mod tests {
         let execution_id = admitted.execution_id();
         let trace_id = admitted.trace_id();
         let digest = admitted.snapshot().digest().to_owned();
-        let captured_digest = digest.clone();
         let adapter_request = String::from("model=mock/echo;max_cost_usd=0");
-
-        let verdict = ExecutionService::default().execute_with(admitted, move |context| {
-            assert_eq!(context.execution_id(), execution_id);
-            assert_eq!(context.trace_id(), trace_id);
-            assert_eq!(context.snapshot().digest(), captured_digest);
-            adapter_request
-        });
+        let session = ExecutionService::default().begin(admitted);
+        let context = session.context();
+        assert_eq!(context.execution_id(), execution_id);
+        assert_eq!(context.trace_id(), trace_id);
+        assert_eq!(context.snapshot().digest(), digest);
+        let verdict = session.complete(adapter_request);
 
         assert_eq!(verdict.execution_id(), execution_id);
         assert_eq!(verdict.trace_id(), trace_id);

--- a/crates/nika-execution/src/snapshot.rs
+++ b/crates/nika-execution/src/snapshot.rs
@@ -200,6 +200,37 @@ impl ExecutionSnapshot {
         Self::capture_from(project, root, std::iter::empty::<&Path>(), limits)
     }
 
+    /// Capture a root already acquired by an interface, plus every dependency
+    /// from the held project directory.
+    ///
+    /// This is the stdin/adaptor admission seam: `root_bytes` become the root
+    /// unit without a temporary file or a second read, while children and
+    /// skills remain descriptor-relative to `project`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExecutionError`] under the same fail-closed conditions as
+    /// [`Self::capture`], including limits applied to the supplied root bytes.
+    pub fn capture_root_bytes(
+        project: &OwnedDir,
+        root: &Path,
+        root_bytes: &[u8],
+        limits: SnapshotLimits,
+    ) -> Result<Self, ExecutionError> {
+        let root = normalize_logical(root)?;
+        let source = CapturedRoot {
+            project,
+            logical_path: &root,
+            bytes: root_bytes,
+        };
+        Self::capture_from(
+            &source,
+            Path::new(&root),
+            std::iter::empty::<&Path>(),
+            limits,
+        )
+    }
+
     /// Capture the workflow closure plus caller-declared opaque imports.
     ///
     /// The current workflow grammar has no `import:` key. This explicit seam
@@ -311,6 +342,21 @@ impl ExecutionSnapshot {
 
 pub(crate) trait ByteSource {
     fn read(&self, logical_path: &str, limit: usize) -> Result<Vec<u8>, ExecutionError>;
+}
+
+struct CapturedRoot<'a> {
+    project: &'a OwnedDir,
+    logical_path: &'a str,
+    bytes: &'a [u8],
+}
+
+impl ByteSource for CapturedRoot<'_> {
+    fn read(&self, logical_path: &str, limit: usize) -> Result<Vec<u8>, ExecutionError> {
+        if logical_path == self.logical_path {
+            return Ok(self.bytes.to_vec());
+        }
+        ByteSource::read(self.project, logical_path, limit)
+    }
 }
 
 impl ByteSource for OwnedDir {

--- a/crates/nika-execution/src/tests.rs
+++ b/crates/nika-execution/src/tests.rs
@@ -436,6 +436,43 @@ fn debug_surfaces_do_not_disclose_captured_or_outcome_payloads() {
     assert_eq!(*verdict.outcome(), SECRET_SHAPED);
 }
 
+#[test]
+fn owned_root_bytes_capture_stdin_world_without_a_dash_file() {
+    let root = "nika: stdin\nmodel: mock/echo\npermits:\n  exec: [\"echo\"]\n  fs:\n    read: [\"skills/review/SKILL.md\"]\ntasks:\n  audit:\n    invoke:\n      workflow: \"child.nika.yaml\"\n      args: { url: \"https://example.com\" }\n    returns: { object: { report: string } }\n  review:\n    agent: { prompt: \"review\", skills: [\"skills/review/SKILL.md\"] }\n";
+    let skill = "---\nname: review\ndescription: Review code.\n---\nOriginal.\n";
+    let (tmp, owned) = project(&[
+        ("child.nika.yaml", CHILD),
+        ("skills/review/SKILL.md", skill),
+    ]);
+    let service = ExecutionService::default();
+    let admitted = service
+        .admit_root_bytes(&owned, Path::new("-"), root.as_bytes())
+        .expect("admit stdin world");
+
+    fs::write(tmp.path().join("child.nika.yaml"), b"nika: replaced\n").expect("mutate child");
+    fs::write(tmp.path().join("skills/review/SKILL.md"), b"replacement").expect("mutate skill");
+
+    assert!(!tmp.path().join("-").exists());
+    assert_eq!(admitted.snapshot().root(), "-");
+    assert_eq!(admitted.snapshot().text("-"), Some(root));
+    assert_eq!(admitted.snapshot().text("child.nika.yaml"), Some(CHILD));
+    assert_eq!(
+        admitted.snapshot().text("skills/review/SKILL.md"),
+        Some(skill)
+    );
+}
+
+#[test]
+fn owned_root_bytes_obey_the_same_size_ceiling() {
+    let (_tmp, owned) = project(&[]);
+    let limits = SnapshotLimits::new(8, 8, 16, 16_384);
+    let service = ExecutionService::new(limits);
+    let error = service
+        .admit_root_bytes(&owned, Path::new("-"), pure_root().as_bytes())
+        .expect_err("oversized stdin root");
+    assert!(matches!(error, ExecutionError::UnitSizeLimit { .. }));
+}
+
 fn snapshot_digest(cx: crate::ExecutionContext<'_>) -> String {
     assert_eq!(cx.snapshot().text("root.nika.yaml"), Some(pure_root()));
     cx.snapshot().digest().to_owned()

--- a/docs/adr/adr-118-nika-arm-custody-library.md
+++ b/docs/adr/adr-118-nika-arm-custody-library.md
@@ -6,7 +6,7 @@ date: "2026-08-21"
 phase: "pre-1.0 · ARM custody"
 deciders: ["@ThibautMelen"]
 tags: ["architecture", "crate-admission", "arm", "filesystem", "layering"]
-affects_crates: ["nika-arm", "nika-cadence", "nika-cli", "nika-fs"]
+affects_crates: ["nika-arm", "nika-cadence", "nika-cli", "nika-execution", "nika-fs"]
 affects_layers: ["L4"]
 supersedes: []
 superseded_by: []
@@ -16,12 +16,11 @@ enables: []
 amends: []
 fci: []
 inv: []
-shadow_zones: ["transitive-workflow-input-custody", "serve-network-boundary"]
+shadow_zones: ["serve-network-boundary"]
 nika_codes: []
 timeline: "pre-1.0"
 follow_ups:
-  - "move child-workflow and skill reads behind one shared owned-byte execution service"
-  - "keep networked Serve behind ADR-117 until that execution service and its security gates are admitted"
+  - "keep networked Serve behind ADR-117 until its separate security gates are admitted"
 ---
 
 # ADR-118: admit `nika-arm` as the shared ARM custody library
@@ -96,13 +95,18 @@ The extraction introduces no HTTP listener, authentication scheme, job API,
 cancellation contract, artifact authority, or runtime implementation. Those
 are separate decisions and remain outside this admission.
 
-### 4. Security carry is named, not hidden
+### 4. W04 amendment: transitive custody is closed
 
-This boundary pins the ARM registry, state, and primary workflow. It does not
-yet pin every transitive workflow input. The current composition adapter can
-still reopen child workflows and skill files by pathname. Closing that gap
-requires one shared owned-byte execution service used by every interface; it
-is a required follow-up and a prerequisite to ADR-117's first network route.
+W04 adds `nika-execution` as the shared owned-byte boundary used by CLI and
+ARM. The firer admits the primary workflow, every transitive child, and every
+skill through one held project capability before the claim. Runtime composition
+receives only the immutable snapshot; the production child runner has no path
+reader or optional compatibility world. Stdin joins the same boundary through
+an owned-root-byte overlay without a temporary file.
+
+This closes the transitive workflow-input shadow named by the original
+decision. It does not admit a network listener: ADR-117's authentication and
+transport gates remain separate.
 
 ## Consequences
 
@@ -119,8 +123,8 @@ is a required follow-up and a prerequisite to ADR-117's first network route.
 
 - `nika-arm` is an L4 library rather than a generally reusable low-level crate.
 - Interface tests must cover adapter parity in addition to the library suite.
-- Transitive child and skill custody remains an explicit security carry until
-  the shared execution service lands.
+- The execution service becomes a required dependency of both CLI and ARM;
+  changes to its admission contract require cross-interface proof.
 
 ### Neutral
 
@@ -139,6 +143,9 @@ is a required follow-up and a prerequisite to ADR-117's first network route.
 4. Mutation testing kills at least 90% of viable `nika-arm` mutants.
 5. The admission commit contains the crate spec, API snapshot, layer registry,
    estate update, and this ADR.
+6. W04 additionally proves file, stdin, and ARM use `ExecutionService`, child
+   recursion performs zero definition reads after capture, and ARM has no
+   subprocess/localhost/latest-trace bridge.
 
 ## Alternatives considered
 

--- a/docs/architecture/crate-layer-registry.md
+++ b/docs/architecture/crate-layer-registry.md
@@ -133,6 +133,7 @@ Given a crate `nika-<role>`, ask these questions in order:
               ▲
 ╭─ L3  (runtime + policy + sandbox) ────────────────────────────────────────╮
 │ nika-runtime          nika-execution       nika-shield                    │
+│                       owned world ↑ file · stdin · ARM                    │
 │ nika-wasm-host (v0.100)                    nika-sandbox   (v0.100)        │
 ╰──────────────────────────────────────────────────────────────────────────╯
               ▲
@@ -167,7 +168,7 @@ flags. They obey the same 12-gate admission as any other crate.
 | L1 | Effect implementations — async, per-crate capability axis | declared axes only (fs/net/exec/env · +computer-use axes from M2) | L0, L0.5 | `nika-clock`, `nika-fs`, `nika-http`, `nika-blob`, `nika-exec-runner`, `nika-screen`, `nika-ocr`, `nika-a11y`, `nika-input`, `nika-browser` (ADR-081 guards), `nika-bm25` ✅, `nika-store` (F-P8 signed memory · SMSR) + the Connectome satellites (`nika-hnsw`, `nika-rrf`, `nika-rerank`, …), `nika-git`, `nika-keys-*`, `nika-pck-registry`, `nika-pck-store`, `nika-catalog-sync` |
 | L1.5 | Provider wire adapters — between effects and verbs | via L1 http seam | L0, L0.5, L1 | `nika-providers` (14/14 wire · in-crate mock), `nika-infer-local` (candle sidecar · ADR-091) |
 | L2 | Verbs + domain services — orchestrates L1 impls behind kernel traits | via L1 traits only | L0, L0.5, L1, L1.5 | `nika-pck`, `nika-verb-*`, `nika-policy` (s8 · design locked), `nika-connectome` (the Connectome orchestrator), `nika-observability`, `nika-builtin-{github,cloud,workspace}`, `nika-registry-client` (size-cap descent from nika-cli · D-2026-07-09-N1) |
-| L3 | Runtime + policy + sandbox — enforces execution contracts | via L2 | L0..L2 | `nika-runtime`, `nika-execution` (descriptor-rooted immutable-world admission), `nika-shield`, `nika-wasm-host` (v0.100), `nika-sandbox` (v0.100) |
+| L3 | Runtime + policy + sandbox — enforces execution contracts | via L2 | L0..L2 | `nika-runtime`, `nika-execution` (descriptor-rooted immutable-world admission; owned-root overlay for stdin/adapters), `nika-shield`, `nika-wasm-host` (v0.100), `nika-sandbox` (v0.100) |
 | L4 | Interfaces — transport/UI surface, libraries only | via L3 | L0..L3 | `nika-cli`, `nika-arm` (descriptor-rooted ARM custody + the one injected firer shared by CLI and Serve), `nika-cli-host` (size-cap member of the nika-cli unit · D-2026-07-09-N1 · ADR-110), `nika-trace` (size-cap member of the nika-cli unit · the flight-recorder reader · D-2026-07-09-N1 · 2026-08-11), `nika-dap`, `nika-display`, `nika-onboard`, `nika-models`, `nika-daemon`, `nika-serve`, `nika-mcp`, `nika-lsp`, `nika-sdk`, `nika-catalog-verify`, `nika-check-wasm` (WIP · ADR-107) |
 | L5 | The binary — sole `[[bin]]` composition root | via L4 | L0..L4 | `nika` (<500 LOC) |
 

--- a/docs/architecture/execution-service-reader-census-2026-08-22.md
+++ b/docs/architecture/execution-service-reader-census-2026-08-22.md
@@ -43,3 +43,9 @@ Measured structural facts:
 The reader count after `ExecutionSnapshot` capture is therefore exactly zero
 for workflow definitions. Counted-source tests guard admission and execution;
 CLI structural tests guard the adapter and child-runner shape.
+
+This is not an OS-sandbox claim about arbitrary injected Rust. CLI and ARM
+retain explicit effect/output capabilities outside `ExecutionSession`; the
+claim measured here is narrower and falsifiable: neither production adapter
+uses those capabilities to reopen a workflow, child, or skill definition after
+admission.

--- a/docs/architecture/execution-service-reader-census-2026-08-22.md
+++ b/docs/architecture/execution-service-reader-census-2026-08-22.md
@@ -1,0 +1,45 @@
+# Execution-service reader census · 2026-08-22
+
+Scope: W04's production `nika run` and ARM execution paths. This census names
+workflow-definition readers; it does not classify trace replay, ARM ledger
+replay, output writes, or static verbs such as `nika check` as execution-world
+readers.
+
+```text
+file root ── OwnedDir ───────────────┐
+stdin root ─ owned bytes ─┐          │
+                          ▼          ▼
+                  ExecutionSnapshot capture
+                  root · children · skills
+                             │
+                             ▼
+                     ExecutionService admit
+                             │
+                 ┌───────────┴───────────┐
+                 ▼                       ▼
+              CLI run                 ARM fire
+                 └── immutable context ──┘
+```
+
+| Phase | Root bytes | Child/skill bytes | Authority after return |
+|---|---|---|---|
+| CLI preview and diagnostics | `RunSource::capture` reads a file or stdin once | the existing static diagnostic reader may inspect composition before admission | none; this is the pre-effect parity gate |
+| File/ARM admission | `ExecutionSnapshot::capture` reads through held `OwnedDir` | same held `OwnedDir`, eagerly and transitively | immutable `ExecutionSnapshot` only |
+| Stdin admission | `ExecutionSnapshot::capture_root_bytes` consumes the acquired root bytes | held current-project `OwnedDir`, eagerly and transitively | immutable `ExecutionSnapshot` only |
+| Runtime, pause continuation, child recursion | snapshot text | snapshot text | no filesystem reader callback or mutable pathname |
+
+Measured structural facts:
+
+- `nika-cli` and `nika-arm` depend on `nika-execution`; neither
+  `nika-execution` nor `nika-arm` depends on `nika-cli`.
+- `ProdChildRunner` contains no optional snapshot, `read_to_string`, legacy
+  constructor, filesystem closure-digest walker, or path resolver.
+- runtime composition requires `&AdmittedWorld`; a `world: None` lane is not
+  representable.
+- ARM execution contains no subprocess command, localhost bridge, or directory
+  scan for a latest trace. The service-issued execution/trace identity crosses
+  claim, run, receipt, and replay directly.
+
+The reader count after `ExecutionSnapshot` capture is therefore exactly zero
+for workflow definitions. Counted-source tests guard admission and execution;
+CLI structural tests guard the adapter and child-runner shape.

--- a/docs/crate-specs/nika-arm.md
+++ b/docs/crate-specs/nika-arm.md
@@ -11,7 +11,7 @@
 | Crate version | tracks workspace |
 | License | `AGPL-3.0-or-later` |
 | Publish | `false` — engine-internal interface library |
-| Dependencies | `nika-cadence` (pure schedule/ledger authority) · `nika-fs` (`OwnedDir`) · `jiff` · `nix` · `serde_json`; dev: `tempfile`, `sha2`. |
+| Dependencies | `nika-cadence` (pure schedule/ledger authority) · `nika-execution` (shared owned-byte admission/execution service) · `nika-fs` (`OwnedDir`) · `jiff` · `nix` · `serde_json`; dev: `tempfile`, `sha2`. |
 | NIKA codes | none allocated — failures are typed I/O results or the existing ARM process exit contract rendered by the calling interface. |
 
 ---
@@ -33,9 +33,10 @@ repair, source pinning, receipt fencing, or trace attribution.
 This split closes two previously measured faults: firing a captured workflow
 under a temporary pathname rebased its relative children and skills, while
 finding the newest trace by directory scan could attribute a concurrent run's
-trace. The shared transaction now carries exact captured UTF-8 bytes under the
-declared logical workflow path and accepts the typed trace returned by the
-injected executor.
+trace. The shared transaction now admits the complete descriptor-rooted workflow
+world once through `ExecutionService`, executes that immutable snapshot under
+the declared logical path, and accepts the exact trace identity returned by the
+same in-process service.
 
 ## 2. Public surface
 
@@ -52,9 +53,11 @@ injected executor.
 - `fire_beat(&FireCtx) -> FireVerdict` performs lock → re-read → decide → claim
   → injected run → fenced receipt → release. `FireVerdict::into_parts` is the
   interface projection.
-- `RunShot` exposes the held project capability, display root, declared workflow
-  path, exact captured source, generation, and spend ceiling through accessors.
-  `RunUpshot::new` returns the process exit and an escaped one-line trace.
+- `RunShot` exposes request metadata: the held project capability, display root,
+  declared workflow path, generation, and spend ceiling. `RunSeam` receives the
+  service-issued `ExecutionContext` beside that request, so it reads the complete
+  immutable snapshot and its direct execution/trace identity rather than reopening
+  workflow inputs. `RunUpshot::new` returns the process exit and escaped trace path.
 - `HealOutcome`, `Rotation`, and `Folded` expose read-only accessors; public
   structs are non-exhaustive and carry no constructible public fields.
 
@@ -69,19 +72,22 @@ that surface is absent from normal builds and the committed public API snapshot.
 ## 3. Determinism and durability laws
 
 1. Time, wait, process id, and execution are injected at the interface edge.
-2. The workflow generation binds the validated beat and exact captured primary
-   workflow bytes. The transaction carries the same held project descriptor to
-   the injected executor, even if its visible pathname is replaced after
-   context construction.
-3. A claim is durable before execution. Its receipt copies slot, generation,
-   and fencing authority; a crash leaves an explicit unsettled claim.
+2. Before the claim, `ExecutionService::admit` captures the descriptor-rooted
+   primary workflow, transitive child workflows, and skill files once. The
+   generation binds the validated beat and admitted root bytes; later mutations
+   cannot change the execution world.
+3. The service allocates `ExecutionId` before the claim. The durable claim and
+   terminal receipt carry the same `exe-<uuid>` plus its direct 32-hex trace ID,
+   along with slot, generation, and fencing authority; a crash leaves that exact
+   association on the unsettled claim for replay.
 4. The beat lease spans the entire decision and run. A queued wait always
    re-reads and re-decides after sleeping.
 5. Replay validates the full archive/live snapshot and durable head before any
    projection or append. A cache never overrides the chain.
 6. Rotation is first-event-only and commits the ordered archive bundle.
-7. The execution seam returns its exact trace path; directory scans are not an
-   attribution authority.
+7. The execution seam returns its exact trace path from the same typed context;
+   directory scans are not an attribution authority. ARM neither shells to the
+   CLI nor calls a localhost HTTP adapter.
 
 ## 4. Tests and parity
 
@@ -138,14 +144,16 @@ general cancellation · no artifact authority · no resume · no exactly-once
 claim. Those contracts belong respectively to `nika-cadence`, the shared L3
 execution service, and the separately threat-modeled Serve boundary.
 
-## 7. Named security carry
+## 7. W04 security carry
 
-This admission pins the ARM registry, state, and primary workflow beneath one
-held project capability. It does **not** claim transitive workflow-input
-custody: the current `nika-cli` composition adapter still reopens child
-workflows and skill files by pathname in `verbs/run/child_runner.rs` and
-`verbs/mod.rs`. A child or skill symlink can therefore leave the held project,
-and a replacement between digest/check and execution can select different
-bytes. That cross-interface execution-service repair is deliberately excluded
-from this behavior-preserving crate extraction and is the first P0 wave in
-the studio's private cybersecurity follow-up plan.
+W04.B closes transitive ARM custody: the registry, primary workflow, child
+workflows, and skill files are captured through one held project capability and
+the ARM adapter executes only the admitted `ExecutionContext`. Mutation after
+the durable claim, including a child or skill pathname swap, cannot change the
+bytes executed. The claim-to-receipt execution identity is replay-verifiable.
+
+W04.C remains the explicit broader-extinction pass: delete any compatibility
+composition or reopen path that is no longer reached by another interface,
+prove the stdin compatibility lane independently, refresh corpus diagrams, and
+run the full cross-interface refutation. It must not weaken resident Serve's
+once/dry/reload/signal semantics.

--- a/docs/crate-specs/nika-arm.md
+++ b/docs/crate-specs/nika-arm.md
@@ -5,8 +5,8 @@
 | Status | **ADMISSION CANDIDATE** — extracted from the proven ARM custody code in `nika-cli`; named-beat tick policy lives in `nika-cadence`; behavior remains guarded by the `nika-arm` library suite plus the real CLI `arm_fire` and Serve tests. |
 | Layer | L4 — interface-shared custody library |
 | Design | Descriptor-rooted `.nika/arm/` state, verified replay/rotation, kernel leases, and the one injected firing transaction. Interfaces inject execution and waiting; they never reinterpret the ledger or discover a trace globally. |
-| LOC budget | ≤5,000 source lines for this custody unit; ≤15,000 hard crate cap. Admission measurement: 4,999 lines including inline tests. |
-| File cap | ≤1,500 lines; admission maximum 1,409 in `fire.rs`. |
+| LOC budget | ≤5,000 source lines for this custody unit; ≤15,000 hard crate cap. W04 measurement: 4,732 lines including inline tests. |
+| File cap | ≤1,500 lines; W04 maximum 1,263 in `state/tests.rs`. |
 | Function cap | ≤100 lines. |
 | Crate version | tracks workspace |
 | License | `AGPL-3.0-or-later` |
@@ -91,8 +91,7 @@ that surface is absent from normal builds and the committed public API snapshot.
 
 ## 4. Tests and parity
 
-The 65 inline library tests moved with their production owners, then 24
-admission regressions closed the measured mutation and review gaps. Together they cover kernel
+The 81 targeted library tests observed after W04.B cover kernel
 lease overlap/release, descriptor and symlink refusals, source replacement,
 captured relative bases, claim-before-run ordering, fencing, orphan settlement,
 tamper/reorder/truncation refusal, archive commitment, crash-window migration,
@@ -144,7 +143,7 @@ general cancellation · no artifact authority · no resume · no exactly-once
 claim. Those contracts belong respectively to `nika-cadence`, the shared L3
 execution service, and the separately threat-modeled Serve boundary.
 
-## 7. W04 security carry
+## 7. W04 migration closure
 
 W04.B closes transitive ARM custody: the registry, primary workflow, child
 workflows, and skill files are captured through one held project capability and
@@ -152,8 +151,10 @@ the ARM adapter executes only the admitted `ExecutionContext`. Mutation after
 the durable claim, including a child or skill pathname swap, cannot change the
 bytes executed. The claim-to-receipt execution identity is replay-verifiable.
 
-W04.C remains the explicit broader-extinction pass: delete any compatibility
-composition or reopen path that is no longer reached by another interface,
-prove the stdin compatibility lane independently, refresh corpus diagrams, and
-run the full cross-interface refutation. It must not weaken resident Serve's
-once/dry/reload/signal semantics.
+W04.C removes the broader compatibility composition path: the production child
+runner has one snapshot constructor, no pathname reader, and no optional world.
+CLI stdin enters `ExecutionService` through owned root bytes, so file, stdin, and
+ARM execution share the same admitted closure. Structural ratchets keep ARM free
+of CLI dependency, subprocess/localhost bridging, and latest-trace discovery.
+Resident Serve's once/dry/reload/signal behavior remains owned by its existing
+adapter and is not changed by this extinction pass.

--- a/docs/crate-specs/nika-cadence.md
+++ b/docs/crate-specs/nika-cadence.md
@@ -6,7 +6,7 @@
 | Layer | L0 — pure, zero I/O, zero async |
 | Design | The arming-registry grammar (the `arm:` block of `nika.yaml`, D-2026-08-10-N3) + the pure next-slot calculator + the W7 typed firing and ledger machines + the named-beat tick classifier (`tick_decision` · `TickDecision` · `v0_unsupported`). Hand-counted 5-field cron (zero cron library — the count is validated BEFORE field semantics, scar #6) · IANA zones resolved from the EMBEDDED tzdb only (`jiff-tzdb`, never the host's zoneinfo) · two cadence forms (cron + readable `lundi 9h07`), display normalizing to the readable one. The machines own no I/O and read no clock: callers inject events, policy, `now`, and borrowed journal text; the L4 adapter alone owns files, locks, fsync, and rotation. |
 | LOC budget | ≤5,000 src prod (W7 measured 4,623 after the complete pure ledger/snapshot seam) · ≤15,000 hard cap |
-| File cap | ≤1,500 LOC each (W7 max 1,493 in `ledger.rs`; `firing.rs` 1,372) |
+| File cap | ≤1,500 LOC each (`ledger.rs` remains below 1,500 after W04 identity wiring; execution-link and projection codecs are split into focused submodules; `firing.rs` 1,372) |
 | Function cap | ≤100 lines each (max ~60) |
 | Crate version | tracks workspace |
 | License | `AGPL-3.0-or-later` |
@@ -134,10 +134,11 @@ returns typed ordered effects under an injected `FiringPolicy` and
 `Timestamp`. Every public enum/struct is forward-compatible; the three
 identities validate their wire form before construction.
 
-**W7 — the pure ledger (`ledger` module)**: `DecisionKind`, `Claim`, typed
-`Receipt`, `HistoryEntry`, `Unsettled`, and `LastRecord` are the wire
-vocabulary. A `Receipt` copies slot identity and generation from its claim,
-carries the exact fencing token, and derives terminal kind from exit (`0`
+**W7/W04 — the pure ledger (`ledger` module)**: `DecisionKind`, `Claim`, typed
+`Receipt`, `HistoryEntry`, `Unsettled`, `LastRecord`, and `ExecutionLink` are the
+wire vocabulary. `ExecutionLink` accepts only a direct `exe-<uuid>` / 32-lower-hex
+trace pair. A `Receipt` copies slot identity, generation, and execution link from
+its claim, carries the exact fencing token, and derives terminal kind from exit (`0`
 fired, `4` paused, every other accepted code failed). Modern bare, mismatched,
 duplicate, future, or contradictory receipts make the chain invalid; only an
 explicitly marked legacy bare receipt remains readable;
@@ -196,12 +197,13 @@ an independently encoded transition table. Mutation floor: run
 `check-mutation-floor.sh` at admission and again for every new semantic
 module.
 
-**W7 ledger tests** additionally pin canonical-line verification, one-byte
+**W7/W04 ledger tests** additionally pin canonical-line verification, one-byte
 tamper refusal, verified-prefix truncation, claim/receipt lifecycle folding,
 orphan deadline equality vs strictly-after ambiguity, legacy replay,
-byte-stable projection round-trip, and tallies. The CLI adapter suite keeps the
-filesystem E2E matrix (delete/rebuild, tamper, reorder, truncation, migration,
-idempotence, and audible refusal).
+byte-stable projection round-trip, direct execution/trace identity, forged or
+one-sided identity refusal, replay preservation, and tallies. The CLI adapter
+suite keeps the filesystem E2E matrix (delete/rebuild, tamper, reorder,
+truncation, migration, idempotence, and audible refusal).
 
 ## 5. Non-goals / guards
 

--- a/docs/crate-specs/nika-cli.md
+++ b/docs/crate-specs/nika-cli.md
@@ -21,9 +21,10 @@ request from flags, acquires the project through `OwnedDir`, admits one
 transitive `ExecutionSnapshot`, then captures that request in the service's
 one-shot runner. Runtime composition consumes the admitted workflow, check,
 skills, child bytes, and child-closure digests; rendering and exit-code mapping
-remain here. The stdin and ARM-captured-source lanes keep their prior adapter
-until their dedicated migration carriers can supply an owned-byte world without
-writing a temporary file.
+remain here. File runs, stdin, and the ARM in-process adapter all converge on
+this service. Stdin supplies its already acquired root bytes through
+`admit_root_bytes`; dependencies still resolve from the held current project,
+without a temporary file or a world-less compatibility path.
 
 ## 2. Verb surface
 
@@ -71,11 +72,11 @@ ordered bundle before consuming it; changed archive history fails closed.
 Every sidecar component and child file is opened no-follow relative to a held
 directory descriptor. Live-history, archive, beat-directory, and lock symlinks
 refuse; a visible path replacement after the claim cannot redirect its receipt.
-Before claiming, the firer captures the workflow bytes once in memory and hashes
-that immutable source. Check and execution consume those same bytes while the
-declared workflow path remains their logical base for relative children and
-skills. An unreadable or symlink source refuses before any claim; later edits
-cannot make execution and the attested generation disagree. Receipt construction
+Before claiming, the firer admits the complete workflow, child, and skill world
+once and hashes the immutable root source. Check and execution consume that same
+snapshot while the declared workflow path remains the logical base for relative
+children and skills. An unreadable or symlink source refuses before any claim;
+later edits cannot make execution and the attested generation disagree. Receipt construction
 is typed and claim-bound, and a corrupt replay is an ENV refusal in reports and
 `serve`, never `DÉCLARÉ`/never-fired fallback.
 

--- a/docs/crate-specs/nika-cli.md
+++ b/docs/crate-specs/nika-cli.md
@@ -16,6 +16,15 @@ The human surface of the engine. One binary, self-contained (spec + examples
 for everything below: **the animation IS the data** (semantic rendering,
 chrome ≤30%, zero decorative noise). And the human always keeps the hand.
 
+`nika run <file>` is an adapter over `nika-execution`: it builds a private CLI
+request from flags, acquires the project through `OwnedDir`, admits one
+transitive `ExecutionSnapshot`, then captures that request in the service's
+one-shot runner. Runtime composition consumes the admitted workflow, check,
+skills, child bytes, and child-closure digests; rendering and exit-code mapping
+remain here. The stdin and ARM-captured-source lanes keep their prior adapter
+until their dedicated migration carriers can supply an owned-byte world without
+writing a temporary file.
+
 ## 2. Verb surface
 
 ### 1.0 launch floor (locked · D-2026-06-10-N6 · amended D-2026-06-20-N1 — was "v0.81")

--- a/docs/crate-specs/nika-execution.md
+++ b/docs/crate-specs/nika-execution.md
@@ -30,6 +30,12 @@ value and gives the injected runner an `ExecutionContext` containing no
 admission is therefore absent by construction and guarded by a counted-reader
 test.
 
+The injected runner is a one-shot closure so an interface adapter may capture
+its private request (CLI flags, transport metadata, or an ARM claim) without a
+global or thread-local side channel. Those adapter fields stay outside
+`ExecutionContext`: the context remains capability-free and exposes only the
+admitted IDs, snapshot, workflow, check report, and resolved skills.
+
 This crate does not own HTTP, UI rendering, durable jobs, ARM cadence, provider
 selection, sandbox implementation, runtime verb semantics, or trace storage.
 Those remain in their existing layers and will consume this service through

--- a/docs/crate-specs/nika-execution.md
+++ b/docs/crate-specs/nika-execution.md
@@ -2,7 +2,7 @@
 
 | | |
 |---|---|
-| Status | **WORKSPACE WIP · ADMISSION CANDIDATE** — the C0/C1 owned-byte carrier is callable and reviewed, but remains in the canonical `wip` set until the full admission ceremony closes. CLI and ARM migration are later consumer waves. |
+| Status | **WORKSPACE WIP · ADMISSION CANDIDATE** — the owned-byte carrier is callable and both CLI and ARM use it; the crate remains in the canonical `wip` set until the full admission ceremony closes. |
 | Layer | L3 — execution admission and orchestration boundary |
 | Design | Descriptor-rooted transitive capture into one immutable snapshot; parser, checker, skill resolver, and injected runner all consume that same owned world. |
 | LOC budget | ≤5,000 source lines; ≤15,000 hard crate cap. |
@@ -23,7 +23,10 @@ Skills, and explicitly declared project imports descriptor-relatively with
 `ExecutionSnapshot` owns every byte, logical path, unit digest, aggregate
 digest, and format version.
 
-`ExecutionService::admit` parses and checks only snapshot text. Skill resolution
+`ExecutionService::admit` parses and checks only snapshot text. For an
+interface-acquired root such as stdin, `admit_root_bytes` places those exact
+bytes in the same world while dependencies remain descriptor-relative to the
+held project. Skill resolution
 uses the same in-memory map. `ExecutionService::execute` consumes the admitted
 value and gives the injected runner an `ExecutionContext` containing no
 `OwnedDir`, absolute path, or reader callback. Filesystem reopening after
@@ -38,19 +41,21 @@ admitted IDs, snapshot, workflow, check report, and resolved skills.
 
 This crate does not own HTTP, UI rendering, durable jobs, ARM cadence, provider
 selection, sandbox implementation, runtime verb semantics, or trace storage.
-Those remain in their existing layers and will consume this service through
-later adapters.
+Those remain in their existing layers. CLI and ARM consume this service through
+their L4 adapters; later Serve/jobs work must use the same boundary.
 
 ## 2. Public surface
 
 - `SnapshotLimits` bounds child depth, unit count, per-unit bytes, and aggregate
   bytes before admission.
 - `ExecutionSnapshot::capture` owns the workflow/child/skill closure.
+  `capture_root_bytes` overlays interface-owned root bytes on the same held
+  project reader without a temporary file or a second root read.
   `capture_with_imports` adds opaque project-level imports without inventing an
   `import:` workflow key; the current language grammar has no such field.
 - `CapturedUnit` exposes kind, contained logical path, exact bytes, UTF-8 view,
   and SHA-256 digest through read-only accessors.
-- `ExecutionService::admit` mints one `ExecutionId`, derives its root `TraceId`
+- `ExecutionService::admit` and `admit_root_bytes` mint one `ExecutionId`, derive its root `TraceId`
   directly from the same 128 bits, and returns `AdmittedExecution` only after
   parser, composed checker, and skill resolution are clean.
 - `ExecutionService::execute` consumes that admission and returns a generic
@@ -97,6 +102,8 @@ Inline `--lib` tests cover:
   capture boundary;
 - deletion of the admitted root before execution, proving the runner still
   observes the exact admitted bytes;
+- stdin-style root bytes with transitive child/skill capture and the same
+  per-unit size ceiling, without creating a `-` file;
 - property tests for digest order independence and dot-segment normalization.
 
 The tests use no sleeps and inspect the bytes presented to the runner, not only
@@ -157,14 +164,14 @@ the workspace metadata keeps this crate WIP.
 | 6 PROPERTY | `snapshot::tests` exercises digest ordering and path normalization with `proptest` |
 | 7 BENCHMARKS | exempt: admission is bounded, one-shot filesystem I/O; no throughput contract or hot loop |
 | 8 DOCS | `RUSTDOCFLAGS='-D warnings' cargo doc -p nika-execution --no-deps` |
-| 9 CANARY E2E | exempt in C0/C1: no interface consumer is changed in this carrier; migration owns its real-binary canary |
+| 9 CANARY E2E | CLI and ARM adapters own their behavior canaries; the service suite proves root-byte and descriptor-rooted admission |
 | 10 PARITY | exempt: no predecessor service exists; existing CLI behavior remains untouched |
 | 11 REVIEW | independent architecture, security, and adversarial review findings resolved before commit |
 | 12 ATOMIC | one lowercase commit with the Nika co-author trailer |
 
 ## 6. Non-goals and next consumers
 
-No CLI/ARM migration · no Serve route · no durable job/event store · no
+No Serve route · no durable job/event store · no
 cancellation state machine · no registry fetch · no artifact custody · no
 runtime provider/sandbox construction. Those surfaces can only consume the
 admitted snapshot; they may not recreate a parallel composition reader.

--- a/docs/crate-specs/nika-execution.md
+++ b/docs/crate-specs/nika-execution.md
@@ -27,17 +27,19 @@ digest, and format version.
 interface-acquired root such as stdin, `admit_root_bytes` places those exact
 bytes in the same world while dependencies remain descriptor-relative to the
 held project. Skill resolution
-uses the same in-memory map. `ExecutionService::execute` consumes the admitted
-value and gives the injected runner an `ExecutionContext` containing no
-`OwnedDir`, absolute path, or reader callback. Filesystem reopening after
-admission is therefore absent by construction and guarded by a counted-reader
-test.
+uses the same in-memory map. `ExecutionService::begin` consumes the admitted
+value and returns an `ExecutionSession`. Its borrowed `ExecutionContext`
+contains no `OwnedDir`, absolute path, or reader callback. Interface adapters
+keep their private request and effect capabilities outside that session, then
+bind the typed outcome with `ExecutionSession::complete`.
 
-The injected runner is a one-shot closure so an interface adapter may capture
-its private request (CLI flags, transport metadata, or an ARM claim) without a
-global or thread-local side channel. Those adapter fields stay outside
-`ExecutionContext`: the context remains capability-free and exposes only the
-admitted IDs, snapshot, workflow, check report, and resolved skills.
+This is an execution-definition custody boundary, not an in-process operating
+system sandbox. The service supplies no mutable workflow locator after
+admission; trusted adapters can still use ambient APIs or their explicit effect
+capabilities. The permanent reader census and adapter tests therefore prove
+the production CLI/ARM paths consume workflow, child, and skill definitions
+only from the snapshot rather than claiming arbitrary Rust code cannot open a
+file.
 
 This crate does not own HTTP, UI rendering, durable jobs, ARM cadence, provider
 selection, sandbox implementation, runtime verb semantics, or trace storage.
@@ -58,9 +60,12 @@ their L4 adapters; later Serve/jobs work must use the same boundary.
 - `ExecutionService::admit` and `admit_root_bytes` mint one `ExecutionId`, derive its root `TraceId`
   directly from the same 128 bits, and returns `AdmittedExecution` only after
   parser, composed checker, and skill resolution are clean.
-- `ExecutionService::execute` consumes that admission and returns a generic
-  `ExecutionVerdict<T>` carrying execution ID, trace ID, snapshot digest, and
-  the injected runner's typed outcome.
+- `ExecutionService::begin` consumes that admission and returns an owned
+  `ExecutionSession`; `context` borrows the admitted definition world and
+  `complete` returns a generic `ExecutionVerdict<T>` carrying execution ID,
+  trace ID, snapshot digest, and the adapter's typed outcome.
+- `ExecutionService::execute` remains the function-pointer convenience surface
+  for adapters that need no request state.
 
 All public structs and enums are non-exhaustive. Response fields remain private
 behind constructors or accessors.


### PR DESCRIPTION
## What & why

Route `nika run` and ARM firings through the same owned-byte `ExecutionService`. CLI keeps rendering and exit mapping; ARM keeps claim/receipt custody while carrying the exact execution and trace identities into the journal. The migration removes the parallel composition paths and executes admitted child/skill bytes without reopening mutable sources.

Base: `435f5ddc125b782ac232a616696e79ea3cc85bb6` (W02 squash)

Rebuilt carriers, in order:

1. `daefba6ea294fa0cc3dadec2e9359ecd840405bf`
2. `56d1178ab98bd7b6dffaef14a956afb268fab77c`
3. `64c32498db91bf66e766efc120a802b96bf4c045`
4. `c66524db6f607db0d51eab496664d1372ad7d514`
5. `6cf15aa5842fd6776daa044253e87c117bbc7782`
6. `11f2bcdfcddbadb9166beccb75b20f85896e8d18`
7. `d6a0e5a75d3fd9deb37c8616b8758c40039ed51a`
8. `22c0bf9e51b3f7747e217419c1aff41958499e3b`

## Proofs

- `cargo fmt --all --check`
- `cargo test -p nika-execution --lib` — 22 passed
- `cargo test -p nika-arm --lib` — 83 passed
- `cargo test -p nika-cli --lib` — 305 passed
- `cargo clippy -p nika-execution -p nika-arm -p nika-cli -p nika-cadence -p nika-dap --all-targets -- -D warnings`
- ARM denial / identity / admitted-byte journeys — 3 passed
- Serve once/dry no-mutation journeys — 2 passed
- post-admission reader-extinction ratchets — 2 passed
- public API surface deletions — 0
- public API coverage — 67/67 admitted library crates
- `git diff --check`
- function-length ratchet — all functions ≤ 100 lines

The ARM suite covers filesystem refusal before claim/run, claim → receipt execution identity, and child/skill execution from admitted bytes after source mutation. The integration journeys prove exact claim → receipt → physical journal identity, forbidden-effect refusal without side effects, and dry-run with no state/trace mutation. A final custody ratchet replaces the capability-capturing runner seam with an owned execution session and proves invalid dry-run overrides never reopen the mutable workflow root.

## Exact limits

This is W04 only: in-process CLI and ARM adapters plus extinction of their old composition paths. It adds no HTTP listener, durable remote-job API, SSE transport, cancellation/artifact custody, OpenAPI/SDK surface, or VPS operations; those remain later waves.

## Checklist

- [x] Conventional commits with `Signed-off-by` and `Co-Authored-By: Nika 🦋 <nika@supernovae.studio>`
- [x] Scoped Rust tests and clippy green for every touched crate
- [x] `cargo fmt --all --check` clean
- [x] Public API locks additive; no deletion
- [x] No crate admission in this PR
