### PR TITLE
fix(arm): re-emit launchd keeps the env wrapper

### DIFF
--- a/crates/nika-cadence/public-api.txt
+++ b/crates/nika-cadence/public-api.txt
@@ -387,6 +387,7 @@ impl<T> typenum::type_operators::Same for nika_cadence::emit::Unit
 pub type nika_cadence::emit::Unit::Output = T
 pub const nika_cadence::emit::GENERATED_MARK: &str
 pub const nika_cadence::emit::MAX_INTERVALS: usize
+pub fn nika_cadence::emit::env_file_named_in_unit(body: &str) -> core::option::Option<alloc::string::String>
 pub fn nika_cadence::emit::labels(reg: &nika_cadence::registry::ArmRegistry) -> alloc::vec::Vec<alloc::string::String>
 pub fn nika_cadence::emit::render(reg: &nika_cadence::registry::ArmRegistry, ctx: &nika_cadence::emit::EmitCtx, target: nika_cadence::emit::Target, mode: nika_cadence::emit::Mode) -> core::result::Result<alloc::vec::Vec<nika_cadence::emit::Unit>, nika_cadence::emit::EmitRefusal>
 pub mod nika_cadence::error

--- a/crates/nika-cadence/src/emit.rs
+++ b/crates/nika-cadence/src/emit.rs
@@ -293,6 +293,80 @@ pub fn render(
     Ok(units)
 }
 
+/// The env-file path a unit names, if it sources one (D7).
+///
+/// Launchd carries `. '<path>' && exec …` (XML-escaped in the plist);
+/// systemd carries `EnvironmentFile=`. The VALUES never appear — only
+/// the path. `None` is the short argv (`nika arm fire <label>`), the
+/// form that silently strips provider keys if it replaces a wrapped
+/// unit.
+#[must_use]
+pub fn env_file_named_in_unit(body: &str) -> Option<String> {
+    let text = xml_unescape(body);
+    if let Some(path) = launchd_sourced_env(&text) {
+        return Some(path);
+    }
+    systemd_sourced_env(&text)
+}
+
+/// `. '<path>' && exec …` — the launchd wrap. Scans every `. ` so a
+/// `WorkingDirectory` that happens to contain that pair cannot steal the
+/// match: only a POSIX-quoted path followed by ` && exec ` counts.
+fn launchd_sourced_env(text: &str) -> Option<String> {
+    let mut search = text;
+    while let Some(at) = search.find(". ") {
+        let rest = search.get(at + 2..)?;
+        if let Some((path, after)) = split_sh_quoted(rest)
+            && after.starts_with(" && exec ")
+            && !path.is_empty()
+        {
+            return Some(path);
+        }
+        search = rest;
+    }
+    None
+}
+
+/// `EnvironmentFile=` on the service — systemd's native D7 form.
+fn systemd_sourced_env(text: &str) -> Option<String> {
+    for line in text.lines() {
+        let Some(path) = line.strip_prefix("EnvironmentFile=") else {
+            continue;
+        };
+        let path = path.trim().replace("%%", "%");
+        if !path.is_empty() {
+            return Some(path);
+        }
+    }
+    None
+}
+
+/// Inverse of POSIX single-quoting for a prefix: `'…'` with `'\''` inside.
+fn split_sh_quoted(text: &str) -> Option<(String, &str)> {
+    let mut rest = text.strip_prefix('\'')?;
+    let mut out = String::new();
+    loop {
+        let i = rest.find('\'')?;
+        out.push_str(&rest[..i]);
+        rest = rest.get(i + 1..)?;
+        if let Some(after) = rest.strip_prefix("\\''") {
+            out.push('\'');
+            rest = after;
+            continue;
+        }
+        return Some((out, rest));
+    }
+}
+
+/// Inverse of the five XML escapes (`&amp;` last — it introduces the rest).
+fn xml_unescape(text: &str) -> String {
+    text.replace("&apos;", "'")
+        .replace("&quot;", "\"")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&amp;", "&")
+}
+
 /// The GENERATED header — one sentence behind two comment markers (XML
 /// for the plist, `#` for systemd). The exact flag spelling stays OUT:
 /// `--` is illegal inside an XML comment (the OS-lint gate proves it),

--- a/crates/nika-cadence/src/tests/emit.rs
+++ b/crates/nika-cadence/src/tests/emit.rs
@@ -143,6 +143,66 @@ fn launchd_per_beat_with_env_file() {
     snap("launchd_per_beat_env", &joined(&units));
 }
 
+/// #1069 — a wrapped unit names its env file; a short-argv unit does
+/// not. Replacing the first with the second is the strip the L4 edge
+/// must refuse.
+#[test]
+fn a_wrapped_unit_names_its_env_file_and_a_bare_unit_does_not() {
+    let reg = registry(TWO_BEATS);
+    let wrapped =
+        emit::render(&reg, &ctx_with_env(), Target::Launchd, Mode::PerBeat).expect("wrap");
+    assert_eq!(
+        emit::env_file_named_in_unit(&wrapped[0].body).as_deref(),
+        Some("/projet/.env")
+    );
+    assert!(
+        wrapped[0].body.contains("&amp;&amp; exec") || wrapped[0].body.contains(" && exec "),
+        "le wrap `. env && exec` est le contrat: {}",
+        wrapped[0].body
+    );
+    let bare = emit::render(&reg, &ctx(), Target::Launchd, Mode::PerBeat).expect("bare");
+    assert_eq!(
+        emit::env_file_named_in_unit(&bare[0].body),
+        None,
+        "le short argv ne source rien: {}",
+        bare[0].body
+    );
+    assert!(
+        !bare[0].body.contains("/bin/sh"),
+        "sans env file, pas de wrap: {}",
+        bare[0].body
+    );
+
+    let systemd =
+        emit::render(&reg, &ctx_with_env(), Target::SystemdUser, Mode::PerBeat).expect("systemd");
+    assert_eq!(
+        emit::env_file_named_in_unit(&systemd[1].body).as_deref(),
+        Some("/projet/.env"),
+        "EnvironmentFile= sur le service: {}",
+        systemd[1].body
+    );
+}
+
+#[test]
+fn env_file_named_in_unit_survives_an_apostrophe_in_the_path() {
+    let reg = registry(TWO_BEATS);
+    let ctx = EmitCtx::new(
+        PathBuf::from("/usr/local/bin/nika"),
+        PathBuf::from("/projet"),
+        PathBuf::from("/projet/nika.yaml"),
+        Some(PathBuf::from("/projet/o's.env")),
+        PathBuf::from("/projet/.nika/arm/logs"),
+        "Europe/Paris".to_owned(),
+    );
+    let units = emit::render(&reg, &ctx, Target::Launchd, Mode::PerBeat).expect("rendu");
+    assert_eq!(
+        emit::env_file_named_in_unit(&units[0].body).as_deref(),
+        Some("/projet/o's.env"),
+        "{}",
+        units[0].body
+    );
+}
+
 #[test]
 fn launchd_serve() {
     let reg = registry(TWO_BEATS);

--- a/crates/nika-cadence/src/tests/emit.rs
+++ b/crates/nika-cadence/src/tests/emit.rs
@@ -184,6 +184,22 @@ fn a_wrapped_unit_names_its_env_file_and_a_bare_unit_does_not() {
 }
 
 #[test]
+fn env_file_named_in_unit_does_not_need_the_generated_mark() {
+    let reg = registry(TWO_BEATS);
+    let units = emit::render(&reg, &ctx_with_env(), Target::Launchd, Mode::PerBeat).expect("wrap");
+    let stripped = units[0].body.replace(emit::GENERATED_MARK, "hand-kept");
+    assert!(
+        !stripped.contains(emit::GENERATED_MARK),
+        "la marque est partie"
+    );
+    assert_eq!(
+        emit::env_file_named_in_unit(&stripped).as_deref(),
+        Some("/projet/.env"),
+        "le wrap se lit sans GENERATED: {stripped}"
+    );
+}
+
+#[test]
 fn env_file_named_in_unit_survives_an_apostrophe_in_the_path() {
     let reg = registry(TWO_BEATS);
     let ctx = EmitCtx::new(

--- a/crates/nika-cli/src/verbs/arm/emit.rs
+++ b/crates/nika-cli/src/verbs/arm/emit.rs
@@ -18,6 +18,11 @@ use nika_cadence::registry::Locus;
 use super::VerbOutput;
 use super::args::{ArmArgs, EmitMode, EmitTarget};
 
+/// Project-arm sidecar remembering `--env-file` so a flag-less re-emit
+/// keeps the D7 wrap (a short argv over a `. env && exec` unit strips
+/// every provider key).
+const ENV_FILE_SIDECAR: &str = ".nika/arm/env-file";
+
 /// `arm --emit <OS>` — render the registry's units, print them (the
 /// default) or write them (`--write`).
 #[must_use]
@@ -46,16 +51,24 @@ pub fn run(args: &ArmArgs, emit_target: EmitTarget) -> VerbOutput {
         Ok(bin) => bin,
         Err(out) => return out,
     };
-    let env_file = match env_file(args, &cwd) {
-        Ok(file) => file,
-        Err(out) => return out,
-    };
     let path = if path.is_absolute() {
         path
     } else {
         cwd.join(path)
     };
     let root = path.parent().map_or_else(|| cwd.clone(), Path::to_path_buf);
+    let dest = if args.write {
+        match dest_dir(args, emit_target) {
+            Ok(dir) => Some(dir),
+            Err(out) => return out,
+        }
+    } else {
+        None
+    };
+    let env_file = match resolve_env_file(args, &cwd, &root, dest.as_deref()) {
+        Ok(file) => file,
+        Err(out) => return out,
+    };
     let target = match emit_target {
         EmitTarget::Launchd => Target::Launchd,
         EmitTarget::Systemd => Target::SystemdUser,
@@ -85,10 +98,15 @@ pub fn run(args: &ArmArgs, emit_target: EmitTarget) -> VerbOutput {
         })
         .collect();
 
-    if args.write {
-        write_units(args, emit_target, &units, &skips, &ctx.log_dir)
-    } else {
-        print_units(&units, &skips, emit_target)
+    if let Some(file) = &ctx.env_file
+        && (args.write || args.env_file.is_some())
+        && let Err(out) = persist_env_file(&root, file)
+    {
+        return out;
+    }
+    match dest {
+        Some(dir) => write_units(&dir, emit_target, &units, &skips, &ctx.log_dir),
+        None => print_units(&units, &skips, emit_target),
     }
 }
 
@@ -111,25 +129,147 @@ fn nika_bin(args: &ArmArgs) -> Result<PathBuf, VerbOutput> {
     }
 }
 
-/// The env file, made absolute and proven readable — D7: the provider
-/// keys live THERE (the unit names the path, the values never cross),
-/// so the file must exist before any unit does.
-fn env_file(args: &ArmArgs, cwd: &Path) -> Result<Option<PathBuf>, VerbOutput> {
-    let Some(file) = &args.env_file else {
-        return Ok(None);
-    };
-    let file = if file.is_absolute() {
-        file.clone()
+/// Flag, then the project-arm sidecar, then an existing unit's wrap.
+/// A named path that cannot be read refuses — never a weaker unit.
+fn resolve_env_file(
+    args: &ArmArgs,
+    cwd: &Path,
+    root: &Path,
+    dest: Option<&Path>,
+) -> Result<Option<PathBuf>, VerbOutput> {
+    if let Some(file) = &args.env_file {
+        let file = absolute(file, cwd);
+        return match std::fs::metadata(&file) {
+            Ok(meta) if meta.is_file() => Ok(Some(file)),
+            _ => Err(VerbOutput::env(format!(
+                "arm --emit --env-file {} · illisible — les clés y vivent, il doit exister avant l'unité",
+                file.display()
+            ))),
+        };
+    }
+    if let Some(file) = persisted_env_file(root)? {
+        return Ok(Some(file));
+    }
+    match dest {
+        Some(dir) => env_file_from_existing_units(dir),
+        None => Ok(None),
+    }
+}
+
+fn absolute(file: &Path, cwd: &Path) -> PathBuf {
+    if file.is_absolute() {
+        file.to_path_buf()
     } else {
         cwd.join(file)
-    };
-    match std::fs::metadata(&file) {
-        Ok(meta) if meta.is_file() => Ok(Some(file)),
-        _ => Err(VerbOutput::env(format!(
-            "arm --emit --env-file {} · illisible — les clés y vivent, il doit exister avant l'unité",
-            file.display()
-        ))),
     }
+}
+
+fn prove_readable(file: PathBuf) -> Result<PathBuf, VerbOutput> {
+    match std::fs::metadata(&file) {
+        Ok(meta) if meta.is_file() => Ok(file),
+        _ => Err(weaker_refusal(&file)),
+    }
+}
+
+fn persisted_env_file(root: &Path) -> Result<Option<PathBuf>, VerbOutput> {
+    let sidecar = root.join(ENV_FILE_SIDECAR);
+    let text = match std::fs::read_to_string(&sidecar) {
+        Ok(text) => text,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => {
+            return Err(VerbOutput::env(format!(
+                "arm --emit · {}: {e}",
+                sidecar.display()
+            )));
+        }
+    };
+    let line = text.trim();
+    if line.is_empty() {
+        return Ok(None);
+    }
+    let file = PathBuf::from(line);
+    let file = if file.is_absolute() {
+        file
+    } else {
+        root.join(file)
+    };
+    prove_readable(file).map(Some)
+}
+
+fn persist_env_file(root: &Path, file: &Path) -> Result<(), VerbOutput> {
+    let sidecar = root.join(ENV_FILE_SIDECAR);
+    let parent = root.join(".nika/arm");
+    if let Err(e) = std::fs::create_dir_all(&parent) {
+        return Err(VerbOutput::env(format!(
+            "arm --emit · {}: {e}",
+            parent.display()
+        )));
+    }
+    std::fs::write(&sidecar, format!("{}\n", file.display()))
+        .map_err(|e| VerbOutput::env(format!("arm --emit · {}: {e}", sidecar.display())))
+}
+
+/// Read a dest that already carries the wrap — recovering the path is
+/// what makes `--write` over field units non-destructive. Two named
+/// paths refuse rather than pick. A named path that is gone refuses
+/// rather than emit the short argv over the wrap.
+fn env_file_from_existing_units(dir: &Path) -> Result<Option<PathBuf>, VerbOutput> {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => {
+            return Err(VerbOutput::env(format!(
+                "arm --emit · {}: {e}",
+                dir.display()
+            )));
+        }
+    };
+    let mut named: Option<PathBuf> = None;
+    for entry in entries {
+        let path = match entry {
+            Ok(entry) => entry.path(),
+            Err(e) => {
+                return Err(VerbOutput::env(format!(
+                    "arm --emit · {}: {e}",
+                    dir.display()
+                )));
+            }
+        };
+        let Ok(body) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        if !body.contains(emit::GENERATED_MARK) {
+            continue;
+        }
+        let Some(raw) = emit::env_file_named_in_unit(&body) else {
+            continue;
+        };
+        let candidate = PathBuf::from(raw);
+        match &named {
+            None => named = Some(candidate),
+            Some(existing) if existing == &candidate => {}
+            Some(existing) => {
+                return Err(VerbOutput::file(format!(
+                    "arm --emit · unités existantes nomment des --env-file différents ({} vs {}) — refuse d'en choisir un · remède: `nika arm --emit launchd --env-file <fichier>`",
+                    existing.display(),
+                    candidate.display()
+                )));
+            }
+        }
+    }
+    match named {
+        None => Ok(None),
+        Some(file) => prove_readable(file).map(Some),
+    }
+}
+
+/// Fail closed: never emit a short argv over a unit that sources keys.
+fn weaker_refusal(file: &Path) -> VerbOutput {
+    VerbOutput::env(format!(
+        "arm --emit · --env-file {} · illisible — un emit sans le drapeau enlèverait le wrap `. env && exec` (plus de clés) · remède: `nika arm --emit launchd --env-file {}`",
+        file.display(),
+        file.display()
+    ))
 }
 
 /// Print mode — the default. Units to stdout, the load commands with
@@ -166,17 +306,13 @@ fn print_units(units: &[Unit], skips: &[String], target: EmitTarget) -> VerbOutp
 /// them (or `--out`), the log dir is created (launchd creates no
 /// parent), and the load commands carry the real paths.
 fn write_units(
-    args: &ArmArgs,
+    dir: &Path,
     target: EmitTarget,
     units: &[Unit],
     skips: &[String],
     log_dir: &Path,
 ) -> VerbOutput {
-    let dir = match dest_dir(args, target) {
-        Ok(dir) => dir,
-        Err(out) => return out,
-    };
-    if let Err(e) = std::fs::create_dir_all(&dir).and_then(|()| std::fs::create_dir_all(log_dir)) {
+    if let Err(e) = std::fs::create_dir_all(dir).and_then(|()| std::fs::create_dir_all(log_dir)) {
         return VerbOutput::env(format!("arm --emit --write · {}: {e}", dir.display()));
     }
     let mut out = String::new();
@@ -195,7 +331,7 @@ fn write_units(
         "\n{} · rien n'est chargé — la charge demeure ton geste:",
         crate::text::count(units.len(), "unité")
     );
-    for command in load_commands(units, target, Some(&dir)) {
+    for command in load_commands(units, target, Some(dir)) {
         let _ = writeln!(out, "  {command}");
     }
     VerbOutput::ok(out)

--- a/crates/nika-cli/src/verbs/arm/emit.rs
+++ b/crates/nika-cli/src/verbs/arm/emit.rs
@@ -167,7 +167,7 @@ fn absolute(file: &Path, cwd: &Path) -> PathBuf {
 fn prove_readable(file: PathBuf) -> Result<PathBuf, VerbOutput> {
     match std::fs::metadata(&file) {
         Ok(meta) if meta.is_file() => Ok(file),
-        _ => Err(weaker_refusal(&file)),
+        _ => Err(weaker_refusal(Some(&file))),
     }
 }
 
@@ -210,9 +210,11 @@ fn persist_env_file(root: &Path, file: &Path) -> Result<(), VerbOutput> {
 }
 
 /// Read a dest that already carries the wrap — recovering the path is
-/// what makes `--write` over field units non-destructive. Two named
-/// paths refuse rather than pick. A named path that is gone refuses
-/// rather than emit the short argv over the wrap.
+/// what makes `--write` over field units non-destructive. The wrap is
+/// the env-exec pattern itself (GENERATED header optional — stripping
+/// the comment must not reopen a weaker overwrite). Two named paths
+/// refuse rather than pick. A named path that is gone refuses rather
+/// than emit the short argv over the wrap.
 fn env_file_from_existing_units(dir: &Path) -> Result<Option<PathBuf>, VerbOutput> {
     let entries = match std::fs::read_dir(dir) {
         Ok(entries) => entries,
@@ -235,26 +237,28 @@ fn env_file_from_existing_units(dir: &Path) -> Result<Option<PathBuf>, VerbOutpu
                 )));
             }
         };
-        let Ok(body) = std::fs::read_to_string(&path) else {
+        let Some(body) = unit_text(&path) else {
             continue;
         };
-        if !body.contains(emit::GENERATED_MARK) {
-            continue;
-        }
-        let Some(raw) = emit::env_file_named_in_unit(&body) else {
-            continue;
-        };
-        let candidate = PathBuf::from(raw);
-        match &named {
-            None => named = Some(candidate),
-            Some(existing) if existing == &candidate => {}
-            Some(existing) => {
-                return Err(VerbOutput::file(format!(
-                    "arm --emit · unités existantes nomment des --env-file différents ({} vs {}) — refuse d'en choisir un · remède: `nika arm --emit launchd --env-file <fichier>`",
-                    existing.display(),
-                    candidate.display()
-                )));
+        match emit::env_file_named_in_unit(&body) {
+            Some(raw) => {
+                let candidate = PathBuf::from(raw);
+                match &named {
+                    None => named = Some(candidate),
+                    Some(existing) if existing == &candidate => {}
+                    Some(existing) => {
+                        return Err(VerbOutput::file(format!(
+                            "arm --emit · unités existantes nomment des --env-file différents ({} vs {}) — refuse d'en choisir un · remède: `nika arm --emit launchd --env-file <fichier>`",
+                            existing.display(),
+                            candidate.display()
+                        )));
+                    }
+                }
             }
+            None if body.contains(" && exec ") || body.contains("&amp;&amp; exec") => {
+                return Err(weaker_refusal(None));
+            }
+            None => {}
         }
     }
     match named {
@@ -263,13 +267,26 @@ fn env_file_from_existing_units(dir: &Path) -> Result<Option<PathBuf>, VerbOutpu
     }
 }
 
+/// Bytes, then lossy UTF-8 — a binary plist still carries the wrap as
+/// ASCII; `read_to_string` would skip it and reopen the strip.
+fn unit_text(path: &Path) -> Option<String> {
+    let bytes = std::fs::read(path).ok()?;
+    Some(String::from_utf8_lossy(&bytes).into_owned())
+}
+
 /// Fail closed: never emit a short argv over a unit that sources keys.
-fn weaker_refusal(file: &Path) -> VerbOutput {
-    VerbOutput::env(format!(
-        "arm --emit · --env-file {} · illisible — un emit sans le drapeau enlèverait le wrap `. env && exec` (plus de clés) · remède: `nika arm --emit launchd --env-file {}`",
-        file.display(),
-        file.display()
-    ))
+fn weaker_refusal(file: Option<&Path>) -> VerbOutput {
+    match file {
+        Some(file) => VerbOutput::env(format!(
+            "arm --emit · --env-file {} · illisible — un emit sans le drapeau enlèverait le wrap `. env && exec` (plus de clés) · remède: `nika arm --emit launchd --env-file {}`",
+            file.display(),
+            file.display()
+        )),
+        None => VerbOutput::env(
+            "arm --emit · une unité source déjà un env file (`. env && exec`) · un emit sans --env-file l'enlèverait (plus de clés) · remède: `nika arm --emit launchd --env-file <fichier>`"
+                .to_owned(),
+        ),
+    }
 }
 
 /// Print mode — the default. Units to stdout, the load commands with

--- a/crates/nika-cli/tests/arm_emit.rs
+++ b/crates/nika-cli/tests/arm_emit.rs
@@ -353,6 +353,67 @@ fn reemit_does_not_strip_an_existing_env_wrap() {
     );
 }
 
+/// #1069 refuter — a dest wrap without the GENERATED header is still
+/// a wrap. Sidecar gone, env file gone: `--write` must refuse and
+/// leave `. env && exec` intact.
+#[test]
+fn reemit_refuses_a_wrap_without_generated_mark() {
+    let zone = machine_zone();
+    let dir = project("nogenerated", &registry_in(&zone));
+    let home = home(&dir);
+    let env_file = dir.join("providers.env");
+    std::fs::write(&env_file, "MISTRAL_API_KEY=hunter2-live-zz\n").expect("env file");
+    let env_arg = env_file.to_str().expect("utf8").to_owned();
+    let dest = dir.join("units");
+    let out = arm(
+        &dir,
+        &home,
+        &[
+            "arm",
+            "--emit",
+            "launchd",
+            "--write",
+            "--out",
+            dest.to_str().expect("utf8"),
+            "--env-file",
+            &env_arg,
+        ],
+    );
+    assert_eq!(out.status.code(), Some(0));
+    let plist = dest.join("nika.arm.doctor.plist");
+    let body = std::fs::read_to_string(&plist).expect("plist");
+    std::fs::write(&plist, body.replace("GENERATED from", "hand-kept from")).expect("strip mark");
+    std::fs::remove_file(dir.join(".nika/arm/env-file")).expect("drop sidecar");
+    std::fs::remove_file(&env_file).expect("drop env");
+
+    let before = std::fs::read_to_string(&plist).expect("before");
+    let out = arm(
+        &dir,
+        &home,
+        &[
+            "arm",
+            "--emit",
+            "launchd",
+            "--write",
+            "--out",
+            dest.to_str().expect("utf8"),
+        ],
+    );
+    assert_eq!(out.status.code(), Some(3), "le refus: {out:?}");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("--env-file"),
+        "le remède nomme le drapeau: {stderr}"
+    );
+    let after = std::fs::read_to_string(&plist).expect("after");
+    assert_eq!(after, before, "l'unité n'est pas écrasée");
+    assert!(
+        after.contains("/bin/sh")
+            && (after.contains("&amp;&amp; exec") || after.contains(" && exec ")),
+        "`. env && exec` demeure: {after}"
+    );
+}
+
 /// A sidecar that names a gone file refuses — never a weaker unit.
 #[test]
 fn stale_env_sidecar_refuses_instead_of_stripping() {

--- a/crates/nika-cli/tests/arm_emit.rs
+++ b/crates/nika-cli/tests/arm_emit.rs
@@ -225,6 +225,160 @@ fn emit_never_carries_a_secret_value() {
     assert!(!body.contains("hunter2-live-zz"), "D7: {body}");
 }
 
+/// #1069 — a flag-less re-emit must keep the wrap once `--env-file`
+/// has been named (the sidecar remembers it). The projection gate
+/// teaches re-emit without the flag; forgetting the wrap was the
+/// destructive path.
+#[test]
+fn flagless_reemit_keeps_the_env_wrap_from_the_sidecar() {
+    let zone = machine_zone();
+    let dir = project("persist", &registry_in(&zone));
+    let home = home(&dir);
+    let env_file = dir.join("providers.env");
+    std::fs::write(&env_file, "MISTRAL_API_KEY=hunter2-live-zz\n").expect("env file");
+    let env_arg = env_file.to_str().expect("utf8").to_owned();
+    let first = dir.join("first");
+    let out = arm(
+        &dir,
+        &home,
+        &[
+            "arm",
+            "--emit",
+            "launchd",
+            "--write",
+            "--out",
+            first.to_str().expect("utf8"),
+            "--env-file",
+            &env_arg,
+        ],
+    );
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let sidecar = std::fs::read_to_string(dir.join(".nika/arm/env-file")).expect("sidecar");
+    assert!(
+        sidecar.contains("providers.env"),
+        "le chemin, persisté: {sidecar}"
+    );
+
+    let second = dir.join("second");
+    let out = arm(
+        &dir,
+        &home,
+        &[
+            "arm",
+            "--emit",
+            "launchd",
+            "--write",
+            "--out",
+            second.to_str().expect("utf8"),
+        ],
+    );
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let body = std::fs::read_to_string(second.join("nika.arm.doctor.plist")).expect("plist");
+    assert!(
+        body.contains("/bin/sh"),
+        "le wrap demeure sans --env-file: {body}"
+    );
+    assert!(
+        body.contains(". ") && (body.contains("&amp;&amp; exec") || body.contains(" && exec ")),
+        "`. env && exec` n'est pas strippé: {body}"
+    );
+    assert!(body.contains("providers.env"), "{body}");
+    assert!(!body.contains("hunter2-live-zz"), "D7: {body}");
+}
+
+/// #1069 — a dest that already carries `. env && exec` is recovered,
+/// not replaced by the short argv, even when the sidecar is gone.
+#[test]
+fn reemit_does_not_strip_an_existing_env_wrap() {
+    let zone = machine_zone();
+    let dir = project("keepwrap", &registry_in(&zone));
+    let home = home(&dir);
+    let env_file = dir.join("providers.env");
+    std::fs::write(&env_file, "MISTRAL_API_KEY=hunter2-live-zz\n").expect("env file");
+    let env_arg = env_file.to_str().expect("utf8").to_owned();
+    let dest = dir.join("units");
+    let out = arm(
+        &dir,
+        &home,
+        &[
+            "arm",
+            "--emit",
+            "launchd",
+            "--write",
+            "--out",
+            dest.to_str().expect("utf8"),
+            "--env-file",
+            &env_arg,
+        ],
+    );
+    assert_eq!(out.status.code(), Some(0));
+    std::fs::remove_file(dir.join(".nika/arm/env-file")).expect("drop sidecar");
+
+    let out = arm(
+        &dir,
+        &home,
+        &[
+            "arm",
+            "--emit",
+            "launchd",
+            "--write",
+            "--out",
+            dest.to_str().expect("utf8"),
+        ],
+    );
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let body = std::fs::read_to_string(dest.join("nika.arm.doctor.plist")).expect("plist");
+    assert!(
+        body.contains("/bin/sh") && body.contains("providers.env"),
+        "l'unité existante n'est pas strippée: {body}"
+    );
+    assert!(
+        body.contains("&amp;&amp; exec") || body.contains(" && exec "),
+        "`. env && exec` demeure: {body}"
+    );
+}
+
+/// A sidecar that names a gone file refuses — never a weaker unit.
+#[test]
+fn stale_env_sidecar_refuses_instead_of_stripping() {
+    let zone = machine_zone();
+    let dir = project("stale", &registry_in(&zone));
+    let home = home(&dir);
+    std::fs::create_dir_all(dir.join(".nika/arm")).expect("sidecar dir");
+    std::fs::write(
+        dir.join(".nika/arm/env-file"),
+        dir.join("gone.env").display().to_string(),
+    )
+    .expect("stale sidecar");
+
+    let out = arm(&dir, &home, &["arm", "--emit", "launchd"]);
+    assert_eq!(out.status.code(), Some(3), "le refus: {out:?}");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("--env-file"),
+        "le remède nomme le drapeau: {stderr}"
+    );
+    assert!(
+        stderr.contains("gone.env"),
+        "le chemin disparu est nommé: {stderr}"
+    );
+}
+
 #[test]
 fn emit_renders_arm_fire_never_run() {
     // D2: the firer is ONE. Every emitted unit calls `arm fire <label>`


### PR DESCRIPTION
## What & why

`nika arm --emit launchd` after 0.111.0 dropped the `. env && exec` wrapper unless `--env-file` was passed, so a flag-less re-emit stripped provider env from field units (studio projection gate). Closes #1069.

- Persist the env-file path in gitignored `.nika/arm/env-file`.
- Recover wrap from an existing dest unit even without the GENERATED header.
- Fail-closed if the named env file is gone: refuse, do not emit short argv over a UTF-8 wrap.

Known remaining gap (not the field bug): UTF-16 / unreadable dest plists are not decoded; those are not the units we emit.

## Proof

- `cargo test -p nika-cadence --lib` green
- `cargo test -p nika-cli --test arm_emit` 14 passed
- Independent reviewer GREEN on first commit; refuter REFUTED GENERATED-only detection; second commit closes that UTF-8 hole.

Signed-off-by: Thibaut Melen <20891897+ThibautMelen@users.noreply.github.com>

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>