### PR TITLE
fix(arm): rewrite emit prose the typos gate flags

### DIFF
--- a/crates/nika-cadence/src/tests/emit.rs
+++ b/crates/nika-cadence/src/tests/emit.rs
@@ -178,7 +178,7 @@ fn a_wrapped_unit_names_its_env_file_and_a_bare_unit_does_not() {
     assert_eq!(
         emit::env_file_named_in_unit(&systemd[1].body).as_deref(),
         Some("/projet/.env"),
-        "EnvironmentFile= sur le service: {}",
+        "EnvironmentFile= on the service unit: {}",
         systemd[1].body
     );
 }

--- a/crates/nika-cli/src/verbs/arm/emit.rs
+++ b/crates/nika-cli/src/verbs/arm/emit.rs
@@ -248,7 +248,7 @@ fn env_file_from_existing_units(dir: &Path) -> Result<Option<PathBuf>, VerbOutpu
                     Some(existing) if existing == &candidate => {}
                     Some(existing) => {
                         return Err(VerbOutput::file(format!(
-                            "arm --emit · unités existantes nomment des --env-file différents ({} vs {}) — refuse d'en choisir un · remède: `nika arm --emit launchd --env-file <fichier>`",
+                            "arm --emit · dest units name two different --env-file paths ({} vs {}) — refuse to pick · pass `nika arm --emit launchd --env-file <file>`",
                             existing.display(),
                             candidate.display()
                         )));


### PR DESCRIPTION
Follow-up to #1140. The squash landed two French words (`existantes`, `sur`) that the typos gate flags as English misspellings. Same meaning, English prose.

Signed-off-by: Thibaut Melen <20891897+ThibautMelen@users.noreply.github.com>

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>