### PR TITLE
feat(serve): project job events over sse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,7 +52,7 @@ Cargo.lock.bak
 /crates/nika-policy/
 /crates/nika-sdk/
 /crates/nika-security/
-/crates/nika-serve/
+# /crates/nika-serve/  -- W06 admitted loopback HTTP (new files must not need -f)
 /crates/nika-storage/
 /crates/nika-vault/
 # /crates/nika-verb-infer/  -- s9 L2 crate (ADMITTED 2026-06-11)

--- a/crates/nika-serve/src/server/config.rs
+++ b/crates/nika-serve/src/server/config.rs
@@ -21,6 +21,7 @@ pub struct ServerLimits {
     max_connections: usize,
     max_headers: usize,
     max_jobs: usize,
+    max_sse_clients: usize,
 }
 
 impl ServerLimits {
@@ -47,6 +48,7 @@ impl ServerLimits {
             max_connections,
             max_headers,
             max_jobs: 10_000,
+            max_sse_clients: max_connections,
         }
     }
 
@@ -54,6 +56,13 @@ impl ServerLimits {
     #[must_use]
     pub const fn with_max_jobs(mut self, max_jobs: usize) -> Self {
         self.max_jobs = max_jobs;
+        self
+    }
+
+    /// Replace the concurrent SSE client ceiling.
+    #[must_use]
+    pub const fn with_max_sse_clients(mut self, max_sse_clients: usize) -> Self {
+        self.max_sse_clients = max_sse_clients;
         self
     }
 
@@ -67,6 +76,7 @@ impl ServerLimits {
             && self.max_connections != 0
             && self.max_headers != 0
             && self.max_jobs != 0
+            && self.max_sse_clients != 0
     }
 
     pub(crate) const fn max_body_bytes(self) -> usize {
@@ -103,6 +113,10 @@ impl ServerLimits {
 
     pub(crate) const fn max_jobs(self) -> usize {
         self.max_jobs
+    }
+
+    pub(crate) const fn max_sse_clients(self) -> usize {
+        self.max_sse_clients
     }
 }
 

--- a/crates/nika-serve/src/server/error.rs
+++ b/crates/nika-serve/src/server/error.rs
@@ -1,17 +1,23 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
 
+use std::convert::Infallible;
 use std::io;
 
 use bytes::Bytes;
-use http_body_util::Full;
+use http_body_util::combinators::UnsyncBoxBody;
+use http_body_util::{BodyExt as _, Full};
 use hyper::header::{CONTENT_TYPE, WWW_AUTHENTICATE};
 use hyper::{Response, StatusCode};
 use thiserror::Error;
 
 use crate::JobStoreError;
 
-pub(crate) type ResponseBody = Full<Bytes>;
+pub(crate) type ResponseBody = UnsyncBoxBody<Bytes, Infallible>;
+
+pub(crate) fn once_body(bytes: impl Into<Bytes>) -> ResponseBody {
+    Full::new(bytes.into()).boxed_unsync()
+}
 
 /// Typed startup and lifecycle failures from the HTTP server.
 #[derive(Debug, Error)]
@@ -73,12 +79,56 @@ impl ApiError {
         }
     }
 
+    pub(crate) const fn job_not_found() -> Self {
+        Self::new(StatusCode::NOT_FOUND, "job_not_found", "job not found")
+    }
+
+    pub(crate) const fn internal() -> Self {
+        Self::new(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "internal_error",
+            "request could not be completed",
+        )
+    }
+
+    pub(crate) const fn store_busy() -> Self {
+        Self::new(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "store_busy",
+            "durable job state is temporarily unavailable",
+        )
+    }
+
+    pub(crate) const fn invalid_cursor() -> Self {
+        Self::new(
+            StatusCode::BAD_REQUEST,
+            "invalid_cursor",
+            "last-event-id must be a decimal event sequence",
+        )
+    }
+
+    pub(crate) const fn cursor_beyond_latest() -> Self {
+        Self::new(
+            StatusCode::BAD_REQUEST,
+            "cursor_beyond_latest",
+            "last-event-id is beyond the latest persisted event",
+        )
+    }
+
+    pub(crate) const fn sse_capacity() -> Self {
+        Self::new(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "sse_capacity",
+            "event stream capacity is exhausted",
+        )
+    }
+
     pub(crate) fn into_response(self) -> Response<ResponseBody> {
         let body = serde_json::json!({
             "error": {"code": self.code, "message": self.message}
         });
         let bytes = serde_json::to_vec(&body).unwrap_or_else(|_| b"{}".to_vec());
-        let mut response = Response::new(Full::new(Bytes::from(bytes)));
+        let mut response = Response::new(once_body(bytes));
         *response.status_mut() = self.status;
         response.headers_mut().insert(
             CONTENT_TYPE,

--- a/crates/nika-serve/src/server/mod.rs
+++ b/crates/nika-serve/src/server/mod.rs
@@ -7,6 +7,7 @@ mod error;
 mod model;
 mod registry;
 mod route;
+mod sse;
 mod store;
 
 use std::future::Future;
@@ -22,10 +23,10 @@ use nika_execution::{ExecutionContext, ExecutionService, SnapshotLimits};
 use nika_fs::OwnedDir;
 use serde_json::json;
 use tokio::net::{TcpListener, TcpStream};
-use tokio::sync::mpsc;
+use tokio::sync::{Semaphore, mpsc};
 use tokio::task::JoinSet;
 
-use crate::{JobId, JobStatus, JobStore};
+use crate::{EventPageLimit, JobId, JobStatus, JobStore, MAX_EVENT_PAGE_LEN};
 
 use auth::BearerToken;
 pub use config::{ServerConfig, ServerLimits};
@@ -67,6 +68,8 @@ struct AppState {
     jobs: mpsc::Sender<ExecutionTask>,
     limits: ServerLimits,
     snapshot_limits: SnapshotLimits,
+    sse_slots: Arc<Semaphore>,
+    event_page_limit: EventPageLimit,
 }
 
 #[derive(Debug)]
@@ -104,6 +107,9 @@ impl BoundServer {
         backend: Arc<dyn ExecutionBackend>,
     ) -> Result<Self, ServerError> {
         validate_config(&config)?;
+        let event_page_limit = EventPageLimit::new(MAX_EVENT_PAGE_LEN).map_err(|_| {
+            ServerError::InvalidConfig("SSE event page limit must be within the store cap")
+        })?;
         let prepared = prepare_authority(&config).await?;
         let listener = TcpListener::bind(config.bind())
             .await
@@ -128,6 +134,8 @@ impl BoundServer {
             jobs,
             limits: config.limits(),
             snapshot_limits: config.snapshot_limits(),
+            sse_slots: Arc::new(Semaphore::new(config.limits().max_sse_clients())),
+            event_page_limit,
         });
         Ok(Self {
             listener,
@@ -226,7 +234,7 @@ async fn prepare_authority(config: &ServerConfig) -> Result<PreparedAuthority, S
 fn validate_config(config: &ServerConfig) -> Result<(), ServerError> {
     if !config.limits().valid() {
         return Err(ServerError::InvalidConfig(
-            "all size, timeout, concurrency, queue, connection, and header ceilings must be non-zero",
+            "all size, timeout, concurrency, queue, connection, sse, and header ceilings must be non-zero",
         ));
     }
     if !config.bind().ip().is_loopback() && !config.allow_remote() {

--- a/crates/nika-serve/src/server/route.rs
+++ b/crates/nika-serve/src/server/route.rs
@@ -5,7 +5,7 @@ use std::convert::Infallible;
 use std::sync::Arc;
 
 use bytes::Bytes;
-use http_body_util::{BodyExt as _, Full, Limited};
+use http_body_util::{BodyExt as _, Limited};
 use hyper::body::Incoming;
 use hyper::header::{CONTENT_ENCODING, CONTENT_LENGTH, CONTENT_TYPE};
 use hyper::{Method, Request, Response, StatusCode};
@@ -13,12 +13,13 @@ use sha2::{Digest as _, Sha256};
 
 use crate::{Admission, IdempotencyKey, JobId, RequestDigest};
 
-use super::error::{ApiError, ResponseBody};
+use super::error::{ApiError, ResponseBody, once_body};
 use super::model::{
     CreateJobRequest, HealthResponse, JobResponse, JobStatusResponse, WorkflowListResponse,
     WorkflowMetadataResponse,
 };
 use super::registry::{list_workflows, valid_workflow_name, workflow_exists};
+use super::sse;
 use super::{AppState, ExecutionTask};
 
 const IDEMPOTENCY_KEY: &str = "idempotency-key";
@@ -48,6 +49,9 @@ async fn protected(request: Request<Incoming>, state: Arc<AppState>) -> Response
             "request body exceeds the configured limit",
         )
         .into_response();
+    }
+    if request.method() == Method::GET && sse::is_events_path(request.uri().path()) {
+        return sse::handle(request, state).await;
     }
     match tokio::time::timeout(
         state.limits.request_timeout(),
@@ -340,7 +344,7 @@ fn is_json(headers: &hyper::HeaderMap) -> bool {
 
 fn json_response<T: serde::Serialize>(status: StatusCode, value: &T) -> Response<ResponseBody> {
     let bytes = serde_json::to_vec(value).unwrap_or_else(|_| b"{}".to_vec());
-    let mut response = Response::new(Full::new(Bytes::from(bytes)));
+    let mut response = Response::new(once_body(bytes));
     *response.status_mut() = status;
     response.headers_mut().insert(
         CONTENT_TYPE,
@@ -350,16 +354,11 @@ fn json_response<T: serde::Serialize>(status: StatusCode, value: &T) -> Response
 }
 
 fn job_not_found() -> Response<ResponseBody> {
-    ApiError::new(StatusCode::NOT_FOUND, "job_not_found", "job not found").into_response()
+    ApiError::job_not_found().into_response()
 }
 
 fn internal_error() -> Response<ResponseBody> {
-    ApiError::new(
-        StatusCode::INTERNAL_SERVER_ERROR,
-        "internal_error",
-        "request could not be completed",
-    )
-    .into_response()
+    ApiError::internal().into_response()
 }
 
 fn queue_full() -> Response<ResponseBody> {
@@ -381,10 +380,5 @@ fn job_capacity() -> Response<ResponseBody> {
 }
 
 fn store_busy() -> Response<ResponseBody> {
-    ApiError::new(
-        StatusCode::SERVICE_UNAVAILABLE,
-        "store_busy",
-        "durable job state is temporarily unavailable",
-    )
-    .into_response()
+    ApiError::store_busy().into_response()
 }

--- a/crates/nika-serve/src/server/sse.rs
+++ b/crates/nika-serve/src/server/sse.rs
@@ -1,0 +1,331 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+use std::convert::Infallible;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use bytes::Bytes;
+use http_body_util::BodyExt as _;
+use hyper::body::{Frame, Incoming};
+use hyper::header::{CACHE_CONTROL, CONTENT_TYPE, HeaderValue};
+use hyper::{Request, Response, StatusCode};
+use serde::Serialize;
+use serde_json::Value;
+use tokio::sync::TryAcquireError;
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+
+use crate::{JobEvent, JobId, JobStatus, JobStoreError};
+
+use super::error::{ApiError, ResponseBody};
+use super::store::EventPage;
+use super::{AppState, ServerError};
+
+const SSE_BUFFER: usize = 8;
+
+pub(super) fn is_events_path(path: &str) -> bool {
+    events_job_id(path).is_some()
+}
+
+pub(super) async fn handle(
+    request: Request<Incoming>,
+    state: Arc<AppState>,
+) -> Response<ResponseBody> {
+    let path = request.uri().path().to_owned();
+    let Some(raw_id) = events_job_id(&path) else {
+        return ApiError::new(StatusCode::NOT_FOUND, "not_found", "route not found")
+            .into_response();
+    };
+    let after = match last_event_id(request.headers()) {
+        Ok(after) => after,
+        Err(error) => return error.into_response(),
+    };
+    let Ok(id) = JobId::parse(raw_id) else {
+        return ApiError::job_not_found().into_response();
+    };
+    if let Err(response) = preview_cursor(&state, id.clone(), after).await {
+        return response;
+    }
+    let permit = match Arc::clone(&state.sse_slots).try_acquire_owned() {
+        Ok(permit) => permit,
+        Err(TryAcquireError::NoPermits) => return ApiError::sse_capacity().into_response(),
+        Err(TryAcquireError::Closed) => return ApiError::internal().into_response(),
+    };
+    let (tx, rx) = mpsc::channel(SSE_BUFFER);
+    let pump = tokio::spawn(pump_events(
+        Arc::clone(&state),
+        id,
+        after,
+        tx,
+        state.limits.request_timeout(),
+    ));
+    sse_response(SseBody {
+        receiver: rx,
+        pump: Some(pump),
+        _permit: permit,
+    })
+}
+
+async fn preview_cursor(
+    state: &AppState,
+    id: JobId,
+    after: u64,
+) -> Result<EventPage, Response<ResponseBody>> {
+    match state
+        .store
+        .events_after(id, after, state.event_page_limit)
+        .await
+    {
+        Ok(page) => Ok(page),
+        Err(ServerError::JobStore(JobStoreError::JobNotFound(_))) => {
+            Err(ApiError::job_not_found().into_response())
+        }
+        Err(ServerError::JobStore(JobStoreError::CursorBeyondLatest { .. })) => {
+            Err(ApiError::cursor_beyond_latest().into_response())
+        }
+        Err(ServerError::JobStore(JobStoreError::Busy) | ServerError::StoreQueueFull) => {
+            Err(ApiError::store_busy().into_response())
+        }
+        Err(_) => Err(ApiError::internal().into_response()),
+    }
+}
+
+fn sse_response(body: SseBody) -> Response<ResponseBody> {
+    let mut response = Response::new(body.boxed_unsync());
+    *response.status_mut() = StatusCode::OK;
+    response
+        .headers_mut()
+        .insert(CONTENT_TYPE, HeaderValue::from_static("text/event-stream"));
+    response
+        .headers_mut()
+        .insert(CACHE_CONTROL, HeaderValue::from_static("no-cache"));
+    response
+}
+
+fn events_job_id(path: &str) -> Option<&str> {
+    let tail = path.strip_prefix("/v1/jobs/")?;
+    let id = tail.strip_suffix("/events")?;
+    (!id.is_empty() && !id.contains('/')).then_some(id)
+}
+
+fn last_event_id(headers: &hyper::HeaderMap) -> Result<u64, ApiError> {
+    let mut values = headers.get_all("last-event-id").iter();
+    let Some(value) = values.next() else {
+        return Ok(0);
+    };
+    if values.next().is_some() {
+        return Err(ApiError::invalid_cursor());
+    }
+    let value = value.to_str().map_err(|_| ApiError::invalid_cursor())?;
+    parse_cursor(value)
+}
+
+fn parse_cursor(value: &str) -> Result<u64, ApiError> {
+    let value = value.trim();
+    if value.is_empty() || !value.bytes().all(|byte| byte.is_ascii_digit()) {
+        return Err(ApiError::invalid_cursor());
+    }
+    if value.len() > 1 && value.starts_with('0') {
+        return Err(ApiError::invalid_cursor());
+    }
+    value.parse().map_err(|_| ApiError::invalid_cursor())
+}
+
+fn is_terminal(status: JobStatus) -> bool {
+    matches!(
+        status,
+        JobStatus::Succeeded | JobStatus::Failed | JobStatus::Interrupted
+    )
+}
+
+#[derive(Debug, Serialize)]
+struct ProjectedEvent<'a> {
+    sequence: u64,
+    kind: Option<&'a str>,
+    status: Option<&'a str>,
+}
+
+fn projected(event: &JobEvent) -> ProjectedEvent<'_> {
+    ProjectedEvent {
+        sequence: event.sequence(),
+        kind: string_field(event.payload(), "kind"),
+        status: string_field(event.payload(), "status"),
+    }
+}
+
+fn string_field<'a>(payload: &'a Value, key: &'a str) -> Option<&'a str> {
+    payload.get(key).and_then(Value::as_str)
+}
+
+fn encode_frame(event: &JobEvent) -> Option<Bytes> {
+    let json = serde_json::to_string(&projected(event)).ok()?;
+    Some(Bytes::from(format!(
+        "id: {}\ndata: {json}\n\n",
+        event.sequence()
+    )))
+}
+
+async fn pump_events(
+    state: Arc<AppState>,
+    id: JobId,
+    mut after: u64,
+    tx: mpsc::Sender<Bytes>,
+    lag: Duration,
+) {
+    let notify = state.store.event_notify();
+    loop {
+        let notified = notify.clone().notified_owned();
+        tokio::pin!(notified);
+        notified.as_mut().enable();
+        let Ok(page) = state
+            .store
+            .events_after(id.clone(), after, state.event_page_limit)
+            .await
+        else {
+            return;
+        };
+        if page.events.is_empty() {
+            if is_terminal(page.status) {
+                return;
+            }
+            notified.await;
+            continue;
+        }
+        if !emit_page(&tx, &page.events, &mut after, lag).await {
+            return;
+        }
+    }
+}
+
+async fn emit_page(
+    tx: &mpsc::Sender<Bytes>,
+    events: &[JobEvent],
+    after: &mut u64,
+    lag: Duration,
+) -> bool {
+    for event in events {
+        let Some(frame) = encode_frame(event) else {
+            continue;
+        };
+        if !send_frame(tx, frame, lag).await {
+            return false;
+        }
+        *after = event.sequence();
+    }
+    true
+}
+
+async fn send_frame(tx: &mpsc::Sender<Bytes>, frame: Bytes, lag: Duration) -> bool {
+    match tx.try_send(frame) {
+        Ok(()) => true,
+        Err(mpsc::error::TrySendError::Closed(_)) => false,
+        Err(mpsc::error::TrySendError::Full(frame)) => {
+            matches!(tokio::time::timeout(lag, tx.send(frame)).await, Ok(Ok(())))
+        }
+    }
+}
+
+struct SseBody {
+    receiver: mpsc::Receiver<Bytes>,
+    pump: Option<JoinHandle<()>>,
+    _permit: tokio::sync::OwnedSemaphorePermit,
+}
+
+impl Drop for SseBody {
+    fn drop(&mut self) {
+        if let Some(pump) = self.pump.take() {
+            pump.abort();
+        }
+    }
+}
+
+impl hyper::body::Body for SseBody {
+    type Data = Bytes;
+    type Error = Infallible;
+
+    fn poll_frame(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        match self.receiver.poll_recv(cx) {
+            Poll::Ready(Some(data)) => Poll::Ready(Some(Ok(Frame::data(data)))),
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn events_path_requires_a_single_job_segment() {
+        assert!(is_events_path(
+            "/v1/jobs/01234567-89ab-4def-8123-456789abcdef/events"
+        ));
+        assert!(!is_events_path("/v1/jobs/x/events/extra"));
+        assert!(!is_events_path("/v1/jobs/x/status"));
+        assert!(!is_events_path("/v1/jobs/x/cancel"));
+        assert!(!is_events_path("/v1/jobs/x/artifacts"));
+    }
+
+    #[test]
+    fn cursor_rejects_non_decimal_and_padded_values() {
+        assert_eq!(parse_cursor("0").expect("zero"), 0);
+        assert_eq!(parse_cursor("12").expect("twelve"), 12);
+        assert_eq!(parse_cursor(" 7 ").expect("trimmed"), 7);
+        assert!(parse_cursor("").is_err());
+        assert!(parse_cursor("01").is_err());
+        assert!(parse_cursor("+1").is_err());
+        assert!(parse_cursor("1.0").is_err());
+        assert!(parse_cursor("nope").is_err());
+        assert!(parse_cursor("-1").is_err());
+    }
+
+    #[test]
+    fn projection_allowlists_sequence_kind_and_status_only() {
+        let payload = json!({
+            "kind": "interrupted",
+            "status": "interrupted",
+            "secret": "s3cret",
+            "path": "/tmp/job.json",
+            "incarnation_generation": 3
+        });
+        let json = serde_json::to_value(ProjectedEvent {
+            sequence: 4,
+            kind: string_field(&payload, "kind"),
+            status: string_field(&payload, "status"),
+        })
+        .expect("projected json");
+        let object = json.as_object().expect("object");
+        let mut keys = object.keys().cloned().collect::<Vec<_>>();
+        keys.sort();
+        assert_eq!(keys, ["kind", "sequence", "status"]);
+        assert_eq!(json["sequence"], 4);
+        assert_eq!(json["kind"], "interrupted");
+        assert_eq!(json["status"], "interrupted");
+        assert!(json.get("secret").is_none());
+        assert!(json.get("path").is_none());
+        assert!(json.get("incarnation_generation").is_none());
+    }
+
+    #[tokio::test]
+    async fn lagged_buffer_drops_instead_of_blocking() {
+        let (tx, _rx) = mpsc::channel(1);
+        assert!(
+            send_frame(&tx, Bytes::from_static(b"a"), Duration::from_millis(10)).await,
+            "first frame fits"
+        );
+        let started = std::time::Instant::now();
+        assert!(
+            !send_frame(&tx, Bytes::from_static(b"b"), Duration::from_millis(20)).await,
+            "full buffer must drop the slow client"
+        );
+        assert!(started.elapsed() < Duration::from_millis(200));
+    }
+}

--- a/crates/nika-serve/src/server/store.rs
+++ b/crates/nika-serve/src/server/store.rs
@@ -5,16 +5,21 @@ use std::sync::Arc;
 use std::thread::JoinHandle;
 
 use serde_json::Value;
-use tokio::sync::oneshot;
+use tokio::sync::{Notify, oneshot};
 
 use crate::{
-    Admission, IdempotencyKey, JobId, JobRecord, JobStatus, JobStore, JobStoreError, RequestDigest,
-    ServerIncarnation,
+    Admission, EventPageLimit, IdempotencyKey, JobEvent, JobId, JobRecord, JobStatus, JobStore,
+    JobStoreError, RequestDigest, ServerIncarnation,
 };
 
 use super::ServerError;
 
 type Reply<T> = oneshot::Sender<Result<T, JobStoreError>>;
+
+pub(super) struct EventPage {
+    pub events: Vec<JobEvent>,
+    pub status: JobStatus,
+}
 
 enum RequestCommand {
     Create {
@@ -26,6 +31,12 @@ enum RequestCommand {
     Get {
         id: JobId,
         reply: Reply<Option<JobRecord>>,
+    },
+    EventsAfter {
+        id: JobId,
+        after: u64,
+        limit: EventPageLimit,
+        reply: Reply<EventPage>,
     },
 }
 
@@ -53,6 +64,7 @@ enum ControlCommand {
 pub(super) struct StoreHandle {
     requests: std::sync::mpsc::SyncSender<RequestCommand>,
     controls: std::sync::mpsc::SyncSender<ControlCommand>,
+    events: Arc<Notify>,
 }
 
 impl StoreHandle {
@@ -76,6 +88,26 @@ impl StoreHandle {
         let (reply, answer) = oneshot::channel();
         self.send_request(RequestCommand::Get { id, reply })?;
         receive(answer).await
+    }
+
+    pub(super) async fn events_after(
+        &self,
+        id: JobId,
+        after: u64,
+        limit: EventPageLimit,
+    ) -> Result<EventPage, ServerError> {
+        let (reply, answer) = oneshot::channel();
+        self.send_request(RequestCommand::EventsAfter {
+            id,
+            after,
+            limit,
+            reply,
+        })?;
+        receive(answer).await
+    }
+
+    pub(super) fn event_notify(&self) -> Arc<Notify> {
+        Arc::clone(&self.events)
     }
 
     pub(super) async fn transition_with_events(
@@ -154,14 +186,26 @@ impl StoreActor {
     ) -> Result<Self, ServerError> {
         let (requests, request_receiver) = std::sync::mpsc::sync_channel(request_capacity);
         let (controls, control_receiver) = std::sync::mpsc::sync_channel(control_capacity);
+        let events = Arc::new(Notify::new());
+        let thread_events = Arc::clone(&events);
         let thread = std::thread::Builder::new()
             .name("nika-serve-store".to_owned())
             .spawn(move || {
-                serve_store(&request_receiver, &control_receiver, &store, &incarnation);
+                serve_store(
+                    &request_receiver,
+                    &control_receiver,
+                    &store,
+                    &incarnation,
+                    &thread_events,
+                );
             })
             .map_err(|_| ServerError::BlockingTask)?;
         Ok(Self {
-            handle: StoreHandle { requests, controls },
+            handle: StoreHandle {
+                requests,
+                controls,
+                events,
+            },
             thread: Some(thread),
         })
     }
@@ -188,10 +232,11 @@ fn serve_store(
     controls: &std::sync::mpsc::Receiver<ControlCommand>,
     store: &JobStore,
     incarnation: &ServerIncarnation,
+    events: &Notify,
 ) {
     loop {
         if let Ok(command) = controls.try_recv() {
-            if !serve_control(command, store, incarnation) {
+            if !serve_control(command, store, incarnation, events) {
                 break;
             }
             continue;
@@ -201,7 +246,7 @@ fn serve_store(
             Err(std::sync::mpsc::RecvTimeoutError::Timeout) => continue,
             Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => match controls.recv() {
                 Ok(command) => {
-                    if !serve_control(command, store, incarnation) {
+                    if !serve_control(command, store, incarnation, events) {
                         break;
                     }
                     continue;
@@ -227,6 +272,29 @@ fn dispatch_request(command: RequestCommand, store: &JobStore) {
         RequestCommand::Get { id, reply } => {
             let _result = reply.send(store.get(&id));
         }
+        RequestCommand::EventsAfter {
+            id,
+            after,
+            limit,
+            reply,
+        } => {
+            let result = store.events_after(&id, after, limit).and_then(|events| {
+                store
+                    .get(&id)?
+                    .ok_or(JobStoreError::JobNotFound(id))
+                    .map(|record| EventPage {
+                        events,
+                        status: record.status(),
+                    })
+            });
+            let _result = reply.send(result);
+        }
+    }
+}
+
+fn notify_persisted<T>(result: &Result<T, JobStoreError>, events: &Notify) {
+    if result.is_ok() {
+        events.notify_waiters();
     }
 }
 
@@ -234,6 +302,7 @@ fn serve_control(
     command: ControlCommand,
     store: &JobStore,
     incarnation: &ServerIncarnation,
+    events: &Notify,
 ) -> bool {
     match command {
         ControlCommand::Transition {
@@ -245,6 +314,7 @@ fn serve_control(
             let result = store
                 .transition_with_events(&id, status, std::slice::from_ref(&event))
                 .map(|mutation| mutation.record().clone());
+            notify_persisted(&result, events);
             let _result = reply.send(result);
         }
         ControlCommand::Interrupt { id, reply } => {
@@ -253,12 +323,15 @@ fn serve_control(
                 "status": "interrupted"
             });
             let result = store.interrupt_running(&id, incarnation, &payload);
+            notify_persisted(&result, events);
             if let Some(reply) = reply {
                 let _result = reply.send(result);
             }
         }
         ControlCommand::SettleInterrupted { reply } => {
-            let _result = reply.send(store.settle_interrupted_jobs(incarnation));
+            let result = store.settle_interrupted_jobs(incarnation);
+            notify_persisted(&result, events);
+            let _result = reply.send(result);
         }
         ControlCommand::Shutdown { reply } => {
             let _result = reply.send(());

--- a/crates/nika-serve/src/server/tests.rs
+++ b/crates/nika-serve/src/server/tests.rs
@@ -1021,6 +1021,214 @@ async fn wait_for_calls(backend: &TestBackend, expected: usize) -> Result<(), St
     Err(format!("backend never reached {expected} calls"))
 }
 
+fn one_sse_limits() -> ServerLimits {
+    limits().with_max_sse_clients(1)
+}
+
+fn live_sse_limits() -> ServerLimits {
+    ServerLimits::new(
+        1024,
+        Duration::from_millis(80),
+        Duration::from_secs(2),
+        Duration::from_millis(200),
+        2,
+        8,
+        64,
+        32,
+    )
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn job_events_are_authenticated_allowlisted_and_resumable() {
+    let world = TestWorld::new();
+    let backend = Arc::new(TestBackend::completes(ExecutionDisposition::Succeeded));
+    let server = world.start(backend, limits()).await;
+    let created = server
+        .request(&post_request(
+            r#"{"workflow":"root.nika.yaml"}"#,
+            "sse-complete",
+            &auth_header(),
+        ))
+        .await;
+    let id = created.json()["id"].as_str().expect("id").to_owned();
+    wait_for_status(&server, &id, "succeeded")
+        .await
+        .expect("succeeded");
+
+    let unauth = server
+        .request(&format!(
+            "GET /v1/jobs/{id}/events HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
+        ))
+        .await;
+    assert_eq!(unauth.status, 401, "{}", unauth.body);
+    assert!(!unauth.body.contains(TOKEN));
+
+    let streamed = server.request(&events_request(&id, None)).await;
+    assert_eq!(streamed.status, 200, "{}", streamed.body);
+    assert!(
+        streamed
+            .headers
+            .to_ascii_lowercase()
+            .contains("content-type: text/event-stream")
+    );
+    let events = parse_sse_data(&streamed.body);
+    assert!(!events.is_empty(), "{}", streamed.body);
+    for event in &events {
+        assert_allowlisted(event);
+    }
+    assert_eq!(events[0]["sequence"], 1);
+
+    let resumed = server.request(&events_request(&id, Some("1"))).await;
+    let resumed_events = parse_sse_data(&resumed.body);
+    assert!(
+        resumed_events.iter().all(|event| event["sequence"] != 1),
+        "{}",
+        resumed.body
+    );
+
+    let future = server.request(&events_request(&id, Some("99"))).await;
+    assert_eq!(future.status, 400, "{}", future.body);
+    assert_eq!(future.json()["error"]["code"], "cursor_beyond_latest");
+
+    for cursor in ["nope", "01", "+1", "1.5", ""] {
+        let invalid = server.request(&events_request(&id, Some(cursor))).await;
+        assert_eq!(invalid.status, 400, "{cursor}: {}", invalid.body);
+        assert_eq!(invalid.json()["error"]["code"], "invalid_cursor");
+    }
+    let duplicate = format!(
+        "GET /v1/jobs/{id}/events HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n{}Last-Event-ID: 1\r\nLast-Event-ID: 1\r\n\r\n",
+        auth_header()
+    );
+    let duplicate = server.request(&duplicate).await;
+    assert_eq!(duplicate.status, 400);
+    assert_eq!(duplicate.json()["error"]["code"], "invalid_cursor");
+
+    let cancel = server
+        .request(&get_request(&format!("/v1/jobs/{id}/cancel")))
+        .await;
+    let artifacts = server
+        .request(&get_request(&format!("/v1/jobs/{id}/artifacts")))
+        .await;
+    assert_eq!(cancel.status, 404);
+    assert_eq!(artifacts.status, 404);
+    server.stop().await.expect("clean stop");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn sse_outlives_request_timeout_and_disconnect_does_not_block_execution() {
+    let world = TestWorld::new();
+    let backend = Arc::new(GatedBackend::new());
+    let server = world.start(backend.clone(), live_sse_limits()).await;
+    let created = server
+        .request(&post_request(
+            r#"{"workflow":"root.nika.yaml"}"#,
+            "sse-live",
+            &auth_header(),
+        ))
+        .await;
+    assert_eq!(created.status, 202, "{}", created.body);
+    let id = created.json()["id"].as_str().expect("id").to_owned();
+    wait_for_status(&server, &id, "running")
+        .await
+        .expect("running");
+
+    let (mut stream, headers) = open_sse(server.address, &events_request(&id, None)).await;
+    assert_eq!(headers.status, 200, "{}", headers.body);
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    let events = collect_sse(&mut stream, headers.body, 1).await;
+    assert_eq!(events[0]["kind"], "execution.started");
+    assert_allowlisted(&events[0]);
+    drop(stream);
+
+    backend.release(1);
+    wait_for_status(&server, &id, "succeeded")
+        .await
+        .expect("execution continued after sse drop");
+    server.stop().await.expect("clean stop");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn sse_client_ceiling_refuses_the_next_stream() {
+    let world = TestWorld::new();
+    let backend = Arc::new(GatedBackend::new());
+    let server = world.start(backend.clone(), one_sse_limits()).await;
+    let created = server
+        .request(&post_request(
+            r#"{"workflow":"root.nika.yaml"}"#,
+            "sse-cap",
+            &auth_header(),
+        ))
+        .await;
+    let id = created.json()["id"].as_str().expect("id").to_owned();
+    wait_for_status(&server, &id, "running")
+        .await
+        .expect("running");
+
+    let (stream, first) = open_sse(server.address, &events_request(&id, None)).await;
+    assert_eq!(first.status, 200, "{}", first.body);
+    let second = server.request(&events_request(&id, None)).await;
+    assert_eq!(second.status, 503, "{}", second.body);
+    assert_eq!(second.json()["error"]["code"], "sse_capacity");
+    let status = server
+        .request(&get_request(&format!("/v1/jobs/{id}/status")))
+        .await;
+    assert_eq!(status.status, 200);
+
+    drop(stream);
+    tokio::time::sleep(Duration::from_millis(30)).await;
+    let (replacement, recovered) = open_sse(server.address, &events_request(&id, None)).await;
+    assert_eq!(recovered.status, 200, "{}", recovered.body);
+    drop(replacement);
+    backend.release(1);
+    wait_for_status(&server, &id, "succeeded")
+        .await
+        .expect("settled");
+    server.stop().await.expect("clean stop");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn interrupted_event_stream_redacts_payload_fields() {
+    let world = TestWorld::new();
+    let hanging = Arc::new(TestBackend::hangs());
+    let first = world.start(hanging.clone(), short_shutdown_limits()).await;
+    let created = first
+        .request(&post_request(
+            r#"{"workflow":"root.nika.yaml"}"#,
+            "sse-redact",
+            &auth_header(),
+        ))
+        .await;
+    let id = created.json()["id"].as_str().expect("id").to_owned();
+    wait_for_status(&first, &id, "running")
+        .await
+        .expect("running");
+    wait_for_calls(hanging.as_ref(), 1)
+        .await
+        .expect("hanging backend entered execute");
+    assert!(matches!(
+        first.stop().await,
+        Err(ServerError::ShutdownTimeout)
+    ));
+
+    let replacement = Arc::new(TestBackend::completes(ExecutionDisposition::Succeeded));
+    let second = world.start(replacement, limits()).await;
+    wait_for_status(&second, &id, "interrupted")
+        .await
+        .expect("interrupted");
+    let streamed = second.request(&events_request(&id, None)).await;
+    assert_eq!(streamed.status, 200, "{}", streamed.body);
+    let events = parse_sse_data(&streamed.body);
+    assert!(!events.is_empty(), "{}", streamed.body);
+    for event in &events {
+        assert_allowlisted(event);
+        assert!(event.get("incarnation_generation").is_none());
+        assert!(event.get("previous_incarnation_generation").is_none());
+        assert!(!streamed.body.contains(TOKEN));
+        assert!(!streamed.body.contains("/jobs"));
+    }
+    second.stop().await.expect("clean stop");
+}
+
 async fn wait_for_status(server: &TestServer, id: &str, expected: &str) -> Result<(), String> {
     for _ in 0..200 {
         let response = server
@@ -1056,6 +1264,71 @@ fn get_request(path: &str) -> String {
         "GET {path} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n{}\r\n",
         auth_header()
     )
+}
+
+fn events_request(id: &str, last_event_id: Option<&str>) -> String {
+    let last = last_event_id
+        .map(|cursor| format!("Last-Event-ID: {cursor}\r\n"))
+        .unwrap_or_default();
+    format!(
+        "GET /v1/jobs/{id}/events HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n{}{last}\r\n",
+        auth_header()
+    )
+}
+
+fn parse_sse_data(body: &str) -> Vec<Value> {
+    let mut events = Vec::new();
+    for block in body.split("\n\n") {
+        for line in block.lines() {
+            if let Some(data) = line.strip_prefix("data: ") {
+                events.push(serde_json::from_str(data).expect("sse json"));
+            }
+        }
+    }
+    events
+}
+
+fn assert_allowlisted(event: &Value) {
+    let object = event.as_object().expect("event object");
+    assert_eq!(object.len(), 3, "{event}");
+    assert!(object.contains_key("sequence"), "{event}");
+    assert!(object.contains_key("kind"), "{event}");
+    assert!(object.contains_key("status"), "{event}");
+}
+
+async fn open_sse(address: SocketAddr, request: &str) -> (tokio::net::TcpStream, WireResponse) {
+    let mut stream = tokio::net::TcpStream::connect(address)
+        .await
+        .expect("connect");
+    stream.write_all(request.as_bytes()).await.expect("write");
+    let mut buf = Vec::new();
+    while !buf.windows(4).any(|window| window == b"\r\n\r\n") {
+        let mut chunk = [0; 512];
+        let n = stream.read(&mut chunk).await.expect("header read");
+        assert!(n > 0, "eof before headers");
+        buf.extend_from_slice(&chunk[..n]);
+    }
+    (stream, WireResponse::parse(&buf))
+}
+
+async fn collect_sse(
+    stream: &mut tokio::net::TcpStream,
+    mut body: String,
+    min: usize,
+) -> Vec<Value> {
+    for _ in 0..200 {
+        let events = parse_sse_data(&body);
+        if events.len() >= min {
+            return events;
+        }
+        let mut chunk = [0; 512];
+        match tokio::time::timeout(Duration::from_millis(20), stream.read(&mut chunk)).await {
+            Ok(Ok(0)) => break,
+            Ok(Ok(n)) => body.push_str(std::str::from_utf8(&chunk[..n]).expect("utf8")),
+            _ => {}
+        }
+    }
+    parse_sse_data(&body)
 }
 
 fn auth_header() -> String {

--- a/docs/crate-specs/nika-serve.md
+++ b/docs/crate-specs/nika-serve.md
@@ -2,7 +2,7 @@
 
 | | |
 |---|---|
-| Status | **WORKSPACE WIP — W06 AUTHENTICATED HTTP**. Durable jobs plus bounded loopback HTTP are present; SSE, OpenAPI/SDK, and full 12-gate admission remain later carriers. |
+| Status | **WORKSPACE WIP — W07 SSE**. Durable jobs plus bounded loopback HTTP and an authenticated job-event SSE projection are present; OpenAPI/SDK and full 12-gate admission remain later carriers. |
 | Layer | L4 — remote execution interface projection |
 | Purpose | Persist request admission, lifecycle status, and resumable event cursors, and project the first authenticated HTTP routes over that state. |
 | LOC budget | ≤5,000 source lines for the state plane; ≤15,000 hard crate cap. |
@@ -20,7 +20,8 @@
 authority required by ADR-117. W05 established its state plane. W06 adds a
 real Hyper/Tokio TCP listener, deny-by-default Bearer authentication, a
 held `.nika.yaml` registry, `ExecutionService` admission, an injected
-`ExecutionBackend` seam, and the first job/workflow routes. It does not
+`ExecutionBackend` seam, and the first job/workflow routes. W07 projects
+the durable job journal over `GET /v1/jobs/{id}/events` as SSE. It does not
 import `nika-cli`. Default `nika serve` remains the resident ARM firer.
 The CLI admits the `--bind` + `--workflows` + `--token-file` pair (and
 refuses `--once`/`--dry` with bind); `nika_serve::serve_http` is the
@@ -69,7 +70,7 @@ becomes a child name.
   adapters parse opaque ids with `JobId::parse`.
 - `ServerConfig` requires bind, workflow root, state root, and token-file
   source. `ServerLimits` names body, request, execution, shutdown,
-  active-job, queue, connection, header, and durable-job ceilings.
+  active-job, queue, connection, SSE-client, header, and durable-job ceilings.
 - `BoundServer::bind` validates and acquires all authority before listening;
   `serve_until` stops admission and gives active jobs a bounded grace period.
 - `ExecutionBackend` receives only `ExecutionContext` over the immutable
@@ -89,10 +90,16 @@ No public job mutation accepts a filesystem path. Startup paths live only in
 | `POST` | `/v1/jobs` | exactly one Bearer + `Idempotency-Key` | opaque id + status |
 | `GET` | `/v1/jobs/{id}` | exactly one Bearer | opaque id + status |
 | `GET` | `/v1/jobs/{id}/status` | exactly one Bearer | status only |
+| `GET` | `/v1/jobs/{id}/events` | exactly one Bearer | SSE `text/event-stream`; `id:` sequence; `data:` `{sequence,kind,status}` |
 
 Cancel and artifact routes return 404. No route returns source bytes,
 idempotency keys, request digests, event payloads, provider/tool data, paths,
 token material, or internal error text. CORS headers are not emitted.
+`Last-Event-ID` resumes after that sequence. An invalid cursor is 400; a
+cursor beyond the latest persisted sequence is a typed 400. The request
+timeout does not bound an open event stream. Events become visible only
+after durable persist. A slow client is dropped rather than stalling
+execution.
 
 On Unix, the token file must be opened no-follow/nonblocking as a regular
 owner-only file. It contains 32–512 visible ASCII bytes (one trailing line
@@ -197,7 +204,7 @@ Inline library tests cover:
 - sentinel-root debug non-disclosure;
 - payload, batch, snapshot, and page boundary refusals without durable mutation.
 - real loopback HTTP health, workflow list/metadata, job-create, job-read,
-  and status requests;
+  status, and job-event SSE requests;
 - valid authentication plus uniform missing, duplicate, malformed, wrong, and
   oversized credential refusal;
 - auth-before-parse, invalid JSON/content type, coarse and streaming body
@@ -211,8 +218,12 @@ Inline library tests cover:
 - exact active-run and queued-job boundaries, durable job capacity, exact and
   excess header counts, connection saturation, credential FIFO refusal, and
   fail-fast store contention followed by clean incarnation release.
+- SSE Bearer-before-lookup, allowlisted `{sequence,kind,status}` frames,
+  `Last-Event-ID` resume, invalid and future cursors, request-timeout bypass,
+  slow-client drop, disconnect without blocking execution, SSE client ceiling,
+  and redaction of payload extras including interrupted incarnation fields.
 
-The W05/W06 focused command contract is:
+The W05/W07 focused command contract is:
 
 ```bash
 cargo test -p nika-serve --lib
@@ -243,7 +254,7 @@ admission wave closes the gates whose authority does not exist in W05.
 
 ## 6. Explicit non-goals
 
-No SSE · no TLS · no OpenAPI/SDK projection · no workflow upload · no
+No TLS · no OpenAPI/SDK projection · no workflow upload · no
 cancellation · no artifact authority · no automatic retry of interrupted
 execution. The store records the lost ownership but cannot prove whether an
 effect committed before the crash. W05 also provides no concrete durable

--- a/docs/security/nika-serve-threat-model.md
+++ b/docs/security/nika-serve-threat-model.md
@@ -1,8 +1,9 @@
 # `nika serve` network threat model
 
 **Status:** binding design boundary for ADR-117; W06 admits authenticated
-loopback HTTP. A checked box in this document means the implementation and
-its test exist, not merely that the design mentions them.
+loopback HTTP and W07 projects the durable job journal over SSE. A checked
+box in this document means the implementation and its test exist, not
+merely that the design mentions them.
 
 ## Security objective
 
@@ -211,7 +212,7 @@ transcript is claimed where no such test existed on that SHA.
 - [x] opaque job guessing and unknown ids disclose no registry membership;
 - [ ] `paused` round-trips through Rust, OpenAPI, fixtures, and TypeScript
   (Rust HTTP projection is proven; OpenAPI/TypeScript remain a later carrier);
-- [ ] SSE auth, resume, stale/future cursors, lag overflow, disconnect, and
+- [x] SSE auth, resume, stale/future cursors, lag overflow, disconnect, and
   redaction are deterministic;
 - [ ] protected responses/logs contain no credential, private path, provider raw
   payload, workflow bytes, or secret-shaped fixture;


### PR DESCRIPTION
## W07 SSE

Projects the existing JobStore journal over `GET /v1/jobs/{id}/events`.

- Same Bearer as other `/v1` routes, auth before lookup
- Frames are allowlisted JSON `{sequence, kind, status}` — no payloads, secrets, or paths
- `Last-Event-ID` resume; invalid cursor 400; beyond latest typed 400
- Request timeout does not bound an open stream; slow client dropped
- Notify waiters only after successful persist
- Cancel and artifact routes stay 404 (W08 authorities are incomplete)
- Stop gitignoring the admitted `nika-serve` crate

64 `nika-serve --lib` tests green locally. Reviewer PASS_WITH_FOLLOWUPS (keepalive later). Refuter SURVIVED.

Does not include OpenAPI/SDK (W09) or a release tag (W12).