### PR TITLE
feat(cli): show nika serve on the help surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
 ---
 ## [Unreleased]
 
+### Added
+
+- **`nika serve --bind` is authenticated loopback HTTP.** Pair it with
+  `--workflows` and `--token-file` (credential bytes never enter argv).
+  Default `nika serve` is still the resident ARM firer. The verb is on
+  `nika --help`. Listen line prints the bound address, including port 0.
+  Job cancel and artifacts stay 404 until those authorities exist.
+
 ### Changed
 
 - **`nika check` names the ancestor `nika.yaml` spend cap.** `nika run`

--- a/crates/nika-cli/src/main.rs
+++ b/crates/nika-cli/src/main.rs
@@ -193,8 +193,10 @@ enum Command {
     /// disposes). Exit `0` clean · `2` the registry refuses.
     #[command(display_order = 72)]
     Arm(verbs::arm::args::ArmArgs),
-    /// The resident firer: the SAME `fire`, the wall clock in place of the OS (W5). Exit `0` clean · `1` otherwise.
-    #[command(hide = true, display_order = 73)]
+    /// Resident ARM firer by default (the SAME `fire`, wall clock in place of the OS).
+    /// `--bind` + `--workflows` + `--token-file` opens authenticated loopback HTTP.
+    /// Exit `0` clean · `1` otherwise.
+    #[command(display_order = 73)]
     Serve(verbs::serve::ServeArgs),
     /// Sign a workflow file (S3 · author-binding): mint `<file>.minisig` · `--check` verifies.
     #[command(hide = true, display_order = 71)]

--- a/crates/nika-cli/src/main.rs
+++ b/crates/nika-cli/src/main.rs
@@ -1168,10 +1168,10 @@ mod tests {
     /// THE LAW (RAMS-13 · census over 19 personas: 12 of 23 verbs
     /// reached by <=1 user, yet all 23 hit 11 first-timers in the
     /// face): the default help shows exactly the 13 craft verbs plus
-    /// `arm`; the full tree stays one flag away (`--help --all`) and
-    /// NOTHING is removed — visible + hidden is the whole enum,
-    /// invariant. Ranged, never deleted: `key`/`sign`/`mcp`/`lsp`
-    /// serve — just not on day one.
+    /// the documented doors `arm` and `serve`; the full tree stays one
+    /// flag away (`--help --all`) and NOTHING is removed — visible +
+    /// hidden is the whole enum, invariant. Ranged, never deleted:
+    /// `key`/`sign`/`mcp`/`lsp` — just not on day one.
     #[test]
     fn the_default_help_shows_the_craft_plus_arm_and_hides_nothing_forever() {
         let cmd = <Cli as clap::CommandFactory>::command();
@@ -1186,22 +1186,24 @@ mod tests {
             .collect();
         let expected: std::collections::BTreeSet<&str> = [
             "try", "new", "init", "list", "check", "run", "test", "trace", "welcome", "doctor",
-            "model", "wire", "explain", "arm",
+            "model", "wire", "explain", "arm", "serve",
         ]
         .into_iter()
         .collect();
         assert_eq!(
             visible, expected,
-            "the default range is exactly the craft plus the documented `arm` door"
+            "the default range is exactly the craft plus the documented `arm` and `serve` doors"
         );
         let help = <Cli as clap::CommandFactory>::command()
             .render_help()
             .to_string();
-        assert!(
-            help.lines()
-                .any(|line| line.split_whitespace().next() == Some("arm")),
-            "`nika --help` must show the documented `arm` door: {help}"
-        );
+        for door in ["arm", "serve"] {
+            assert!(
+                help.lines()
+                    .any(|line| line.split_whitespace().next() == Some(door)),
+                "`nika --help` must show the documented `{door}` door: {help}"
+            );
+        }
         let hidden = cmd
             .get_subcommands()
             .filter(|c| c.is_hide_set() && c.get_name() != "help")


### PR DESCRIPTION
## Why

W06 HTTP shipped with `nika serve` still `hide = true`, so `nika --help` never named the verb a user must type with `--bind` + `--workflows` + `--token-file`.

## Change

- Unhide `serve` next to `arm`
- Docstring: resident ARM firer by default; HTTP is the three-flag pair
- CHANGELOG Unreleased records loopback HTTP; cancel/artifacts stay 404

Default `nika serve` is unchanged (no socket).