### PR TITLE
feat(serve): publish the live routes as openapi 3.1

### DIFF
--- a/crates/nika-serve/src/server/mod.rs
+++ b/crates/nika-serve/src/server/mod.rs
@@ -5,6 +5,7 @@ mod auth;
 mod config;
 mod error;
 mod model;
+mod openapi;
 mod registry;
 mod route;
 mod sse;

--- a/crates/nika-serve/src/server/openapi.rs
+++ b/crates/nika-serve/src/server/openapi.rs
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+use serde_json::{Value, json};
+
+/// [`OpenAPI`](https://spec.openapis.org/oas/v3.1.0) document of the live HTTP surface.
+///
+/// Cancel and artifact paths are omitted until those authorities exist.
+pub(crate) fn document() -> Value {
+    json!({
+        "openapi": "3.1.0",
+        "info": {
+            "title": "nika serve",
+            "version": env!("CARGO_PKG_VERSION"),
+            "description": "Authenticated loopback remote execution. Cancel and artifacts are absent."
+        },
+        "servers": [{"url": "http://127.0.0.1"}],
+        "security": [{"bearerAuth": []}],
+        "components": components(),
+        "paths": paths(),
+    })
+}
+
+fn components() -> Value {
+    json!({
+        "securitySchemes": {
+            "bearerAuth": {
+                "type": "http",
+                "scheme": "bearer",
+                "description": "Exactly one Authorization: Bearer value from the token file"
+            }
+        },
+        "parameters": {
+            "IdempotencyKey": {
+                "name": "Idempotency-Key",
+                "in": "header",
+                "required": true,
+                "schema": {"type": "string", "minLength": 1, "maxLength": 255}
+            },
+            "LastEventId": {
+                "name": "Last-Event-ID",
+                "in": "header",
+                "required": false,
+                "schema": {"type": "string", "pattern": "^(0|[1-9][0-9]*)$"}
+            }
+        },
+        "schemas": {
+            "JobStatus": {
+                "type": "string",
+                "enum": ["queued", "running", "interrupted", "paused", "succeeded", "failed"]
+            },
+            "Job": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["id", "status"],
+                "properties": {
+                    "id": {"type": "string", "format": "uuid"},
+                    "status": {"$ref": "#/components/schemas/JobStatus"}
+                }
+            },
+            "JobStatusOnly": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["status"],
+                "properties": {
+                    "status": {"$ref": "#/components/schemas/JobStatus"}
+                }
+            },
+            "CreateJob": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["workflow"],
+                "properties": {
+                    "workflow": {"type": "string"}
+                }
+            },
+            "Error": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["error"],
+                "properties": {
+                    "error": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": ["code", "message"],
+                        "properties": {
+                            "code": {"type": "string"},
+                            "message": {"type": "string"}
+                        }
+                    }
+                }
+            }
+        }
+    })
+}
+
+fn paths() -> Value {
+    json!({
+        "/health": {
+            "get": {
+                "security": [],
+                "summary": "Public process liveness",
+                "responses": {"200": {"description": "Engine identity only"}}
+            }
+        },
+        "/v1/openapi.json": {
+            "get": {
+                "summary": "This document",
+                "responses": {
+                    "200": {"description": "OpenAPI 3.1"},
+                    "401": {"description": "Bearer required"}
+                }
+            }
+        },
+        "/v1/workflows": {
+            "get": {
+                "summary": "Contained workflow names",
+                "responses": {"200": {"description": "Relative .nika.yaml names"}, "401": error_ref()}
+            }
+        },
+        "/v1/workflows/{name}": {
+            "get": {
+                "summary": "Workflow metadata without source bytes",
+                "parameters": [{"name": "name", "in": "path", "required": true, "schema": {"type": "string"}}],
+                "responses": {"200": {"description": "Contained name"}, "401": error_ref(), "404": error_ref()}
+            }
+        },
+        "/v1/jobs": {
+            "post": {
+                "summary": "Admit a job",
+                "parameters": [{"$ref": "#/components/parameters/IdempotencyKey"}],
+                "requestBody": {
+                    "required": true,
+                    "content": {"application/json": {"schema": {"$ref": "#/components/schemas/CreateJob"}}}
+                },
+                "responses": {
+                    "202": {"description": "Created", "content": json_job()},
+                    "200": {"description": "Idempotent replay", "content": json_job()},
+                    "401": error_ref()
+                }
+            }
+        },
+        "/v1/jobs/{id}": {
+            "get": {
+                "summary": "Job identity and status",
+                "parameters": [job_id_param()],
+                "responses": {
+                    "200": {"description": "Job", "content": json_job()},
+                    "401": error_ref(),
+                    "404": error_ref()
+                }
+            }
+        },
+        "/v1/jobs/{id}/status": {
+            "get": {
+                "summary": "Status only",
+                "parameters": [job_id_param()],
+                "responses": {
+                    "200": {"description": "Status", "content": json_status()},
+                    "401": error_ref(),
+                    "404": error_ref()
+                }
+            }
+        },
+        "/v1/jobs/{id}/events": {
+            "get": {
+                "summary": "Job event SSE",
+                "parameters": [
+                    job_id_param(),
+                    {"$ref": "#/components/parameters/LastEventId"}
+                ],
+                "responses": {
+                    "200": {"description": "text/event-stream; data is {sequence,kind,status}"},
+                    "400": error_ref(),
+                    "401": error_ref(),
+                    "404": error_ref()
+                }
+            }
+        }
+    })
+}
+
+fn job_id_param() -> Value {
+    json!({"name": "id", "in": "path", "required": true, "schema": {"type": "string", "format": "uuid"}})
+}
+
+fn json_job() -> Value {
+    json!({"application/json": {"schema": {"$ref": "#/components/schemas/Job"}}})
+}
+
+fn json_status() -> Value {
+    json!({"application/json": {"schema": {"$ref": "#/components/schemas/JobStatusOnly"}}})
+}
+
+fn error_ref() -> Value {
+    json!({"description": "Error envelope", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}})
+}
+
+#[cfg(test)]
+mod tests {
+    use super::document;
+
+    const LIVE_PATHS: &[&str] = &[
+        "/health",
+        "/v1/workflows",
+        "/v1/workflows/{name}",
+        "/v1/jobs",
+        "/v1/jobs/{id}",
+        "/v1/jobs/{id}/status",
+        "/v1/jobs/{id}/events",
+        "/v1/openapi.json",
+    ];
+
+    const ABSENT_PATHS: &[&str] = &["/v1/jobs/{id}/cancel", "/v1/jobs/{id}/artifacts", "/v1/run"];
+
+    #[test]
+    fn document_is_openapi_31_and_lists_only_live_paths() {
+        let spec = document();
+        assert_eq!(spec["openapi"], "3.1.0");
+        let paths = spec["paths"].as_object().expect("paths");
+        for path in LIVE_PATHS {
+            assert!(paths.contains_key(*path), "missing {path}");
+        }
+        for path in ABSENT_PATHS {
+            assert!(!paths.contains_key(*path), "must stay absent: {path}");
+        }
+        let rendered = spec.to_string();
+        assert!(!rendered.contains("s3cret"));
+        assert!(!rendered.contains("Bearer token-value"));
+        assert!(!rendered.contains("/v1/run"));
+    }
+}

--- a/crates/nika-serve/src/server/route.rs
+++ b/crates/nika-serve/src/server/route.rs
@@ -76,6 +76,9 @@ async fn route_authenticated(
     let path = request.uri().path().to_owned();
     match (request.method(), path.as_str()) {
         (&Method::POST, "/v1/jobs") => create_job(request, state).await,
+        (&Method::GET, "/v1/openapi.json") => {
+            json_response(StatusCode::OK, &super::openapi::document())
+        }
         (&Method::GET, "/v1/workflows") => list_registry(&state).await,
         (&Method::GET, path) if path.starts_with("/v1/workflows/") => {
             workflow_metadata(path, &state).await

--- a/crates/nika-serve/src/server/tests.rs
+++ b/crates/nika-serve/src/server/tests.rs
@@ -1372,6 +1372,28 @@ impl WireResponse {
     }
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn openapi_is_authenticated_and_omits_absent_authorities() {
+    let world = TestWorld::new();
+    let backend = Arc::new(TestBackend::completes(ExecutionDisposition::Succeeded));
+    let server = world.start(backend, limits()).await;
+    let unauth = server
+        .request("GET /v1/openapi.json HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+        .await;
+    assert_eq!(unauth.status, 401);
+    assert!(!unauth.body.contains(TOKEN));
+    let spec = server.request(&get_request("/v1/openapi.json")).await;
+    assert_eq!(spec.status, 200, "{}", spec.body);
+    let body = spec.json();
+    assert_eq!(body, super::openapi::document());
+    assert_eq!(body["openapi"], "3.1.0");
+    assert!(body["paths"].get("/v1/jobs").is_some());
+    assert!(body["paths"].get("/v1/jobs/{id}/events").is_some());
+    assert!(body["paths"].get("/v1/jobs/{id}/cancel").is_none());
+    assert!(body["paths"].get("/v1/jobs/{id}/artifacts").is_none());
+    server.stop().await.expect("clean stop");
+}
+
 #[cfg(unix)]
 fn secure_file(path: &std::path::Path) {
     use std::os::unix::fs::PermissionsExt as _;

--- a/docs/crate-specs/nika-serve.md
+++ b/docs/crate-specs/nika-serve.md
@@ -2,7 +2,7 @@
 
 | | |
 |---|---|
-| Status | **WORKSPACE WIP — W07 SSE**. Durable jobs plus bounded loopback HTTP and an authenticated job-event SSE projection are present; OpenAPI/SDK and full 12-gate admission remain later carriers. |
+| Status | **WORKSPACE WIP — W09 OPENAPI**. Durable jobs, loopback HTTP, SSE, and an authenticated OpenAPI 3.1 document of the live routes. SDK retarget and 12-gate admission remain later. |
 | Layer | L4 — remote execution interface projection |
 | Purpose | Persist request admission, lifecycle status, and resumable event cursors, and project the first authenticated HTTP routes over that state. |
 | LOC budget | ≤5,000 source lines for the state plane; ≤15,000 hard crate cap. |
@@ -91,6 +91,7 @@ No public job mutation accepts a filesystem path. Startup paths live only in
 | `GET` | `/v1/jobs/{id}` | exactly one Bearer | opaque id + status |
 | `GET` | `/v1/jobs/{id}/status` | exactly one Bearer | status only |
 | `GET` | `/v1/jobs/{id}/events` | exactly one Bearer | SSE `text/event-stream`; `id:` sequence; `data:` `{sequence,kind,status}` |
+| `GET` | `/v1/openapi.json` | exactly one Bearer | OpenAPI 3.1 document of the live routes |
 
 Cancel and artifact routes return 404. No route returns source bytes,
 idempotency keys, request digests, event payloads, provider/tool data, paths,

--- a/docs/security/nika-serve-threat-model.md
+++ b/docs/security/nika-serve-threat-model.md
@@ -75,12 +75,13 @@ alone.
 | `/v1/workflows/{name}` | no | no | Bearer auth; contained relative name metadata; no source bytes |
 | `/v1/jobs/{opaque-id}` | no | no | Bearer auth before lookup; uniform unknown-id response |
 | `/v1/jobs/{opaque-id}/events` | no | no | Bearer auth; bounded SSE buffer; monotonic `Last-Event-ID`; redaction |
+| `GET /v1/openapi.json` | no | no | Bearer auth; live-route document; no credential examples; no cancel/artifact paths |
 | effecting `/v1/*` POST | no | yes | auth before parse; body limit; content type; idempotency before execution |
 | cancel routes | absent | — | remain absent until typed runtime cancellation settles terminal state |
 | artifact routes | absent | — | remain absent until a held typed artifact manifest exists |
 
-The exact route spelling beyond `/health` and the `/v1` authority prefix is
-owned by the later OpenAPI carrier. Adding a route cannot weaken this table.
+Adding a route cannot weaken this table. The OpenAPI document is a projection
+of the live routes, never a second authority.
 
 ## Required controls
 


### PR DESCRIPTION
## W09.A OpenAPI

`GET /v1/openapi.json` (Bearer) returns OpenAPI 3.1 built from the live HTTP surface.

- Paths: `/health`, workflows, jobs, status, events, this document
- Cancel and artifacts omitted
- No credential examples
- 66 `nika-serve --lib` tests

SDK retarget (`POST /v1/run` → `POST /v1/jobs`) is a follow-up on nika-client.