### PR TITLE
feat(cli): doctor names the serve http door

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
   Default `nika serve` is still the resident ARM firer. The verb is on
   `nika --help`. Listen line prints the bound address, including port 0.
   Job cancel and artifacts stay 404 until those authorities exist.
+- **`nika doctor` names the HTTP door when a token file is present.**
+  Owner-only mode is OK; group/world-readable is a fail with the umask
+  077 fix. The row never claims TLS — that is the reverse proxy.
+  Silent when the cwd has no `.nika/serve.token` (the door is opt-in).
+  systemd and Caddy examples live in `docs/ops/`.
 
 ### Changed
 

--- a/crates/nika-cli-host/src/doctor.rs
+++ b/crates/nika-cli-host/src/doctor.rs
@@ -122,6 +122,9 @@ pub fn diagnose(probe: &Probe) -> Vec<Finding> {
     out.push(sandbox_finding(&crate::probe::sandbox_probe()));
     out.extend(sidecar_finding());
     out.extend(models_finding(&probe.models));
+    if let Ok(cwd) = std::env::current_dir() {
+        out.extend(serve_http_door(&cwd));
+    }
 
     for client in &probe.clients {
         out.push(client_finding(client, &probe.kits));
@@ -236,6 +239,48 @@ fn provider_findings(probe: &Probe, out: &mut Vec<Finding>) {
             ),
         });
     }
+}
+
+/// HTTP door readiness. Silent when the cwd has no token file — the
+/// door is opt-in. Never claims TLS: this process does not terminate it.
+pub(crate) fn serve_http_door(root: &std::path::Path) -> Vec<Finding> {
+    let token = root.join(".nika/serve.token");
+    if !token.is_file() {
+        return Vec::new();
+    }
+    if let Some(finding) = serve_token_group_readable(&token) {
+        return vec![finding];
+    }
+    vec![Finding {
+        level: Level::Ok,
+        label: "serve".to_owned(),
+        detail: "token owner-only · TLS is the reverse proxy's job \
+                 (this process does not terminate TLS)"
+            .to_owned(),
+        fix: None,
+    }]
+}
+
+#[cfg(unix)]
+fn serve_token_group_readable(path: &std::path::Path) -> Option<Finding> {
+    use std::os::unix::fs::PermissionsExt as _;
+    let mode = std::fs::metadata(path).ok()?.permissions().mode();
+    // Unix other/group bits; same mask as nika-serve BearerToken.
+    #[allow(clippy::verbose_bit_mask)]
+    if mode & 0o077 == 0 {
+        return None;
+    }
+    Some(Finding {
+        level: Level::Fail,
+        label: "serve".to_owned(),
+        detail: "token file is group/world-readable — `nika serve` will refuse it".to_owned(),
+        fix: Some("umask 077 && chmod 600 .nika/serve.token".to_owned()),
+    })
+}
+
+#[cfg(not(unix))]
+fn serve_token_group_readable(_path: &std::path::Path) -> Option<Finding> {
+    None
 }
 
 /// The sovereign sidecar lane (ADR-091) — a row ONLY when this binary was

--- a/crates/nika-cli-host/src/doctor/tests.rs
+++ b/crates/nika-cli-host/src/doctor/tests.rs
@@ -1403,3 +1403,46 @@ fn a_noop_backend_warns_with_the_exact_fix() {
         assert!(fix.contains("sandbox-exec"), "{fix}");
     }
 }
+
+#[test]
+fn serve_row_is_silent_without_a_token_file() {
+    let dir = temp_dir("serve-absent");
+    assert!(serve_http_door(&dir).is_empty());
+}
+
+#[cfg(unix)]
+#[test]
+fn serve_row_fails_when_the_token_is_world_readable() {
+    use std::os::unix::fs::PermissionsExt as _;
+    let dir = temp_dir("serve-mode");
+    let nika = dir.join(".nika");
+    std::fs::create_dir(&nika).expect("nika dir");
+    let token = nika.join("serve.token");
+    std::fs::write(&token, "x".repeat(40)).expect("token");
+    std::fs::set_permissions(&token, std::fs::Permissions::from_mode(0o644)).expect("mode");
+    let rows = serve_http_door(&dir);
+    assert_eq!(rows[0].level, Level::Fail);
+    assert!(
+        rows[0]
+            .fix
+            .as_deref()
+            .is_some_and(|f| f.contains("chmod 600"))
+    );
+    assert!(!format!("{rows:?}").contains("xxxx"));
+}
+
+#[cfg(unix)]
+#[test]
+fn serve_row_ok_names_tls_as_the_proxy_and_hides_the_secret() {
+    use std::os::unix::fs::PermissionsExt as _;
+    let dir = temp_dir("serve-ok");
+    let nika = dir.join(".nika");
+    std::fs::create_dir(&nika).expect("nika dir");
+    let token = nika.join("serve.token");
+    std::fs::write(&token, "s3cret-token-value-never-printed!!").expect("token");
+    std::fs::set_permissions(&token, std::fs::Permissions::from_mode(0o600)).expect("mode");
+    let rows = serve_http_door(&dir);
+    assert_eq!(rows[0].level, Level::Ok);
+    assert!(rows[0].detail.contains("does not terminate TLS"));
+    assert!(!rows[0].detail.contains("s3cret"));
+}

--- a/docs/crate-specs/nika-serve.md
+++ b/docs/crate-specs/nika-serve.md
@@ -2,7 +2,7 @@
 
 | | |
 |---|---|
-| Status | **WORKSPACE WIP — W09 OPENAPI**. Durable jobs, loopback HTTP, SSE, and an authenticated OpenAPI 3.1 document of the live routes. SDK retarget and 12-gate admission remain later. |
+| Status | **WORKSPACE WIP — W10 OPS**. Durable jobs, loopback HTTP, SSE, OpenAPI 3.1, SIGTERM drain, and an honest doctor row for the token file. Cancel/artifacts stay absent. |
 | Layer | L4 — remote execution interface projection |
 | Purpose | Persist request admission, lifecycle status, and resumable event cursors, and project the first authenticated HTTP routes over that state. |
 | LOC budget | ≤5,000 source lines for the state plane; ≤15,000 hard crate cap. |

--- a/docs/ops/Caddyfile.nika-serve
+++ b/docs/ops/Caddyfile.nika-serve
@@ -1,0 +1,14 @@
+# Reverse proxy in front of loopback nika serve.
+# This process terminates TLS. nika serve does not.
+# SSE must not be buffered. Auth stays on the Bearer token —
+# forwarded headers never grant admission.
+
+nika.example.test {
+	reverse_proxy 127.0.0.1:8787 {
+		flush_interval -1
+		transport http {
+			read_timeout 0
+			write_timeout 0
+		}
+	}
+}

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -1,0 +1,17 @@
+# nika serve operations
+
+HTTP is an explicit door:
+
+```sh
+umask 077
+printf 'your-32-plus-ascii-token\n' > .nika/serve.token
+chmod 600 .nika/serve.token
+nika serve --bind 127.0.0.1:8787 --workflows ./workflows --token-file .nika/serve.token
+```
+
+Bare `nika serve` stays the resident ARM firer.
+
+- `nika-serve.service` — systemd unit, loopback, SIGTERM drain.
+- `Caddyfile.nika-serve` — TLS + unbuffered SSE. Caddy terminates TLS;
+  `nika doctor` never claims TLS from a proxy guess.
+- Cancel and artifacts stay 404 until those authorities exist.

--- a/docs/ops/nika-serve.service
+++ b/docs/ops/nika-serve.service
@@ -1,0 +1,36 @@
+# systemd user/system unit for the HTTP door.
+# Loopback only. Put TLS on the reverse proxy, never in this process.
+# Copy, then set User, WorkingDirectory, and the three Environment= paths.
+#
+#   umask 077
+#   printf '…32+ ascii…\n' > /var/lib/nika/serve.token
+#   chmod 600 /var/lib/nika/serve.token
+#
+# nika serve without --bind remains the resident ARM firer. This unit is
+# the HTTP pair only.
+
+[Unit]
+Description=nika serve HTTP (loopback)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=nika
+Group=nika
+WorkingDirectory=/var/lib/nika
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+ReadWritePaths=/var/lib/nika
+StateDirectory=nika
+UMask=0077
+ExecStart=/usr/local/bin/nika serve --bind 127.0.0.1:8787 --workflows /var/lib/nika/workflows --token-file /var/lib/nika/serve.token --state-root /var/lib/nika/serve
+Restart=on-failure
+RestartSec=2
+TimeoutStopSec=30
+KillSignal=SIGTERM
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/security/nika-serve-threat-model.md
+++ b/docs/security/nika-serve-threat-model.md
@@ -219,7 +219,7 @@ transcript is claimed where no such test existed on that SHA.
   payload, workflow bytes, or secret-shaped fixture;
 - [x] cancellation and artifact routes are absent until their typed authorities
   are admitted;
-- [ ] SIGINT/SIGTERM stop admission, settle in-flight authority, and leave no
+- [x] SIGINT/SIGTERM stop admission, settle in-flight authority, and leave no
   duplicate-runnable idempotency record.
 
 ## Review triggers


### PR DESCRIPTION
## Why

W10 needs an honest operator surface for the HTTP door. `nika doctor` was silent about token-file mode and would have let a user believe TLS came with `--bind`.

## What

- `nika doctor` rows `serve` only when `.nika/serve.token` exists (opt-in, calm default).
- Owner-only mode is OK. Group/world-readable fails with the `umask 077` / `chmod 600` fix. The secret is never printed.
- The row states TLS is the reverse proxy's job. This process does not terminate TLS.
- `docs/ops/` systemd unit + Caddyfile (unbuffered SSE, loopback).
- Threat-model SIGTERM drain checkbox matches the existing `serve_until` shutdown path.

Cancel and artifacts stay 404. No VPS was provisioned from this PR.

## Tests

`cargo test -p nika-cli-host --lib serve_row` — 3 passed.