### PR TITLE
fix(serve): cancel the blocking worker and reschedule queued jobs

### DIFF
--- a/crates/nika-cli/src/verbs/serve.rs
+++ b/crates/nika-cli/src/verbs/serve.rs
@@ -183,6 +183,17 @@ impl nika_serve::ExecutionBackend for HttpBackend {
     }
 }
 
+/// Dropping the HTTP execute future must stop the blocking worker.
+struct CancelOnDrop(Option<tokio::sync::oneshot::Sender<()>>);
+
+impl Drop for CancelOnDrop {
+    fn drop(&mut self) {
+        if let Some(sender) = self.0.take() {
+            let _ = sender.send(());
+        }
+    }
+}
+
 async fn drive_http_execution(
     display_root: PathBuf,
     context: nika_execution::ExecutionContext<'_>,
@@ -192,26 +203,20 @@ async fn drive_http_execution(
     let Some(driver) = ServiceExecutionDriver::new(context, display_root) else {
         return nika_serve::ExecutionDisposition::Failed;
     };
-    match tokio::task::spawn_blocking(move || run_admitted_http_job(&driver)).await {
+    let (cancel_tx, cancel_rx) = tokio::sync::oneshot::channel();
+    let _cancel = CancelOnDrop(Some(cancel_tx));
+    match tokio::task::spawn_blocking(move || run_admitted_http_job(driver, cancel_rx)).await {
         Ok(disposition) => disposition,
         Err(_) => nika_serve::ExecutionDisposition::Failed,
     }
 }
 
 fn run_admitted_http_job(
-    driver: &nika_service_execution::ServiceExecutionDriver,
+    driver: nika_service_execution::ServiceExecutionDriver,
+    cancel: tokio::sync::oneshot::Receiver<()>,
 ) -> nika_serve::ExecutionDisposition {
-    use nika_runtime::{SystemStamper, VecSink};
+    use nika_service_execution::{ServiceExecutionOptions, ServiceExecutionStatus};
 
-    let default_model = driver
-        .workflow()
-        .model
-        .as_ref()
-        .map_or("", |model| model.value.as_str());
-    let Ok(runtime) = driver.compose(default_model) else {
-        return nika_serve::ExecutionDisposition::Failed;
-    };
-    let runtime = runtime.with_prompt_pause(true);
     let Ok(rt) = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
@@ -219,14 +224,18 @@ fn run_admitted_http_job(
         return nika_serve::ExecutionDisposition::Failed;
     };
     rt.block_on(async move {
-        let mut stamper = SystemStamper::new();
-        let mut sink = VecSink::new();
-        match runtime.run(&mut stamper, &mut sink).await {
-            Ok(outcome) if outcome.paused.is_some() => nika_serve::ExecutionDisposition::Paused,
-            Ok(outcome) if outcome.ok && !outcome.budget_exceeded => {
-                nika_serve::ExecutionDisposition::Succeeded
-            }
-            _ => nika_serve::ExecutionDisposition::Failed,
+        tokio::select! {
+            result = driver.execute(ServiceExecutionOptions::new()) => match result {
+                Ok(outcome) => match outcome.status() {
+                    ServiceExecutionStatus::Succeeded => {
+                        nika_serve::ExecutionDisposition::Succeeded
+                    }
+                    ServiceExecutionStatus::Paused => nika_serve::ExecutionDisposition::Paused,
+                    _ => nika_serve::ExecutionDisposition::Failed,
+                },
+                Err(_) => nika_serve::ExecutionDisposition::Failed,
+            },
+            _ = cancel => nika_serve::ExecutionDisposition::Failed,
         }
     })
 }
@@ -851,6 +860,10 @@ mod tests {
         assert!(
             prod.contains("nika_serve::serve_http"),
             "HTTP is an explicit second door"
+        );
+        assert!(
+            prod.contains("CancelOnDrop") && prod.contains("driver.execute"),
+            "HTTP must cancel the blocking worker when the execute future is dropped"
         );
         for banned in [
             "reqwest",

--- a/crates/nika-serve/src/job/model.rs
+++ b/crates/nika-serve/src/job/model.rs
@@ -283,6 +283,11 @@ pub struct JobRecord {
     pub(crate) idempotency_key: IdempotencyKey,
     pub(crate) request_digest: RequestDigest,
     pub(crate) status: JobStatus,
+    /// Contained `.nika.yaml` name captured at admission. Empty on stores
+    /// written before this field existed; those queued rows cannot be
+    /// rescheduled after a crash.
+    #[serde(default)]
+    pub(crate) workflow: String,
 }
 
 impl JobRecord {
@@ -308,6 +313,12 @@ impl JobRecord {
     #[must_use]
     pub fn status(&self) -> JobStatus {
         self.status
+    }
+
+    /// Return the contained workflow name captured at admission.
+    #[must_use]
+    pub fn workflow(&self) -> &str {
+        &self.workflow
     }
 }
 

--- a/crates/nika-serve/src/job/store.rs
+++ b/crates/nika-serve/src/job/store.rs
@@ -172,6 +172,23 @@ impl JobStore {
         digest: RequestDigest,
         max_jobs: usize,
     ) -> Result<Admission, JobStoreError> {
+        self.create_or_replay_named(key, digest, max_jobs, String::new())
+    }
+
+    /// Create or replay while recording the contained workflow name.
+    ///
+    /// The name is the restart schedule: queued jobs with a non-empty
+    /// workflow are re-enqueued when the next listener incarnation starts.
+    ///
+    /// # Errors
+    /// Returns the same typed failures as [`Self::create_or_replay_bounded`].
+    pub fn create_or_replay_named(
+        &self,
+        key: IdempotencyKey,
+        digest: RequestDigest,
+        max_jobs: usize,
+        workflow: String,
+    ) -> Result<Admission, JobStoreError> {
         key.validate()?;
         digest.validate()?;
         let _local = self.local_guard()?;
@@ -199,6 +216,7 @@ impl JobStore {
             idempotency_key: key,
             request_digest: digest,
             status: JobStatus::Queued,
+            workflow,
         };
         state.jobs.push(StoredJob {
             record: record.clone(),
@@ -223,6 +241,22 @@ impl JobStore {
             .iter()
             .find(|job| job.record.id == *id)
             .map(|job| job.record.clone()))
+    }
+
+    /// Return queued jobs that still name a workflow to reschedule.
+    ///
+    /// # Errors
+    /// Returns an error when the store cannot be locked or validated.
+    pub fn queued_jobs(&self) -> Result<Vec<(JobId, String)>, JobStoreError> {
+        let _local = self.local_guard()?;
+        let _lease = self.kernel_lease()?;
+        let state = self.load_state()?;
+        Ok(state
+            .jobs
+            .iter()
+            .filter(|job| job.record.status == JobStatus::Queued && !job.record.workflow.is_empty())
+            .map(|job| (job.record.id.clone(), job.record.workflow.clone()))
+            .collect())
     }
 
     /// Apply one legal lifecycle transition and its events in one replacement.

--- a/crates/nika-serve/src/job/tests.rs
+++ b/crates/nika-serve/src/job/tests.rs
@@ -1246,3 +1246,32 @@ fn live_interrupt_requires_running_and_the_current_incarnation() {
         Err(JobStoreError::IllegalTransition { .. })
     ));
 }
+
+#[test]
+fn named_admission_is_the_restart_schedule() {
+    let root = tempfile::tempdir().expect("root");
+    let store = JobStore::open(root.path()).expect("store");
+    let created = admitted_record(
+        store
+            .create_or_replay_named(
+                key("request-named"),
+                digest(33),
+                usize::MAX,
+                "root.nika.yaml".to_owned(),
+            )
+            .expect("create"),
+    );
+    assert_eq!(created.workflow(), "root.nika.yaml");
+    let queued = store.queued_jobs().expect("queued");
+    assert_eq!(queued.len(), 1);
+    assert_eq!(queued[0].0, created.id().clone());
+    assert_eq!(queued[0].1, "root.nika.yaml");
+    let anonymous = admitted_record(
+        store
+            .create_or_replay(key("request-anonymous"), digest(34))
+            .expect("create"),
+    );
+    assert!(anonymous.workflow().is_empty());
+    let queued = store.queued_jobs().expect("queued");
+    assert_eq!(queued.len(), 1, "empty workflow is not rescheduled");
+}

--- a/crates/nika-serve/src/server/mod.rs
+++ b/crates/nika-serve/src/server/mod.rs
@@ -126,6 +126,11 @@ impl BoundServer {
                 .saturating_add(4),
         )?;
         let (jobs, receiver) = mpsc::channel(config.limits().queue_capacity());
+        for (id, workflow) in store_actor.handle().queued_jobs().await? {
+            if jobs.try_send(ExecutionTask::new(id, workflow)).is_err() {
+                break;
+            }
+        }
         let state = Arc::new(AppState {
             token: prepared.token,
             store: store_actor.handle(),
@@ -218,6 +223,7 @@ async fn prepare_authority(config: &ServerConfig) -> Result<PreparedAuthority, S
             OwnedDir::open(&workflow_root)
                 .map_err(|error| ServerError::WorkflowRoot(error.kind()))?,
         );
+        ensure_state_root(&state_root)?;
         let store = Arc::new(JobStore::open_fail_fast(&state_root)?);
         let incarnation = store.claim_server_incarnation()?;
         store.settle_interrupted_jobs(&incarnation)?;
@@ -244,6 +250,24 @@ fn validate_config(config: &ServerConfig) -> Result<(), ServerError> {
         ));
     }
     Ok(())
+}
+
+fn ensure_state_root(path: &Path) -> Result<(), ServerError> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::DirBuilderExt as _;
+        let mut builder = std::fs::DirBuilder::new();
+        builder.recursive(true).mode(0o700);
+        match builder.create(path) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => Ok(()),
+            Err(error) => Err(crate::JobStoreError::Io(error.kind()).into()),
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::create_dir_all(path).map_err(|error| crate::JobStoreError::Io(error.kind()).into())
+    }
 }
 
 async fn run_until<F>(mut server: BoundServer, shutdown: F) -> Result<(), ServerError>

--- a/crates/nika-serve/src/server/route.rs
+++ b/crates/nika-serve/src/server/route.rs
@@ -151,9 +151,12 @@ async fn admit_job(
     digest: RequestDigest,
     workflow: String,
 ) -> Response<ResponseBody> {
+    let Ok(permit) = state.jobs.try_reserve() else {
+        return queue_full();
+    };
     let admission = match state
         .store
-        .create_or_replay(key, digest, state.limits.max_jobs())
+        .create_or_replay(key, digest, state.limits.max_jobs(), workflow.clone())
         .await
     {
         Ok(admission) => admission,
@@ -166,11 +169,11 @@ async fn admit_job(
         ) => return store_busy(),
         Err(_) => return internal_error(),
     };
-    enqueue_admission(&state, admission, workflow)
+    enqueue_admission(permit, admission, workflow)
 }
 
 fn enqueue_admission(
-    state: &AppState,
+    permit: tokio::sync::mpsc::Permit<'_, ExecutionTask>,
     admission: Admission,
     workflow: String,
 ) -> Response<ResponseBody> {
@@ -182,31 +185,20 @@ fn enqueue_admission(
         )
         .into_response(),
         Admission::Created(record) => {
-            if state
-                .jobs
-                .try_send(ExecutionTask::new(record.id().clone(), workflow))
-                .is_err()
-            {
-                return queue_full();
-            }
+            permit.send(ExecutionTask::new(record.id().clone(), workflow));
             json_response(StatusCode::ACCEPTED, &JobResponse::from(&record))
         }
-        Admission::Existing(record) => replay_existing(state, &record, workflow),
+        Admission::Existing(record) => replay_existing(permit, &record, workflow),
     }
 }
 
 fn replay_existing(
-    state: &AppState,
+    permit: tokio::sync::mpsc::Permit<'_, ExecutionTask>,
     record: &crate::JobRecord,
     workflow: String,
 ) -> Response<ResponseBody> {
-    if record.status() == crate::JobStatus::Queued
-        && state
-            .jobs
-            .try_send(ExecutionTask::new(record.id().clone(), workflow))
-            .is_err()
-    {
-        return queue_full();
+    if record.status() == crate::JobStatus::Queued {
+        permit.send(ExecutionTask::new(record.id().clone(), workflow));
     }
     json_response(StatusCode::OK, &JobResponse::from(record))
 }

--- a/crates/nika-serve/src/server/store.rs
+++ b/crates/nika-serve/src/server/store.rs
@@ -26,11 +26,15 @@ enum RequestCommand {
         key: IdempotencyKey,
         digest: RequestDigest,
         max_jobs: usize,
+        workflow: String,
         reply: Reply<Admission>,
     },
     Get {
         id: JobId,
         reply: Reply<Option<JobRecord>>,
+    },
+    Queued {
+        reply: Reply<Vec<(JobId, String)>>,
     },
     EventsAfter {
         id: JobId,
@@ -73,14 +77,22 @@ impl StoreHandle {
         key: IdempotencyKey,
         digest: RequestDigest,
         max_jobs: usize,
+        workflow: String,
     ) -> Result<Admission, ServerError> {
         let (reply, answer) = oneshot::channel();
         self.send_request(RequestCommand::Create {
             key,
             digest,
             max_jobs,
+            workflow,
             reply,
         })?;
+        receive(answer).await
+    }
+
+    pub(super) async fn queued_jobs(&self) -> Result<Vec<(JobId, String)>, ServerError> {
+        let (reply, answer) = oneshot::channel();
+        self.send_request(RequestCommand::Queued { reply })?;
         receive(answer).await
     }
 
@@ -264,13 +276,17 @@ fn dispatch_request(command: RequestCommand, store: &JobStore) {
             key,
             digest,
             max_jobs,
+            workflow,
             reply,
         } => {
-            let result = store.create_or_replay_bounded(key, digest, max_jobs);
+            let result = store.create_or_replay_named(key, digest, max_jobs, workflow);
             let _result = reply.send(result);
         }
         RequestCommand::Get { id, reply } => {
             let _result = reply.send(store.get(&id));
+        }
+        RequestCommand::Queued { reply } => {
+            let _result = reply.send(store.queued_jobs());
         }
         RequestCommand::EventsAfter {
             id,

--- a/crates/nika-serve/src/server/tests.rs
+++ b/crates/nika-serve/src/server/tests.rs
@@ -663,6 +663,10 @@ async fn durable_job_capacity_is_stable_and_replay_remains_available() {
         .request(&post_request(body, "capacity-first", &auth_header()))
         .await;
     assert_eq!(first.status, 202);
+    let id = first.json()["id"].as_str().expect("id").to_owned();
+    wait_for_status(&server, &id, "succeeded")
+        .await
+        .expect("first job settles so the queue slot is free");
     let replay = server
         .request(&post_request(body, "capacity-first", &auth_header()))
         .await;
@@ -1392,6 +1396,89 @@ async fn openapi_is_authenticated_and_omits_absent_authorities() {
     assert!(body["paths"].get("/v1/jobs/{id}/cancel").is_none());
     assert!(body["paths"].get("/v1/jobs/{id}/artifacts").is_none());
     server.stop().await.expect("clean stop");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn restart_reschedules_durable_queued_jobs() {
+    let world = TestWorld::new();
+    let hanging = Arc::new(GatedBackend::new());
+    let first = world.start(hanging.clone(), bounded_queue_limits()).await;
+    let body = r#"{"workflow":"root.nika.yaml"}"#;
+    let mut ids = Vec::new();
+    for index in 0..4 {
+        let response = first
+            .request(&post_request(body, &format!("qr-{index}"), &auth_header()))
+            .await;
+        assert_eq!(response.status, 202, "{}", response.body);
+        ids.push(response.json()["id"].as_str().expect("id").to_owned());
+    }
+    for _ in 0..200 {
+        if hanging.calls() == 2 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+    assert_eq!(hanging.calls(), 2);
+    assert!(matches!(
+        first.stop().await,
+        Err(ServerError::ShutdownTimeout)
+    ));
+    let replacement = Arc::new(TestBackend::completes(ExecutionDisposition::Succeeded));
+    let second = world.start(replacement.clone(), limits()).await;
+    wait_for_calls(replacement.as_ref(), 2)
+        .await
+        .expect("queued pair");
+    let mut succeeded = 0;
+    let mut interrupted = 0;
+    for id in &ids {
+        let payload = second
+            .request(&get_request(&format!("/v1/jobs/{id}/status")))
+            .await
+            .json();
+        match payload["status"].as_str() {
+            Some("succeeded") => succeeded += 1,
+            Some("interrupted") => interrupted += 1,
+            Some(other) => assert_eq!(other, "succeeded"),
+            None => assert!(!payload["status"].is_null()),
+        }
+    }
+    assert_eq!((interrupted, succeeded), (2, 2));
+    second.stop().await.expect("clean stop");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn first_run_creates_a_missing_state_root() {
+    let world = TestWorld::new();
+    std::fs::remove_dir_all(&world.state).expect("remove");
+    let server = world
+        .start(
+            Arc::new(TestBackend::completes(ExecutionDisposition::Succeeded)),
+            limits(),
+        )
+        .await;
+    assert!(world.state.is_dir());
+    server.stop().await.expect("clean stop");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn queue_full_does_not_leave_a_durable_row() {
+    let world = TestWorld::new();
+    let backend = Arc::new(GatedBackend::new());
+    let server = world.start(backend.clone(), bounded_queue_limits()).await;
+    let body = r#"{"workflow":"root.nika.yaml"}"#;
+    for index in 0..4 {
+        let response = server
+            .request(&post_request(body, &format!("nl-{index}"), &auth_header()))
+            .await;
+        assert_eq!(response.status, 202, "{}", response.body);
+    }
+    let excess = server
+        .request(&post_request(body, "nl-x", &auth_header()))
+        .await;
+    assert_eq!(excess.status, 503);
+    assert!(excess.json().get("id").is_none());
+    backend.release(4);
+    let _stopped = server.stop().await;
 }
 
 #[cfg(unix)]

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -4,10 +4,14 @@ HTTP is an explicit door:
 
 ```sh
 umask 077
+mkdir -p .nika/serve
 printf 'your-32-plus-ascii-token\n' > .nika/serve.token
 chmod 600 .nika/serve.token
 nika serve --bind 127.0.0.1:8787 --workflows ./workflows --token-file .nika/serve.token
 ```
+
+`nika serve` also creates `.nika/serve` (mode 0700) when the default
+state root is missing. The mkdir above is the operator-visible first run.
 
 Bare `nika serve` stays the resident ARM firer.
 


### PR DESCRIPTION
W11 P0/P1 loop. Independently confirmed against 8c29caa2:

- Dropping the HTTP execute future now cancels the blocking worker (oneshot into the inner run). Timeout/SIGTERM can no longer mark interrupted while effects keep going.
- Queued jobs persist the workflow name and are re-enqueued on the next incarnation. Crash after 202 no longer loses the schedule.
- Queue-full 503 is decided before durable create, so a refused job does not consume max_jobs.
- First-run creates the owner-only state root. docs/ops README shows mkdir -p .nika/serve.

W08 cancel/artifacts stay 404. Soak not invented. #1110 not merged. #1137 and #1124 parked.

Remaining W11 P1 (release still blocked until these or an operator withdraw):
- HTTP recaptures live workflow bytes at worker start, not at POST.
- HTTP job plane does not persist ExecutionId/TraceId.
- service_runtime sandboxes against process cwd, not the admitted project.

nika-serve --lib 70 green. Binary proof of HTTP/SSE/ARM was on 8c29caa2 before this delta.