### PR TITLE
fix(serve): teach the token mint and isolate action dogfood

### DIFF
--- a/.github/workflows/action-dogfood.yml
+++ b/.github/workflows/action-dogfood.yml
@@ -2,10 +2,17 @@
 # Proves the whole chain end-to-end — install the released binary, check,
 # run cost-capped, name the trace — through the SAME door a user gets
 # (the binary boundary · nika.sh/install.sh · no local build).
+#
+# clock: released · install.sh pulls GitHub Latest, never this tree.
+# Tags are excluded: a tag of a language-clock change (nika.yaml rename)
+# then dogfoods the previous binary against this checkout and fails
+# closed for the wrong reason. Smoke lives in $RUNNER_TEMP so project
+# discovery does not walk into this engine's nika.yaml.
 name: action-dogfood
 
 on:
   push:
+    branches: [main]
     paths:
       - "action/**"
       - ".github/workflows/action-dogfood.yml"
@@ -23,11 +30,11 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Write a $0 mock workflow
+      - name: Write a $0 mock workflow outside this checkout
         shell: bash
         run: |
-          mkdir -p wf
-          cat > wf/smoke.nika.yaml <<'YAML'
+          mkdir -p "$RUNNER_TEMP/nika-dogfood"
+          cat > "$RUNNER_TEMP/nika-dogfood/smoke.nika.yaml" <<'YAML'
           # A zero-cost mock run proving the action end-to-end.
           nika: action-dogfood
 
@@ -42,7 +49,8 @@ jobs:
         id: nika
         uses: ./action
         with:
-          file: wf/smoke.nika.yaml
+          file: smoke.nika.yaml
+          working-directory: ${{ runner.temp }}/nika-dogfood
           max-cost-usd: "0.01"
 
       - name: Assert the trace exists and verifies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,25 @@ Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
 ---
 ## [Unreleased]
 
+### Changed
+
+- **`nika serve --bind` prints the token mint instead of an opaque
+  credential refusal.** Missing `--token-file`, a short secret, or a
+  group/world-readable file all teach
+  `umask 077 && openssl rand -hex 24 > .nika/serve.token && chmod 600
+  .nika/serve.token` and never echo the bytes. The HTTP door still
+  refuses to mint a secret on its own.
+- **The listen line names the next hop.** After bind it prints
+  `GET /health`, authenticated `GET /v1/openapi.json`, and
+  `POST /v1/jobs` with Bearer plus Idempotency-Key. A non-loopback
+  bind adds that the blast radius is every workflow in `--workflows`.
+  `GET /health` JSON stays the ADR-117 identity allowlist.
+- **Action dogfood no longer runs on tags.** `install.sh` resolves the
+  latest published binary, which lags the tagged tree until release.yml
+  finishes. The smoke workflow now lives outside the checkout so project
+  discovery cannot walk into this engine's `nika.yaml`. An additive
+  `working-directory` input on the composite action is the seam.
+
 ## [0.114.0](https://github.com/supernovae-st/nika/compare/v0.113.0..v0.114.0) - 2026-08-23
 
 **Remote execution as a loopback door.** Default `nika serve` stays the

--- a/action/action.yml
+++ b/action/action.yml
@@ -25,6 +25,10 @@ inputs:
     description: "Nika version to install (default: latest release)"
     required: false
     default: ""
+  working-directory:
+    description: "Directory nika check/run execute from. Project discovery walks up from here; leave empty to use the job workspace."
+    required: false
+    default: ""
 
 outputs:
   trace:
@@ -46,16 +50,27 @@ runs:
 
     - name: Check (audit before run)
       shell: bash
-      run: nika check "${{ inputs.file }}"
+      run: |
+        if [ -n "${{ inputs.working-directory }}" ]; then
+          cd "${{ inputs.working-directory }}"
+        fi
+        nika check "${{ inputs.file }}"
 
     - name: Run (cost-capped · traced)
       id: run
       shell: bash
       run: |
+        if [ -n "${{ inputs.working-directory }}" ]; then
+          cd "${{ inputs.working-directory }}"
+        fi
         rc=0
         nika run "${{ inputs.file }}" --max-cost-usd "${{ inputs.max-cost-usd }}" --json ${{ inputs.args }} || rc=$?
         # The newest trace is this run's journal — name it for upload.
+        # Absolute: a working-directory input must not strand the caller.
         trace=$(ls -t .nika/traces/*.ndjson 2>/dev/null | head -1 || true)
+        if [ -n "$trace" ]; then
+          trace="$(realpath "$trace")"
+        fi
         echo "trace=$trace" >> "$GITHUB_OUTPUT"
         # Exit 4 = paused on a human gate: a real state, not a failure —
         # but CI has no human, so surface it loudly and stop the job.

--- a/crates/nika-cli/src/verbs/serve.rs
+++ b/crates/nika-cli/src/verbs/serve.rs
@@ -40,7 +40,8 @@ pub struct ServeArgs {
     /// Acknowledge a non-loopback `--bind`. Authentication is unchanged.
     #[arg(long)]
     pub allow_remote: bool,
-    /// Owner-only file holding the Bearer secret. Bytes never enter argv.
+    /// Owner-only Bearer file (32–512 visible ASCII bytes, mode 0600). Never argv.
+    /// Mint: umask 077 && openssl rand -hex 24 > .nika/serve.token && chmod 600 .nika/serve.token
     #[arg(long, value_name = "FILE")]
     pub token_file: Option<PathBuf>,
     /// Durable job-state root. Defaults to `<cwd>/.nika/serve`.
@@ -105,6 +106,15 @@ fn http_requested(args: &ServeArgs) -> bool {
         || args.allow_remote
 }
 
+/// Operator-visible mint. `openssl rand -hex 24` is 48 graphic ASCII bytes.
+const TOKEN_FILE_MINT: &str =
+    "umask 077 && openssl rand -hex 24 > .nika/serve.token && chmod 600 .nika/serve.token";
+const TOKEN_FILE_RULE: &str = "32–512 visible ASCII bytes, mode 0600, never argv";
+
+fn token_file_refused(prefix: &str) -> String {
+    format!("serve · {prefix} ({TOKEN_FILE_RULE})\n  {TOKEN_FILE_MINT}")
+}
+
 fn serve_http_mode(args: &ServeArgs) -> Result<VerbOutput, String> {
     let bind = args
         .bind
@@ -114,9 +124,10 @@ fn serve_http_mode(args: &ServeArgs) -> Result<VerbOutput, String> {
         .workflows
         .as_deref()
         .ok_or_else(|| "serve · --bind and --workflows are an inseparable pair".to_owned())?;
-    let token_file = args.token_file.as_deref().ok_or_else(|| {
-        "serve · --bind requires --token-file (credential bytes never enter argv)".to_owned()
-    })?;
+    let token_file = args
+        .token_file
+        .as_deref()
+        .ok_or_else(|| token_file_refused("--bind requires --token-file"))?;
     if args.once || args.dry {
         return Err("serve · --once/--dry cannot bind a listener".to_owned());
     }
@@ -141,7 +152,10 @@ fn serve_http_mode(args: &ServeArgs) -> Result<VerbOutput, String> {
         backend,
         http_shutdown(),
     ))
-    .map_err(|error| format!("serve · {error}"))?;
+    .map_err(|error| match error {
+        nika_serve::ServerError::Credential => token_file_refused("token file refused"),
+        other => format!("serve · {other}"),
+    })?;
     Ok(VerbOutput::ok(String::new()))
 }
 
@@ -897,6 +911,13 @@ mod tests {
         assert_eq!(out.code, exit::WORKFLOW, "{}", out.text);
         assert!(out.text.contains("--once"), "{}", out.text);
 
+        let mut mint = serve_args();
+        mint.bind = Some("127.0.0.1:0".to_owned());
+        mint.workflows = Some(PathBuf::from("workflows"));
+        let out = run(&mint);
+        assert_eq!(out.code, exit::WORKFLOW, "{}", out.text);
+        assert!(out.text.contains("openssl rand -hex 24"), "{}", out.text);
+
         args.once = false;
         args.dry = true;
         let out = run(&args);
@@ -908,5 +929,48 @@ mod tests {
         let out = run(&args);
         assert_eq!(out.code, exit::WORKFLOW, "{}", out.text);
         assert!(out.text.contains("bind address is invalid"), "{}", out.text);
+    }
+
+    #[test]
+    fn a_short_token_file_teaches_the_mint_and_does_not_echo_the_secret() {
+        let tmp = tempfile::tempdir().expect("tmp");
+        let workflows = tmp.path().join("wf");
+        std::fs::create_dir(&workflows).expect("wf");
+        let token = tmp.path().join("short.token");
+        std::fs::write(&token, "too-short\n").expect("token");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            std::fs::set_permissions(&token, std::fs::Permissions::from_mode(0o600)).expect("mode");
+        }
+        let mut args = serve_args();
+        args.bind = Some("127.0.0.1:0".to_owned());
+        args.workflows = Some(workflows);
+        args.token_file = Some(token);
+        let out = run(&args);
+        assert_eq!(out.code, exit::WORKFLOW, "{}", out.text);
+        assert!(out.text.contains("openssl rand -hex 24"), "{}", out.text);
+        assert!(!out.text.contains("too-short"), "{}", out.text);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_world_readable_token_file_teaches_the_mint_and_does_not_echo_the_secret() {
+        use std::os::unix::fs::PermissionsExt as _;
+        let tmp = tempfile::tempdir().expect("tmp");
+        let workflows = tmp.path().join("wf");
+        std::fs::create_dir(&workflows).expect("wf");
+        let token = tmp.path().join("open.token");
+        let secret = "a".repeat(32);
+        std::fs::write(&token, &secret).expect("token");
+        std::fs::set_permissions(&token, std::fs::Permissions::from_mode(0o644)).expect("mode");
+        let mut args = serve_args();
+        args.bind = Some("127.0.0.1:0".to_owned());
+        args.workflows = Some(workflows);
+        args.token_file = Some(token);
+        let out = run(&args);
+        assert_eq!(out.code, exit::WORKFLOW, "{}", out.text);
+        assert!(out.text.contains("openssl rand -hex 24"), "{}", out.text);
+        assert!(!out.text.contains(&secret), "{}", out.text);
     }
 }

--- a/crates/nika-serve/src/server/listen.rs
+++ b/crates/nika-serve/src/server/listen.rs
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+use std::net::SocketAddr;
+
+/// Operator stderr after bind. Next hops live here, not on GET /health
+/// (ADR-117 identity allowlist).
+pub(crate) fn listen_line(addr: SocketAddr) -> String {
+    let hops =
+        "GET /health · GET /v1/openapi.json (Bearer) · POST /v1/jobs (Bearer + Idempotency-Key)";
+    if addr.ip().is_loopback() {
+        format!("nika serve · listening http://{addr} · {hops}")
+    } else {
+        format!(
+            "nika serve · listening http://{addr} · {hops}\n  non-loopback · blast radius is every workflow in --workflows · auth unchanged"
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{IpAddr, Ipv4Addr};
+
+    #[test]
+    fn listen_line_names_the_authenticated_next_hops() {
+        let loopback = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8787);
+        let line = listen_line(loopback);
+        assert!(line.contains("http://127.0.0.1:8787"), "{line}");
+        assert!(line.contains("GET /health"), "{line}");
+        assert!(line.contains("GET /v1/openapi.json"), "{line}");
+        assert!(line.contains("Bearer"), "{line}");
+        assert!(line.contains("POST /v1/jobs"), "{line}");
+        assert!(line.contains("Idempotency-Key"), "{line}");
+        assert!(!line.contains("blast radius"), "{line}");
+
+        let remote = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 8787);
+        let line = listen_line(remote);
+        assert!(line.contains("0.0.0.0:8787"), "{line}");
+        assert!(line.contains("blast radius"), "{line}");
+        assert!(line.contains("--workflows"), "{line}");
+    }
+}

--- a/crates/nika-serve/src/server/mod.rs
+++ b/crates/nika-serve/src/server/mod.rs
@@ -4,6 +4,7 @@
 mod auth;
 mod config;
 mod error;
+mod listen;
 mod model;
 mod openapi;
 mod registry;
@@ -32,6 +33,7 @@ use crate::{EventPageLimit, JobId, JobStatus, JobStore, MAX_EVENT_PAGE_LEN};
 use auth::BearerToken;
 pub use config::{ServerConfig, ServerLimits};
 pub use error::ServerError;
+use listen::listen_line;
 use store::{StoreActor, StoreHandle};
 
 /// Backend-owned terminal class projected onto the durable job lifecycle.
@@ -198,7 +200,8 @@ pub async fn serve_http(
     let server = BoundServer::bind(config, backend).await?;
     let addr = server.local_addr()?;
     // Operator-facing: `--bind …:0` is useless without the chosen port.
-    eprintln!("nika serve · listening http://{addr} · GET /health");
+    // Next hops live here, not on GET /health (ADR-117 identity allowlist).
+    eprintln!("{}", listen_line(addr));
     server.serve_until(shutdown).await
 }
 

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -5,7 +5,7 @@ HTTP is an explicit door:
 ```sh
 umask 077
 mkdir -p .nika/serve
-printf 'your-32-plus-ascii-token\n' > .nika/serve.token
+openssl rand -hex 24 > .nika/serve.token
 chmod 600 .nika/serve.token
 nika serve --bind 127.0.0.1:8787 --workflows ./workflows --token-file .nika/serve.token
 ```


### PR DESCRIPTION
## Why

A six-persona first-user gauntlet against the tagged 0.114 binary found the same two walls independently:

1. `server credential source refused` does not teach a mint (P1, P5, P7, P14, P4).
2. Tag-triggered action-dogfood installs *latest published* against this tree (P13). The v0.114.0 tag dogfooded 0.113.0, then died on `project.tag-frozen`.

## What

- Missing or refused `--token-file` prints the openssl mint and never echoes the secret.
- Listen line names `GET /health`, authenticated OpenAPI, and `POST /v1/jobs` (Bearer + Idempotency-Key).
- Non-loopback bind names the workflow blast radius.
- Action dogfood runs on `main` and pull requests only (`clock: released`). Smoke lives in `$RUNNER_TEMP` so this engine `nika.yaml` cannot freeze the run.
- Additive `working-directory` on the composite action.

## Not this PR

- W08 cancel/artifacts stay 404.
- Typed credential causes and `nika doctor` matching serve policy are the next loop (P7).
- HTTP admission-via-`nika check` is a product decision, not a first-user mint.

## Tests

- `cargo test -p nika-cli --lib serve`
- `cargo test -p nika-serve --lib listen_line`

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>