### PR TITLE
fix(cli): doctor refuses tokens serve would refuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
 
 ### Changed
 
+- **`nika doctor` uses the same token-file policy as `nika serve`.** A
+  short, non-graphic, or symlink `.nika/serve.token` is a fail with the
+  openssl mint, not an owner-only green. Group/world-readable still
+  names `chmod 600`. The row stays silent when the file is absent.
+
 - **`nika serve --bind` prints the token mint instead of an opaque
   credential refusal.** Missing `--token-file`, a short secret, or a
   group/world-readable file all teach

--- a/crates/nika-cli-host/src/doctor.rs
+++ b/crates/nika-cli-host/src/doctor.rs
@@ -241,14 +241,33 @@ fn provider_findings(probe: &Probe, out: &mut Vec<Finding>) {
     }
 }
 
+/// Operator-visible mint. Same recipe `nika serve --bind` prints.
+const SERVE_TOKEN_MINT: &str =
+    "umask 077 && openssl rand -hex 24 > .nika/serve.token && chmod 600 .nika/serve.token";
+
 /// HTTP door readiness. Silent when the cwd has no token file — the
 /// door is opt-in. Never claims TLS: this process does not terminate it.
+/// Policy matches `nika-serve` `BearerToken::from_file` (symlink, mode,
+/// 32–512 graphic ASCII) so doctor cannot green a file serve would refuse.
 pub(crate) fn serve_http_door(root: &std::path::Path) -> Vec<Finding> {
     let token = root.join(".nika/serve.token");
-    if !token.is_file() {
+    let Ok(meta) = std::fs::symlink_metadata(&token) else {
         return Vec::new();
+    };
+    if meta.file_type().is_symlink() {
+        return vec![serve_token_refused(
+            "token file is a symlink — `nika serve` will refuse it",
+        )];
+    }
+    if !meta.is_file() {
+        return vec![serve_token_refused(
+            "token path is not a regular file — `nika serve` will refuse it",
+        )];
     }
     if let Some(finding) = serve_token_group_readable(&token) {
+        return vec![finding];
+    }
+    if let Some(finding) = serve_token_bytes_refused(&token) {
         return vec![finding];
     }
     vec![Finding {
@@ -259,6 +278,30 @@ pub(crate) fn serve_http_door(root: &std::path::Path) -> Vec<Finding> {
             .to_owned(),
         fix: None,
     }]
+}
+
+fn serve_token_refused(detail: &str) -> Finding {
+    Finding {
+        level: Level::Fail,
+        label: "serve".to_owned(),
+        detail: detail.to_owned(),
+        fix: Some(SERVE_TOKEN_MINT.to_owned()),
+    }
+}
+
+fn serve_token_bytes_refused(path: &std::path::Path) -> Option<Finding> {
+    let mut bytes = std::fs::read(path).ok()?;
+    if bytes.ends_with(b"\r\n") {
+        bytes.truncate(bytes.len() - 2);
+    } else if matches!(bytes.last(), Some(b'\n' | b'\r')) {
+        bytes.pop();
+    }
+    if (32..=512).contains(&bytes.len()) && bytes.iter().all(u8::is_ascii_graphic) {
+        return None;
+    }
+    Some(serve_token_refused(
+        "token file is not 32–512 visible ASCII bytes — `nika serve` will refuse it",
+    ))
 }
 
 #[cfg(unix)]

--- a/crates/nika-cli-host/src/doctor/tests.rs
+++ b/crates/nika-cli-host/src/doctor/tests.rs
@@ -1446,3 +1446,47 @@ fn serve_row_ok_names_tls_as_the_proxy_and_hides_the_secret() {
     assert!(rows[0].detail.contains("does not terminate TLS"));
     assert!(!rows[0].detail.contains("s3cret"));
 }
+
+#[cfg(unix)]
+#[test]
+fn serve_row_fails_when_the_token_is_too_short_and_does_not_echo_it() {
+    use std::os::unix::fs::PermissionsExt as _;
+    let dir = temp_dir("serve-short");
+    let nika = dir.join(".nika");
+    std::fs::create_dir(&nika).expect("nika dir");
+    let token = nika.join("serve.token");
+    let secret = "too-short-secret";
+    std::fs::write(&token, secret).expect("token");
+    std::fs::set_permissions(&token, std::fs::Permissions::from_mode(0o600)).expect("mode");
+    let rows = serve_http_door(&dir);
+    assert_eq!(rows[0].level, Level::Fail);
+    assert!(
+        rows[0]
+            .fix
+            .as_deref()
+            .is_some_and(|f| f.contains("openssl rand -hex 24"))
+    );
+    assert!(!format!("{rows:?}").contains(secret));
+}
+
+#[cfg(unix)]
+#[test]
+fn serve_row_fails_when_the_token_is_a_symlink() {
+    use std::os::unix::fs::PermissionsExt as _;
+    let dir = temp_dir("serve-symlink");
+    let nika = dir.join(".nika");
+    std::fs::create_dir(&nika).expect("nika dir");
+    let target = dir.join("real.token");
+    std::fs::write(&target, "a".repeat(32)).expect("target");
+    std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o600)).expect("mode");
+    std::os::unix::fs::symlink(&target, nika.join("serve.token")).expect("symlink");
+    let rows = serve_http_door(&dir);
+    assert_eq!(rows[0].level, Level::Fail);
+    assert!(rows[0].detail.contains("symlink"));
+    assert!(
+        rows[0]
+            .fix
+            .as_deref()
+            .is_some_and(|f| f.contains("openssl rand -hex 24"))
+    );
+}

--- a/crates/nika-cli/src/verbs/serve.rs
+++ b/crates/nika-cli/src/verbs/serve.rs
@@ -38,6 +38,7 @@ pub struct ServeArgs {
     #[arg(long, value_name = "DIR")]
     pub workflows: Option<PathBuf>,
     /// Acknowledge a non-loopback `--bind`. Authentication is unchanged.
+    /// TLS is a reverse proxy — this process does not terminate it.
     #[arg(long)]
     pub allow_remote: bool,
     /// Owner-only Bearer file (32–512 visible ASCII bytes, mode 0600). Never argv.


### PR DESCRIPTION
## Why

Gauntlet P7: `nika doctor` greened a short or symlinked `.nika/serve.token`
(owner-only mode only). `nika serve` still refused. That is a false green.

## What

- Doctor follows symlink metadata, mode bits, and 32–512 graphic ASCII.
- Fail prints the openssl mint and never echoes the secret.
- `--allow-remote` help names TLS as a reverse proxy.

## Tests

- `serve_row_fails_when_the_token_is_too_short_and_does_not_echo_it`
- `serve_row_fails_when_the_token_is_a_symlink`

Follows #1151. W08 cancel/artifacts stay 404.

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>