### PR TITLE
fix(serve): name the nika code on failed jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
 
 ### Changed
 
+- **Failed HTTP jobs name a NIKA code.** `GET /v1/jobs/{id}` grows an
+  optional `{error:{code,message}}` on `failed`. SSE settled/refused
+  frames may carry the same redacted pair. Paths and secret-shaped
+  fields stay dropped. Succeeded jobs omit `error`.
+
+
+
 - **`nika doctor` uses the same token-file policy as `nika serve`.** A
   short, non-graphic, or symlink `.nika/serve.token` is a fail with the
   openssl mint, not an owner-only green. Group/world-readable still

--- a/crates/nika-cli/src/verbs/serve.rs
+++ b/crates/nika-cli/src/verbs/serve.rs
@@ -191,7 +191,7 @@ impl nika_serve::ExecutionBackend for HttpBackend {
         &'a self,
         context: nika_execution::ExecutionContext<'a>,
     ) -> std::pin::Pin<
-        Box<dyn std::future::Future<Output = nika_serve::ExecutionDisposition> + Send + 'a>,
+        Box<dyn std::future::Future<Output = nika_serve::ExecutionOutcome> + Send + 'a>,
     > {
         let display_root = self.display_root.clone();
         Box::pin(async move { drive_http_execution(display_root, context).await })
@@ -212,45 +212,63 @@ impl Drop for CancelOnDrop {
 async fn drive_http_execution(
     display_root: PathBuf,
     context: nika_execution::ExecutionContext<'_>,
-) -> nika_serve::ExecutionDisposition {
+) -> nika_serve::ExecutionOutcome {
     use nika_service_execution::ServiceExecutionDriver;
 
     let Some(driver) = ServiceExecutionDriver::new(context, display_root) else {
-        return nika_serve::ExecutionDisposition::Failed;
+        return nika_serve::ExecutionOutcome::failed(
+            "admission_refused",
+            "workflow world could not be composed",
+        );
     };
     let (cancel_tx, cancel_rx) = tokio::sync::oneshot::channel();
     let _cancel = CancelOnDrop(Some(cancel_tx));
     match tokio::task::spawn_blocking(move || run_admitted_http_job(driver, cancel_rx)).await {
-        Ok(disposition) => disposition,
-        Err(_) => nika_serve::ExecutionDisposition::Failed,
+        Ok(outcome) => outcome,
+        Err(_) => {
+            nika_serve::ExecutionOutcome::failed("NIKA-COMP-001", "execution worker did not finish")
+        }
     }
 }
 
 fn run_admitted_http_job(
     driver: nika_service_execution::ServiceExecutionDriver,
     cancel: tokio::sync::oneshot::Receiver<()>,
-) -> nika_serve::ExecutionDisposition {
+) -> nika_serve::ExecutionOutcome {
     use nika_service_execution::{ServiceExecutionOptions, ServiceExecutionStatus};
 
     let Ok(rt) = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
     else {
-        return nika_serve::ExecutionDisposition::Failed;
+        return nika_serve::ExecutionOutcome::failed(
+            "NIKA-COMP-001",
+            "execution runtime could not start",
+        );
     };
     rt.block_on(async move {
         tokio::select! {
             result = driver.execute(ServiceExecutionOptions::new()) => match result {
-                Ok(outcome) => match outcome.status() {
-                    ServiceExecutionStatus::Succeeded => {
-                        nika_serve::ExecutionDisposition::Succeeded
+                Ok(outcome) => {
+                    let disposition = match outcome.status() {
+                        ServiceExecutionStatus::Succeeded => {
+                            nika_serve::ExecutionDisposition::Succeeded
+                        }
+                        ServiceExecutionStatus::Paused => nika_serve::ExecutionDisposition::Paused,
+                        _ => nika_serve::ExecutionDisposition::Failed,
+                    };
+                    let mut mapped = nika_serve::ExecutionOutcome::from(disposition);
+                    if let Some((code, message)) = outcome.error() {
+                        mapped = mapped.with_error(code, message);
                     }
-                    ServiceExecutionStatus::Paused => nika_serve::ExecutionDisposition::Paused,
-                    _ => nika_serve::ExecutionDisposition::Failed,
-                },
-                Err(_) => nika_serve::ExecutionDisposition::Failed,
+                    mapped
+                }
+                Err(_) => nika_serve::ExecutionOutcome::failed(
+                    "NIKA-COMP-001",
+                    "service runtime could not be composed",
+                ),
             },
-            _ = cancel => nika_serve::ExecutionDisposition::Failed,
+            _ = cancel => nika_serve::ExecutionDisposition::Failed.into(),
         }
     })
 }

--- a/crates/nika-serve/src/job/model.rs
+++ b/crates/nika-serve/src/job/model.rs
@@ -295,6 +295,12 @@ pub struct JobRecord {
     /// Trace identity derived from [`Self::execution_id`]. Empty until readmit.
     #[serde(default)]
     pub(crate) trace_id: String,
+    /// Redacted NIKA / admission code. Empty until a failed settlement.
+    #[serde(default)]
+    pub(crate) error_code: String,
+    /// Redacted operator message. Empty until a failed settlement.
+    #[serde(default)]
+    pub(crate) error_message: String,
 }
 
 impl JobRecord {
@@ -338,6 +344,13 @@ impl JobRecord {
     #[must_use]
     pub fn trace_id(&self) -> Option<&str> {
         (!self.trace_id.is_empty()).then_some(self.trace_id.as_str())
+    }
+
+    /// Return the redacted failure diagnosis after a failed settlement.
+    #[must_use]
+    pub fn error(&self) -> Option<(&str, &str)> {
+        (!self.error_code.is_empty())
+            .then_some((self.error_code.as_str(), self.error_message.as_str()))
     }
 }
 

--- a/crates/nika-serve/src/job/store.rs
+++ b/crates/nika-serve/src/job/store.rs
@@ -249,6 +249,8 @@ impl JobStore {
             workflow,
             execution_id: String::new(),
             trace_id: String::new(),
+            error_code: String::new(),
+            error_message: String::new(),
         };
         if let Some(world) = world {
             self.dir.write_atomic(&world_file(&record.id), world)?;
@@ -368,6 +370,7 @@ impl JobStore {
         }
         let events = job.append_payloads(&batch)?;
         job.record.status = next;
+        copy_error_from_payloads(&mut job.record, payloads);
         let record = job.record.clone();
         self.persist_event_mutation(&state, &batch)?;
         Ok(JobMutation { record, events })
@@ -1083,4 +1086,48 @@ fn snapshot_too_large(bytes: u64) -> JobStoreError {
         bytes,
         maximum: MAX_JOB_SNAPSHOT_BYTES,
     }
+}
+
+fn copy_error_from_payloads(record: &mut JobRecord, payloads: &[Value]) {
+    if !record.error_code.is_empty() {
+        return;
+    }
+    for payload in payloads {
+        let Some(code) = payload
+            .get("code")
+            .and_then(Value::as_str)
+            .filter(|code| !code.is_empty())
+        else {
+            continue;
+        };
+        let message = payload.get("message").and_then(Value::as_str).unwrap_or("");
+        record.error_code = bound_token(code, 64);
+        record.error_message = bound_message(message);
+        return;
+    }
+}
+
+fn bound_token(raw: &str, max: usize) -> String {
+    raw.chars()
+        .filter(char::is_ascii_graphic)
+        .take(max)
+        .collect()
+}
+
+fn bound_message(raw: &str) -> String {
+    let mut out = String::new();
+    for token in raw.split_whitespace() {
+        if token.starts_with('/') || token.contains(":\\") {
+            continue;
+        }
+        if !out.is_empty() {
+            out.push(' ');
+        }
+        out.push_str(token);
+        if out.len() >= 240 {
+            out.truncate(240);
+            break;
+        }
+    }
+    out
 }

--- a/crates/nika-serve/src/job/tests.rs
+++ b/crates/nika-serve/src/job/tests.rs
@@ -149,6 +149,41 @@ fn restart_replays_the_same_job() {
 }
 
 #[test]
+fn failed_transition_persists_redacted_error_and_drops_paths() {
+    let root = tempfile::tempdir().expect("root");
+    let store = JobStore::open(root.path()).expect("store");
+    let created = admitted_record(
+        store
+            .create_or_replay(key("request-error"), digest(40))
+            .expect("create"),
+    );
+    store
+        .transition_with_events(
+            created.id(),
+            JobStatus::Running,
+            &[json!({"kind": "execution.started", "status": "running"})],
+        )
+        .expect("running");
+    let failed = store
+        .transition_with_events(
+            created.id(),
+            JobStatus::Failed,
+            &[json!({
+                "kind": "execution.settled",
+                "status": "failed",
+                "code": "NIKA-ASSERT-001",
+                "message": "task boom: expected true /tmp/secret.json",
+                "path": "/tmp/secret.json"
+            })],
+        )
+        .expect("failed");
+    let (code, message) = failed.record().error().expect("diagnosis");
+    assert_eq!(code, "NIKA-ASSERT-001");
+    assert!(message.contains("task boom"));
+    assert!(!message.contains("/tmp"), "{message}");
+}
+
+#[test]
 fn conflicting_key_reuse_does_not_mutate_the_job() {
     let root = tempfile::tempdir().expect("root");
     let store = JobStore::open(root.path()).expect("store");

--- a/crates/nika-serve/src/lib.rs
+++ b/crates/nika-serve/src/lib.rs
@@ -16,6 +16,6 @@ pub use job::{
     ServerIncarnation,
 };
 pub use server::{
-    BoundServer, ExecutionBackend, ExecutionDisposition, ServerConfig, ServerError, ServerLimits,
-    serve_http,
+    BoundServer, ExecutionBackend, ExecutionDisposition, ExecutionOutcome, ServerConfig,
+    ServerError, ServerLimits, serve_http,
 };

--- a/crates/nika-serve/src/server/failure_tests.rs
+++ b/crates/nika-serve/src/server/failure_tests.rs
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use super::tests::{
+    TestWorld, auth_header, events_request, get_request, limits, parse_sse_data, post_request,
+    wait_for_status,
+};
+use super::{ExecutionBackend, ExecutionContext, ExecutionDisposition, ExecutionOutcome};
+
+struct FailingBackend;
+struct SucceedingBackend;
+
+impl ExecutionBackend for FailingBackend {
+    fn execute<'a>(
+        &'a self,
+        _context: ExecutionContext<'a>,
+    ) -> Pin<Box<dyn Future<Output = ExecutionOutcome> + Send + 'a>> {
+        Box::pin(
+            async move { ExecutionOutcome::failed("NIKA-ASSERT-001", "task boom: expected true") },
+        )
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn failed_job_get_and_sse_name_the_redacted_nika_code() {
+    let world = TestWorld::new();
+    let server = world.start(Arc::new(FailingBackend), limits()).await;
+    let created = server
+        .request(&post_request(
+            r#"{"workflow":"root.nika.yaml"}"#,
+            "fail-code",
+            &auth_header(),
+        ))
+        .await;
+    let id = created.json()["id"].as_str().expect("id").to_owned();
+    wait_for_status(&server, &id, "failed")
+        .await
+        .expect("failed");
+
+    let job = server
+        .request(&get_request(&format!("/v1/jobs/{id}")))
+        .await;
+    let body = job.json();
+    assert_eq!(body["status"], "failed", "{}", job.body);
+    assert_eq!(body["error"]["code"], "NIKA-ASSERT-001", "{}", job.body);
+    assert_eq!(
+        body["error"]["message"], "task boom: expected true",
+        "{}",
+        job.body
+    );
+    assert!(!job.body.contains("/tmp"), "{}", job.body);
+
+    let streamed = server.request(&events_request(&id, None)).await;
+    let events = parse_sse_data(&streamed.body);
+    let settled = events
+        .iter()
+        .find(|event| event["kind"] == "execution.settled")
+        .expect("settled frame");
+    assert_eq!(settled["code"], "NIKA-ASSERT-001", "{settled}");
+    assert_eq!(settled["message"], "task boom: expected true", "{settled}");
+    assert!(settled.get("secret").is_none());
+    server.stop().await.expect("clean stop");
+}
+
+impl ExecutionBackend for SucceedingBackend {
+    fn execute<'a>(
+        &'a self,
+        _context: ExecutionContext<'a>,
+    ) -> Pin<Box<dyn Future<Output = ExecutionOutcome> + Send + 'a>> {
+        Box::pin(async move { ExecutionDisposition::Succeeded.into() })
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn succeeded_job_omits_error_object() {
+    let world = TestWorld::new();
+    let server = world.start(Arc::new(SucceedingBackend), limits()).await;
+    let created = server
+        .request(&post_request(
+            r#"{"workflow":"root.nika.yaml"}"#,
+            "ok-no-error",
+            &auth_header(),
+        ))
+        .await;
+    let id = created.json()["id"].as_str().expect("id").to_owned();
+    wait_for_status(&server, &id, "succeeded")
+        .await
+        .expect("succeeded");
+    let job = server
+        .request(&get_request(&format!("/v1/jobs/{id}")))
+        .await;
+    assert!(job.json().get("error").is_none(), "{}", job.body);
+    server.stop().await.expect("clean stop");
+}

--- a/crates/nika-serve/src/server/mod.rs
+++ b/crates/nika-serve/src/server/mod.rs
@@ -48,6 +48,59 @@ pub enum ExecutionDisposition {
     Failed,
 }
 
+/// Disposition plus an optional redacted diagnosis (NIKA code + message).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExecutionOutcome {
+    disposition: ExecutionDisposition,
+    error_code: Option<String>,
+    error_message: Option<String>,
+}
+
+impl From<ExecutionDisposition> for ExecutionOutcome {
+    fn from(disposition: ExecutionDisposition) -> Self {
+        Self {
+            disposition,
+            error_code: None,
+            error_message: None,
+        }
+    }
+}
+
+impl ExecutionOutcome {
+    /// Failed execution with a redacted operator-visible diagnosis.
+    #[must_use]
+    pub fn failed(code: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            disposition: ExecutionDisposition::Failed,
+            error_code: Some(code.into()),
+            error_message: Some(message.into()),
+        }
+    }
+
+    /// Terminal class.
+    #[must_use]
+    pub const fn disposition(&self) -> ExecutionDisposition {
+        self.disposition
+    }
+
+    /// Redacted `(code, message)` when the backend supplied one.
+    #[must_use]
+    pub fn error(&self) -> Option<(&str, &str)> {
+        Some((self.error_code.as_deref()?, self.error_message.as_deref()?))
+    }
+
+    /// Attach a diagnosis. Ignored unless this outcome is
+    /// [`ExecutionDisposition::Failed`].
+    #[must_use]
+    pub fn with_error(mut self, code: impl Into<String>, message: impl Into<String>) -> Self {
+        if self.disposition == ExecutionDisposition::Failed {
+            self.error_code = Some(code.into());
+            self.error_message = Some(message.into());
+        }
+        self
+    }
+}
+
 /// Effecting execution seam used after [`ExecutionService`] admission.
 pub trait ExecutionBackend: Send + Sync + 'static {
     /// Execute the exact immutable world in `context`.
@@ -59,7 +112,7 @@ pub trait ExecutionBackend: Send + Sync + 'static {
     fn execute<'a>(
         &'a self,
         context: ExecutionContext<'a>,
-    ) -> Pin<Box<dyn Future<Output = ExecutionDisposition> + Send + 'a>>;
+    ) -> Pin<Box<dyn Future<Output = ExecutionOutcome> + Send + 'a>>;
 }
 
 struct AppState {
@@ -375,7 +428,12 @@ async fn run_job(state: Arc<AppState>, task: ExecutionTask) -> Result<(), Server
         guard
             .settle(
                 JobStatus::Failed,
-                json!({"kind": "execution.refused", "status": "failed"}),
+                json!({
+                    "kind": "execution.refused",
+                    "status": "failed",
+                    "code": "admission_refused",
+                    "message": "workflow world could not be readmitted"
+                }),
             )
             .await?;
         return Ok(());
@@ -437,27 +495,27 @@ async fn settle_disposition(
     admitted: nika_execution::AdmittedExecution,
 ) -> Result<(), ServerError> {
     let session = state.service.begin(admitted);
-    let disposition = tokio::time::timeout(
+    let outcome = tokio::time::timeout(
         state.limits.execution_timeout(),
         state.backend.execute(session.context()),
     )
     .await;
-    let Ok(disposition) = disposition else {
+    let Ok(outcome) = outcome else {
         guard.interrupt().await?;
         return Ok(());
     };
-    let verdict = session.complete(disposition);
+    let verdict = session.complete(outcome.disposition());
     let status = match *verdict.outcome() {
         ExecutionDisposition::Succeeded => JobStatus::Succeeded,
         ExecutionDisposition::Paused => JobStatus::Paused,
         ExecutionDisposition::Failed => JobStatus::Failed,
     };
-    guard
-        .settle(
-            status,
-            json!({"kind": "execution.settled", "status": status}),
-        )
-        .await?;
+    let mut event = json!({"kind": "execution.settled", "status": status});
+    if let Some((code, message)) = outcome.error() {
+        event["code"] = json!(code);
+        event["message"] = json!(message);
+    }
+    guard.settle(status, event).await?;
     Ok(())
 }
 
@@ -531,5 +589,9 @@ fn execution_result(
     }
 }
 
+#[cfg(test)]
+mod failure_tests;
+#[cfg(test)]
+mod test_support;
 #[cfg(test)]
 mod tests;

--- a/crates/nika-serve/src/server/model.rs
+++ b/crates/nika-serve/src/server/model.rs
@@ -19,15 +19,28 @@ pub(crate) struct JobResponse<'a> {
     execution_id: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     trace_id: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<JobErrorBody<'a>>,
+}
+
+#[derive(Debug, Serialize)]
+struct JobErrorBody<'a> {
+    code: &'a str,
+    message: &'a str,
 }
 
 impl<'a> From<&'a JobRecord> for JobResponse<'a> {
     fn from(record: &'a JobRecord) -> Self {
+        let error = matches!(record.status(), JobStatus::Failed)
+            .then(|| record.error())
+            .flatten()
+            .map(|(code, message)| JobErrorBody { code, message });
         Self {
             id: record.id().as_str(),
             status: record.status(),
             execution_id: record.execution_id(),
             trace_id: record.trace_id(),
+            error,
         }
     }
 }

--- a/crates/nika-serve/src/server/openapi.rs
+++ b/crates/nika-serve/src/server/openapi.rs
@@ -57,7 +57,16 @@ fn components() -> Value {
                     "id": {"type": "string", "format": "uuid"},
                     "status": {"$ref": "#/components/schemas/JobStatus"},
                     "execution_id": {"type": "string"},
-                    "trace_id": {"type": "string"}
+                    "trace_id": {"type": "string"},
+                    "error": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": ["code", "message"],
+                        "properties": {
+                            "code": {"type": "string"},
+                            "message": {"type": "string"}
+                        }
+                    }
                 }
             },
             "JobStatusOnly": {
@@ -172,7 +181,7 @@ fn paths() -> Value {
                     {"$ref": "#/components/parameters/LastEventId"}
                 ],
                 "responses": {
-                    "200": {"description": "text/event-stream; data is {sequence,kind,status}"},
+                    "200": {"description": "text/event-stream; data is {sequence,kind,status} plus optional redacted error {code,message}"},
                     "400": error_ref(),
                     "401": error_ref(),
                     "404": error_ref()

--- a/crates/nika-serve/src/server/sse.rs
+++ b/crates/nika-serve/src/server/sse.rs
@@ -146,6 +146,10 @@ struct ProjectedEvent<'a> {
     sequence: u64,
     kind: Option<&'a str>,
     status: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    code: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    message: Option<&'a str>,
 }
 
 fn projected(event: &JobEvent) -> ProjectedEvent<'_> {
@@ -153,6 +157,8 @@ fn projected(event: &JobEvent) -> ProjectedEvent<'_> {
         sequence: event.sequence(),
         kind: string_field(event.payload(), "kind"),
         status: string_field(event.payload(), "status"),
+        code: string_field(event.payload(), "code"),
+        message: string_field(event.payload(), "message"),
     }
 }
 
@@ -296,12 +302,7 @@ mod tests {
             "path": "/tmp/job.json",
             "incarnation_generation": 3
         });
-        let json = serde_json::to_value(ProjectedEvent {
-            sequence: 4,
-            kind: string_field(&payload, "kind"),
-            status: string_field(&payload, "status"),
-        })
-        .expect("projected json");
+        let json = serde_json::to_value(projected_from(&payload, 4)).expect("projected json");
         let object = json.as_object().expect("object");
         let mut keys = object.keys().cloned().collect::<Vec<_>>();
         keys.sort();
@@ -312,6 +313,33 @@ mod tests {
         assert!(json.get("secret").is_none());
         assert!(json.get("path").is_none());
         assert!(json.get("incarnation_generation").is_none());
+    }
+
+    #[test]
+    fn projection_forwards_redacted_failure_code_and_drops_paths() {
+        let payload = json!({
+            "kind": "execution.settled",
+            "status": "failed",
+            "code": "NIKA-ASSERT-001",
+            "message": "task boom: expected true",
+            "secret": "s3cret",
+            "path": "/tmp/job.json"
+        });
+        let json = serde_json::to_value(projected_from(&payload, 2)).expect("projected json");
+        assert_eq!(json["code"], "NIKA-ASSERT-001");
+        assert_eq!(json["message"], "task boom: expected true");
+        assert!(json.get("secret").is_none());
+        assert!(json.get("path").is_none());
+    }
+
+    fn projected_from(payload: &serde_json::Value, sequence: u64) -> ProjectedEvent<'_> {
+        ProjectedEvent {
+            sequence,
+            kind: string_field(payload, "kind"),
+            status: string_field(payload, "status"),
+            code: string_field(payload, "code"),
+            message: string_field(payload, "message"),
+        }
     }
 
     #[tokio::test]

--- a/crates/nika-serve/src/server/test_support.rs
+++ b/crates/nika-serve/src/server/test_support.rs
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use serde_json::Value;
+
+pub(super) fn assert_allowlisted(event: &Value) {
+    let object = event.as_object().expect("event object");
+    assert!(
+        object.contains_key("sequence")
+            && object.contains_key("kind")
+            && object.contains_key("status")
+            && object.keys().all(|key| matches!(
+                key.as_str(),
+                "sequence" | "kind" | "status" | "code" | "message"
+            )),
+        "{event}"
+    );
+}

--- a/crates/nika-serve/src/server/tests.rs
+++ b/crates/nika-serve/src/server/tests.rs
@@ -14,12 +14,13 @@ use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 use tokio::sync::oneshot;
 use tokio::task::JoinSet;
 
+use super::test_support::assert_allowlisted;
 use super::*;
 
-const TOKEN: &str = "remote-test-token-012345678901234567890123456789";
+pub(super) const TOKEN: &str = "remote-test-token-012345678901234567890123456789";
 const WORKFLOW: &str = "nika: root\npermits:\n  tools: [\"nika:jq\"]\ntasks:\n  value:\n    invoke:\n      tool: nika:jq\n      args: { input: 1, expression: \".\" }\n";
 
-struct TestWorld {
+pub(super) struct TestWorld {
     root: tempfile::TempDir,
     workflows: PathBuf,
     state: PathBuf,
@@ -27,7 +28,7 @@ struct TestWorld {
 }
 
 impl TestWorld {
-    fn new() -> Self {
+    pub(super) fn new() -> Self {
         let root = tempfile::tempdir().expect("test root");
         let workflows = root.path().join("workflows");
         let state = root.path().join("state");
@@ -45,7 +46,8 @@ impl TestWorld {
         }
     }
 
-    async fn start(&self, backend: Arc<dyn ExecutionBackend>, limits: ServerLimits) -> TestServer {
+    #[rustfmt::skip]
+    pub(super) async fn start(&self, backend: Arc<dyn ExecutionBackend>, limits: ServerLimits) -> TestServer {
         let config = ServerConfig::new(
             SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
             &self.workflows,
@@ -67,18 +69,18 @@ impl TestWorld {
     }
 }
 
-struct TestServer {
+pub(super) struct TestServer {
     address: SocketAddr,
     shutdown: Option<oneshot::Sender<()>>,
     join: tokio::task::JoinHandle<Result<(), ServerError>>,
 }
 
 impl TestServer {
-    async fn request(&self, request: &str) -> WireResponse {
+    pub(super) async fn request(&self, request: &str) -> WireResponse {
         wire_request(self.address, request).await
     }
 
-    async fn stop(mut self) -> Result<(), ServerError> {
+    pub(super) async fn stop(mut self) -> Result<(), ServerError> {
         self.shutdown.take().expect("shutdown sender").send(()).ok();
         self.join.await.expect("server join")
     }
@@ -126,7 +128,7 @@ impl ExecutionBackend for GatedBackend {
     fn execute<'a>(
         &'a self,
         _context: nika_execution::ExecutionContext<'a>,
-    ) -> Pin<Box<dyn Future<Output = ExecutionDisposition> + Send + 'a>> {
+    ) -> Pin<Box<dyn Future<Output = ExecutionOutcome> + Send + 'a>> {
         Box::pin(async move {
             self.calls.fetch_add(1, Ordering::SeqCst);
             let active = self.active.fetch_add(1, Ordering::SeqCst) + 1;
@@ -134,7 +136,7 @@ impl ExecutionBackend for GatedBackend {
             let permit = self.permits.acquire().await.expect("gate remains open");
             permit.forget();
             self.active.fetch_sub(1, Ordering::SeqCst);
-            ExecutionDisposition::Succeeded
+            ExecutionDisposition::Succeeded.into()
         })
     }
 }
@@ -165,7 +167,7 @@ impl ExecutionBackend for TestBackend {
     fn execute<'a>(
         &'a self,
         context: nika_execution::ExecutionContext<'a>,
-    ) -> Pin<Box<dyn Future<Output = ExecutionDisposition> + Send + 'a>> {
+    ) -> Pin<Box<dyn Future<Output = ExecutionOutcome> + Send + 'a>> {
         Box::pin(async move {
             self.calls.fetch_add(1, Ordering::SeqCst);
             assert_eq!(
@@ -176,15 +178,15 @@ impl ExecutionBackend for TestBackend {
                 WORKFLOW
             );
             if self.hang {
-                pending::<ExecutionDisposition>().await
+                pending::<ExecutionOutcome>().await
             } else {
-                self.disposition
+                self.disposition.into()
             }
         })
     }
 }
 
-fn limits() -> ServerLimits {
+pub(super) fn limits() -> ServerLimits {
     ServerLimits::new(
         1024,
         Duration::from_secs(2),
@@ -1237,7 +1239,11 @@ async fn interrupted_event_stream_redacts_payload_fields() {
     second.stop().await.expect("clean stop");
 }
 
-async fn wait_for_status(server: &TestServer, id: &str, expected: &str) -> Result<(), String> {
+pub(super) async fn wait_for_status(
+    server: &TestServer,
+    id: &str,
+    expected: &str,
+) -> Result<(), String> {
     for _ in 0..200 {
         let response = server
             .request(&get_request(&format!("/v1/jobs/{id}/status")))
@@ -1260,21 +1266,21 @@ async fn wire_request(address: SocketAddr, request: &str) -> WireResponse {
     WireResponse::parse(&response)
 }
 
-fn post_request(body: &str, key: &str, authorization: &str) -> String {
+pub(super) fn post_request(body: &str, key: &str, authorization: &str) -> String {
     format!(
         "POST /v1/jobs HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\nContent-Type: application/json\r\nContent-Length: {}\r\nIdempotency-Key: {key}\r\n{authorization}\r\n{body}",
         body.len()
     )
 }
 
-fn get_request(path: &str) -> String {
+pub(super) fn get_request(path: &str) -> String {
     format!(
         "GET {path} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n{}\r\n",
         auth_header()
     )
 }
 
-fn events_request(id: &str, last_event_id: Option<&str>) -> String {
+pub(super) fn events_request(id: &str, last_event_id: Option<&str>) -> String {
     let last = last_event_id
         .map(|cursor| format!("Last-Event-ID: {cursor}\r\n"))
         .unwrap_or_default();
@@ -1284,7 +1290,7 @@ fn events_request(id: &str, last_event_id: Option<&str>) -> String {
     )
 }
 
-fn parse_sse_data(body: &str) -> Vec<Value> {
+pub(super) fn parse_sse_data(body: &str) -> Vec<Value> {
     let mut events = Vec::new();
     for block in body.split("\n\n") {
         for line in block.lines() {
@@ -1294,14 +1300,6 @@ fn parse_sse_data(body: &str) -> Vec<Value> {
         }
     }
     events
-}
-
-fn assert_allowlisted(event: &Value) {
-    let object = event.as_object().expect("event object");
-    assert_eq!(object.len(), 3, "{event}");
-    assert!(object.contains_key("sequence"), "{event}");
-    assert!(object.contains_key("kind"), "{event}");
-    assert!(object.contains_key("status"), "{event}");
 }
 
 async fn open_sse(address: SocketAddr, request: &str) -> (tokio::net::TcpStream, WireResponse) {
@@ -1339,15 +1337,15 @@ async fn collect_sse(
     parse_sse_data(&body)
 }
 
-fn auth_header() -> String {
+pub(super) fn auth_header() -> String {
     format!("Authorization: Bearer {TOKEN}\r\n")
 }
 
 #[derive(Debug)]
-struct WireResponse {
-    status: u16,
+pub(super) struct WireResponse {
+    pub(super) status: u16,
     headers: String,
-    body: String,
+    pub(super) body: String,
 }
 
 impl WireResponse {
@@ -1369,7 +1367,7 @@ impl WireResponse {
         }
     }
 
-    fn json(&self) -> Value {
+    pub(super) fn json(&self) -> Value {
         serde_json::from_str(&self.body).expect("JSON response")
     }
 

--- a/crates/nika-service-execution/src/lib.rs
+++ b/crates/nika-service-execution/src/lib.rs
@@ -755,6 +755,8 @@ pub enum ServiceExecutionStatus {
 pub struct ServiceExecutionResult {
     status: ServiceExecutionStatus,
     events: Vec<ServiceEvent>,
+    error_code: Option<String>,
+    error_message: Option<String>,
 }
 
 impl std::fmt::Debug for ServiceExecutionResult {
@@ -770,19 +772,32 @@ impl ServiceExecutionResult {
     /// Construct a redacted status and metadata-only event projection.
     #[must_use]
     pub fn new(status: ServiceExecutionStatus, events: Vec<ServiceEvent>) -> Self {
-        Self { status, events }
+        Self {
+            status,
+            events,
+            error_code: None,
+            error_message: None,
+        }
     }
 
     fn from_runtime(outcome: &Result<RunOutcome, RuntimeError>, events: Vec<ServiceEvent>) -> Self {
-        let status = match outcome {
-            Err(_) => ServiceExecutionStatus::Refused,
-            Ok(outcome) if outcome.paused.is_some() => ServiceExecutionStatus::Paused,
+        let (status, error) = match outcome {
+            Err(error) => (
+                ServiceExecutionStatus::Refused,
+                Some((error.spec_code(), error.wire_message())),
+            ),
+            Ok(outcome) if outcome.paused.is_some() => (ServiceExecutionStatus::Paused, None),
             Ok(outcome) if outcome.ok && !outcome.budget_exceeded => {
-                ServiceExecutionStatus::Succeeded
+                (ServiceExecutionStatus::Succeeded, None)
             }
-            Ok(_) => ServiceExecutionStatus::Failed,
+            Ok(outcome) => (ServiceExecutionStatus::Failed, Some(first_failure(outcome))),
         };
-        Self::new(status, events)
+        let mut result = Self::new(status, events);
+        if let Some((code, message)) = error {
+            result.error_code = Some(code);
+            result.error_message = Some(redact_service_message(&message));
+        }
+        result
     }
 
     /// Redacted terminal status.
@@ -795,6 +810,12 @@ impl ServiceExecutionResult {
     #[must_use]
     pub fn events(&self) -> &[ServiceEvent] {
         &self.events
+    }
+
+    /// Redacted `(code, message)` for a refused or failed run.
+    #[must_use]
+    pub fn error(&self) -> Option<(&str, &str)> {
+        Some((self.error_code.as_deref()?, self.error_message.as_deref()?))
     }
 
     /// Consume the result into its redacted status and event projection.
@@ -969,6 +990,24 @@ fn refusal(code: &str, message: String) -> ChildRunRefusal {
         code: code.to_owned(),
         message,
     }
+}
+
+fn redact_service_message(raw: &str) -> String {
+    let mut out = String::new();
+    for token in raw.split_whitespace() {
+        if token.starts_with('/') || token.contains(":\\") {
+            continue;
+        }
+        if !out.is_empty() {
+            out.push(' ');
+        }
+        out.push_str(token);
+        if out.len() >= 240 {
+            out.truncate(240);
+            break;
+        }
+    }
+    out
 }
 
 fn first_failure(outcome: &RunOutcome) -> (String, String) {

--- a/crates/nika-service-execution/src/tests.rs
+++ b/crates/nika-service-execution/src/tests.rs
@@ -95,6 +95,18 @@ async fn service_driver_runs_a_child_from_the_owned_snapshot() -> TestResult<()>
 }
 
 #[tokio::test]
+async fn failed_root_run_projects_a_nika_code_without_paths() -> TestResult<()> {
+    let root = "nika: root\npermits:\n  tools: [\"nika:jq\"]\ntasks:\n  boom:\n    invoke:\n      tool: nika:jq\n      args: { input: 1, expression: \"error(\\\"gauntlet\\\")\" }\n";
+    let driver = admitted_driver(&[("root.nika.yaml", root)])?;
+    let result = driver.execute(ServiceExecutionOptions::new()).await?;
+    assert_eq!(result.status(), ServiceExecutionStatus::Failed);
+    let (code, message) = result.error().expect("failed run diagnosis");
+    assert!(code.starts_with("NIKA-"), "{code} {message}");
+    assert!(!message.contains('/'), "{message}");
+    Ok(())
+}
+
+#[tokio::test]
 async fn independently_parsed_workflow_and_report_cannot_replace_the_admitted_pair()
 -> TestResult<()> {
     let admitted = "nika: admitted\npermits: { tools: [\"nika:jq\"] }\ntasks:\n  value:\n    invoke: { tool: \"nika:jq\", args: { input: 7, expression: \".\" } }\n";


### PR DESCRIPTION
## Why

Gauntlet P14/P4: a failed HTTP job only said `failed`. The NIKA code
lived in the engine and was redacted at the service boundary, so
`GET /v1/jobs/{id}` and SSE could not name it.

## What

- `GET /v1/jobs/{id}` grows optional `{ error: { code, message } }` on `failed`.
- SSE settled frames may forward the same redacted pair.
- Paths and secret-shaped fields stay dropped. Succeeded jobs omit `error`.
- `nika-service-execution` projects a redacted diagnosis; HTTP maps it.

## Not this PR

- W08 cancel/artifacts stay 404.
- HTTP admission-via-`nika check` is a product decision.
- Typed `ServerError::Credential` stays later.

## Tests

- `failed_job_get_and_sse_name_the_redacted_nika_code`
- `succeeded_job_omits_error_object`
- `cargo test -p nika-serve --lib` (75)
- `cargo test -p nika-cli --lib serve` (11)
- `cargo test -p nika-service-execution --lib` (7)

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>