### PR TITLE
fix(serve): name the nika code on admission refuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
   optional `{error:{code,message}}` on `failed`. SSE settled/refused
   frames may carry the same redacted pair. Paths and secret-shaped
   fields stay dropped. Succeeded jobs omit `error`.
+- **POST `/v1/jobs` 422 names the capture diagnosis.** A parse-fatal or
+  check-fatal world returns `{error:{code,message}}` with the NIKA code
+  when the engine stamped one. Symlink and other capture refuses stay
+  `admission_refused`. Paths stay dropped.
 
 
 

--- a/crates/nika-execution/src/service.rs
+++ b/crates/nika-execution/src/service.rs
@@ -409,7 +409,7 @@ fn parse(logical_path: &str, text: &str) -> Result<RawWorkflow, ExecutionError> 
     )
     .map_err(|error| ExecutionError::Parse {
         logical_path: logical_path.to_owned(),
-        detail: error.to_string(),
+        detail: error.diagnostic().to_string(),
     })
 }
 
@@ -463,7 +463,10 @@ fn report_findings(logical_path: &str, report: &CheckReport) -> Vec<String> {
     report
         .findings
         .iter()
-        .map(|finding| format!("{logical_path}: {}", finding.message))
+        .map(|finding| match finding.code.as_deref() {
+            Some(code) => format!("{code} {logical_path}: {}", finding.message),
+            None => format!("{logical_path}: {}", finding.message),
+        })
         .collect()
 }
 

--- a/crates/nika-execution/src/snapshot.rs
+++ b/crates/nika-execution/src/snapshot.rs
@@ -810,7 +810,7 @@ fn parse_workflow(logical_path: &str, text: &str) -> Result<RawWorkflow, Executi
     )
     .map_err(|error| ExecutionError::Parse {
         logical_path: logical_path.to_owned(),
-        detail: error.to_string(),
+        detail: error.diagnostic().to_string(),
     })
 }
 

--- a/crates/nika-execution/src/tests.rs
+++ b/crates/nika-execution/src/tests.rs
@@ -322,6 +322,19 @@ fn child_local_static_defects_are_refused() {
 }
 
 #[test]
+fn parse_refuse_stamps_the_spec_code_in_the_detail() {
+    let (_tmp, owned) = project(&[("bad.nika.yaml", "nika: v1\nworkflow: nope\n")]);
+    let error = ExecutionService::default()
+        .admit(&owned, Path::new("bad.nika.yaml"))
+        .expect_err("fourteen-key parse");
+    let text = error.to_string();
+    assert!(
+        text.contains("NIKA-PARSE-"),
+        "parse refuse must name a spec code: {text}"
+    );
+}
+
+#[test]
 fn depth_count_and_size_limits_fail_closed() {
     let root = parent("child.nika.yaml");
     let (_tmp, owned) = project(&[("root.nika.yaml", &root), ("child.nika.yaml", CHILD)]);

--- a/crates/nika-serve/src/server/error.rs
+++ b/crates/nika-serve/src/server/error.rs
@@ -124,16 +124,7 @@ impl ApiError {
     }
 
     pub(crate) fn into_response(self) -> Response<ResponseBody> {
-        let body = serde_json::json!({
-            "error": {"code": self.code, "message": self.message}
-        });
-        let bytes = serde_json::to_vec(&body).unwrap_or_else(|_| b"{}".to_vec());
-        let mut response = Response::new(once_body(bytes));
-        *response.status_mut() = self.status;
-        response.headers_mut().insert(
-            CONTENT_TYPE,
-            hyper::header::HeaderValue::from_static("application/json"),
-        );
+        let mut response = json_error(self.status, self.code, self.message);
         if self.challenge {
             response.headers_mut().insert(
                 WWW_AUTHENTICATE,
@@ -142,4 +133,67 @@ impl ApiError {
         }
         response
     }
+}
+
+pub(crate) fn json_error(status: StatusCode, code: &str, message: &str) -> Response<ResponseBody> {
+    let body = serde_json::json!({
+        "error": {"code": code, "message": message}
+    });
+    let bytes = serde_json::to_vec(&body).unwrap_or_else(|_| b"{}".to_vec());
+    let mut response = Response::new(once_body(bytes));
+    *response.status_mut() = status;
+    response.headers_mut().insert(
+        CONTENT_TYPE,
+        hyper::header::HeaderValue::from_static("application/json"),
+    );
+    response
+}
+
+pub(crate) fn capture_refused(error: &nika_execution::ExecutionError) -> Response<ResponseBody> {
+    let (code, message) = diagnose_capture(error);
+    json_error(StatusCode::UNPROCESSABLE_ENTITY, &code, &message)
+}
+
+pub(crate) fn diagnose_capture(error: &nika_execution::ExecutionError) -> (String, String) {
+    let raw = error.to_string();
+    let code = first_nika_code(&raw).unwrap_or("admission_refused");
+    (bound_token(code, 64), bound_message(&raw))
+}
+
+fn first_nika_code(raw: &str) -> Option<&str> {
+    let start = raw.find("NIKA-")?;
+    let rest = &raw[start..];
+    let end = rest
+        .find(|ch: char| !(ch.is_ascii_uppercase() || ch.is_ascii_digit() || ch == '-'))
+        .unwrap_or(rest.len());
+    let token = rest.get(..end).filter(|value| !value.is_empty())?;
+    token
+        .contains('-')
+        .then_some(token)
+        .filter(|value| value.bytes().any(|byte| byte.is_ascii_digit()))
+}
+
+fn bound_token(raw: &str, max: usize) -> String {
+    raw.chars()
+        .filter(char::is_ascii_graphic)
+        .take(max)
+        .collect()
+}
+
+fn bound_message(raw: &str) -> String {
+    let mut out = String::new();
+    for token in raw.split_whitespace() {
+        if token.starts_with('/') || token.contains(":\\") {
+            continue;
+        }
+        if !out.is_empty() {
+            out.push(' ');
+        }
+        out.push_str(token);
+        if out.len() >= 240 {
+            out.truncate(240);
+            break;
+        }
+    }
+    out
 }

--- a/crates/nika-serve/src/server/failure_tests.rs
+++ b/crates/nika-serve/src/server/failure_tests.rs
@@ -98,3 +98,28 @@ async fn succeeded_job_omits_error_object() {
     assert!(job.json().get("error").is_none(), "{}", job.body);
     server.stop().await.expect("clean stop");
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn parse_fatal_post_names_the_nika_parse_code() {
+    let world = TestWorld::new();
+    std::fs::write(
+        world.workflows.join("bad.nika.yaml"),
+        "nika: v1\nworkflow: nope\n",
+    )
+    .expect("parse-fatal fixture");
+    let server = world.start(Arc::new(SucceedingBackend), limits()).await;
+    let response = server
+        .request(&post_request(
+            r#"{"workflow":"bad.nika.yaml"}"#,
+            "parse-fatal",
+            &auth_header(),
+        ))
+        .await;
+    assert_eq!(response.status, 422, "{}", response.body);
+    let body = response.json();
+    let code = body["error"]["code"].as_str().expect("code");
+    assert!(code.starts_with("NIKA-PARSE-"), "{code} {}", response.body);
+    assert!(!response.body.contains("/tmp"), "{}", response.body);
+    assert!(response.json().get("id").is_none(), "{}", response.body);
+    server.stop().await.expect("clean stop");
+}

--- a/crates/nika-serve/src/server/mod.rs
+++ b/crates/nika-serve/src/server/mod.rs
@@ -33,6 +33,7 @@ use crate::{EventPageLimit, JobId, JobStatus, JobStore, MAX_EVENT_PAGE_LEN};
 use auth::BearerToken;
 pub use config::{ServerConfig, ServerLimits};
 pub use error::ServerError;
+use error::diagnose_capture;
 use listen::listen_line;
 use store::{StoreActor, StoreHandle};
 
@@ -423,20 +424,29 @@ async fn run_job(state: Arc<AppState>, task: ExecutionTask) -> Result<(), Server
     if !start_running(&mut guard).await? {
         return Ok(());
     }
-    let admitted = admit_workflow(&state, &task).await;
-    let Ok(admitted) = admitted else {
-        guard
-            .settle(
-                JobStatus::Failed,
-                json!({
-                    "kind": "execution.refused",
-                    "status": "failed",
-                    "code": "admission_refused",
-                    "message": "workflow world could not be readmitted"
-                }),
-            )
-            .await?;
-        return Ok(());
+    let admitted = match admit_workflow(&state, &task).await {
+        Ok(admitted) => admitted,
+        Err(error) => {
+            let (code, message) = match &error {
+                Some(error) => diagnose_capture(error),
+                None => (
+                    "admission_refused".to_owned(),
+                    "workflow world could not be readmitted".to_owned(),
+                ),
+            };
+            guard
+                .settle(
+                    JobStatus::Failed,
+                    json!({
+                        "kind": "execution.refused",
+                        "status": "failed",
+                        "code": code,
+                        "message": message
+                    }),
+                )
+                .await?;
+            return Ok(());
+        }
     };
     settle_disposition(&state, &mut guard, admitted).await
 }
@@ -463,12 +473,12 @@ async fn start_running(guard: &mut RunningGuard) -> Result<bool, ServerError> {
 async fn admit_workflow(
     state: &AppState,
     task: &ExecutionTask,
-) -> Result<nika_execution::AdmittedExecution, ()> {
+) -> Result<nika_execution::AdmittedExecution, Option<nika_execution::ExecutionError>> {
     let encoded = state
         .store
         .load_world(task.id.clone())
         .await
-        .map_err(|_| ())?;
+        .map_err(|_| None)?;
     let service = state.service;
     let store = state.store.clone();
     let id = task.id.clone();
@@ -476,16 +486,15 @@ async fn admit_workflow(
         let snapshot = nika_execution::ExecutionSnapshot::decode(&encoded)?;
         service.readmit_snapshot(snapshot)
     })
-    .await;
-    let Ok(Ok(admitted)) = admission else {
-        return Err(());
-    };
+    .await
+    .map_err(|_| None)?;
+    let admitted = admission.map_err(Some)?;
     let execution_id = admitted.execution_id().to_string();
     let trace_id = admitted.trace_id().to_string();
     store
         .stamp_identity(id, execution_id, trace_id)
         .await
-        .map_err(|_| ())?;
+        .map_err(|_| None)?;
     Ok(admitted)
 }
 

--- a/crates/nika-serve/src/server/openapi.rs
+++ b/crates/nika-serve/src/server/openapi.rs
@@ -147,7 +147,8 @@ fn paths() -> Value {
                 "responses": {
                     "202": {"description": "Created", "content": json_job()},
                     "200": {"description": "Idempotent replay", "content": json_job()},
-                    "401": error_ref()
+                    "401": error_ref(),
+                    "422": error_ref()
                 }
             }
         },
@@ -239,5 +240,11 @@ mod tests {
         assert!(!rendered.contains("s3cret"));
         assert!(!rendered.contains("Bearer token-value"));
         assert!(!rendered.contains("/v1/run"));
+        assert!(
+            spec["paths"]["/v1/jobs"]["post"]["responses"]
+                .as_object()
+                .expect("post responses")
+                .contains_key("422")
+        );
     }
 }

--- a/crates/nika-serve/src/server/route.rs
+++ b/crates/nika-serve/src/server/route.rs
@@ -13,7 +13,7 @@ use sha2::{Digest as _, Sha256};
 
 use crate::{Admission, IdempotencyKey, JobId, RequestDigest};
 
-use super::error::{ApiError, ResponseBody, once_body};
+use super::error::{ApiError, ResponseBody, capture_refused, once_body};
 use super::model::{
     CreateJobRequest, HealthResponse, JobResponse, JobStatusResponse, WorkflowListResponse,
     WorkflowMetadataResponse,
@@ -108,7 +108,7 @@ async fn create_job(request: Request<Incoming>, state: Arc<AppState>) -> Respons
     admit_job(state, key, digest, payload.workflow).await
 }
 
-async fn capture_world(state: &AppState, workflow: &str) -> Result<String, ApiError> {
+async fn capture_world(state: &AppState, workflow: &str) -> Result<String, Response<ResponseBody>> {
     let service = state.service;
     let limits = state.snapshot_limits;
     let project = Arc::clone(&state.project);
@@ -120,8 +120,8 @@ async fn capture_world(state: &AppState, workflow: &str) -> Result<String, ApiEr
         Ok::<String, nika_execution::ExecutionError>(encoded)
     })
     .await
-    .map_err(|_| admission_refused())?;
-    captured.map_err(|_| admission_refused())
+    .map_err(|_| admission_refused().into_response())?;
+    captured.map_err(|error| capture_refused(&error))
 }
 
 fn admission_refused() -> ApiError {
@@ -177,7 +177,7 @@ async fn admit_job(
 ) -> Response<ResponseBody> {
     let world = match capture_world(&state, &workflow).await {
         Ok(world) => world,
-        Err(error) => return error.into_response(),
+        Err(response) => return response,
     };
     let Ok(permit) = state.jobs.try_reserve() else {
         return queue_full();

--- a/crates/nika-serve/src/server/tests.rs
+++ b/crates/nika-serve/src/server/tests.rs
@@ -22,7 +22,7 @@ const WORKFLOW: &str = "nika: root\npermits:\n  tools: [\"nika:jq\"]\ntasks:\n  
 
 pub(super) struct TestWorld {
     root: tempfile::TempDir,
-    workflows: PathBuf,
+    pub(super) workflows: PathBuf,
     state: PathBuf,
     token: PathBuf,
 }


### PR DESCRIPTION
## Why

Gauntlet P4: a parse-fatal POST returned opaque `admission_refused`.
Capture already runs parse + check; the 422 dropped the NIKA code.

## What

- `POST /v1/jobs` 422 forwards `{error:{code,message}}` when parse or
  check stamped a NIKA code.
- Symlink and other capture refuses stay `admission_refused`.
- Paths stay dropped.
- OpenAPI lists 422 on POST.

## Not this PR

- W08 cancel/artifacts stay 404.
- Typed `ServerError::Credential` stays later.

## Tests

- `parse_fatal_post_names_the_nika_parse_code`
- `symlinked_workflow_refuses_before_backend_execution`
- `cargo test -p nika-serve --lib` (76)
- `cargo test -p nika-execution --lib` (28)

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>