### PR TITLE
fix(serve): type token-file refusal without leaking paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
   check-fatal world returns `{error:{code,message}}` with the NIKA code
   when the engine stamped one. Symlink and other capture refuses stay
   `admission_refused`. Paths stay dropped.
+- **Token-file refusal is typed.** `ServerError::Credential` now names
+  unreadable, not a regular file, insecure mode, or invalid material.
+  `nika serve --bind` still prints the openssl mint and never echoes
+  bytes. Missing `--token-file` is unchanged. Paths stay dropped.
 
 
 

--- a/crates/nika-cli/src/verbs/serve.rs
+++ b/crates/nika-cli/src/verbs/serve.rs
@@ -116,6 +116,18 @@ fn token_file_refused(prefix: &str) -> String {
     format!("serve · {prefix} ({TOKEN_FILE_RULE})\n  {TOKEN_FILE_MINT}")
 }
 
+fn credential_prefix(kind: nika_serve::CredentialRefuse) -> &'static str {
+    match kind {
+        nika_serve::CredentialRefuse::Unreadable => "token file unreadable",
+        nika_serve::CredentialRefuse::FollowRefused => {
+            "token file must be a regular file, not a symlink"
+        }
+        nika_serve::CredentialRefuse::InsecureMode => "token file must be mode 0600",
+        nika_serve::CredentialRefuse::InvalidMaterial => "token file must be 32–512 visible ASCII",
+        _ => "token file refused",
+    }
+}
+
 fn serve_http_mode(args: &ServeArgs) -> Result<VerbOutput, String> {
     let bind = args
         .bind
@@ -154,7 +166,7 @@ fn serve_http_mode(args: &ServeArgs) -> Result<VerbOutput, String> {
         http_shutdown(),
     ))
     .map_err(|error| match error {
-        nika_serve::ServerError::Credential => token_file_refused("token file refused"),
+        nika_serve::ServerError::Credential(kind) => token_file_refused(credential_prefix(kind)),
         other => format!("serve · {other}"),
     })?;
     Ok(VerbOutput::ok(String::new()))
@@ -968,6 +980,7 @@ mod tests {
         args.token_file = Some(token);
         let out = run(&args);
         assert_eq!(out.code, exit::WORKFLOW, "{}", out.text);
+        assert!(out.text.contains("32–512 visible ASCII"), "{}", out.text);
         assert!(out.text.contains("openssl rand -hex 24"), "{}", out.text);
         assert!(!out.text.contains("too-short"), "{}", out.text);
     }
@@ -989,7 +1002,49 @@ mod tests {
         args.token_file = Some(token);
         let out = run(&args);
         assert_eq!(out.code, exit::WORKFLOW, "{}", out.text);
+        assert!(out.text.contains("mode 0600"), "{}", out.text);
         assert!(out.text.contains("openssl rand -hex 24"), "{}", out.text);
         assert!(!out.text.contains(&secret), "{}", out.text);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_symlink_token_file_teaches_regular_file_and_does_not_echo_the_secret() {
+        let tmp = tempfile::tempdir().expect("tmp");
+        let workflows = tmp.path().join("wf");
+        std::fs::create_dir(&workflows).expect("wf");
+        let real = tmp.path().join("real.token");
+        let secret = "a".repeat(32);
+        std::fs::write(&real, &secret).expect("token");
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            std::fs::set_permissions(&real, std::fs::Permissions::from_mode(0o600)).expect("mode");
+        }
+        let linked = tmp.path().join("linked.token");
+        std::os::unix::fs::symlink(&real, &linked).expect("symlink");
+        let mut args = serve_args();
+        args.bind = Some("127.0.0.1:0".to_owned());
+        args.workflows = Some(workflows);
+        args.token_file = Some(linked);
+        let out = run(&args);
+        assert_eq!(out.code, exit::WORKFLOW, "{}", out.text);
+        assert!(out.text.contains("regular file"), "{}", out.text);
+        assert!(out.text.contains("openssl rand -hex 24"), "{}", out.text);
+        assert!(!out.text.contains(&secret), "{}", out.text);
+    }
+
+    #[test]
+    fn a_missing_token_file_teaches_unreadable_and_the_mint() {
+        let tmp = tempfile::tempdir().expect("tmp");
+        let workflows = tmp.path().join("wf");
+        std::fs::create_dir(&workflows).expect("wf");
+        let mut args = serve_args();
+        args.bind = Some("127.0.0.1:0".to_owned());
+        args.workflows = Some(workflows);
+        args.token_file = Some(tmp.path().join("absent.token"));
+        let out = run(&args);
+        assert_eq!(out.code, exit::WORKFLOW, "{}", out.text);
+        assert!(out.text.contains("unreadable"), "{}", out.text);
+        assert!(out.text.contains("openssl rand -hex 24"), "{}", out.text);
     }
 }

--- a/crates/nika-serve/src/lib.rs
+++ b/crates/nika-serve/src/lib.rs
@@ -16,6 +16,6 @@ pub use job::{
     ServerIncarnation,
 };
 pub use server::{
-    BoundServer, ExecutionBackend, ExecutionDisposition, ExecutionOutcome, ServerConfig,
-    ServerError, ServerLimits, serve_http,
+    BoundServer, CredentialRefuse, ExecutionBackend, ExecutionDisposition, ExecutionOutcome,
+    ServerConfig, ServerError, ServerLimits, serve_http,
 };

--- a/crates/nika-serve/src/server/auth.rs
+++ b/crates/nika-serve/src/server/auth.rs
@@ -16,7 +16,11 @@ use sha2::{Digest as _, Sha256};
 use subtle::ConstantTimeEq as _;
 use zeroize::Zeroizing;
 
-use super::ServerError;
+use super::{CredentialRefuse, ServerError};
+
+const fn refused(kind: CredentialRefuse) -> ServerError {
+    ServerError::Credential(kind)
+}
 
 const MIN_TOKEN_BYTES: usize = 32;
 const MAX_TOKEN_BYTES: usize = 512;
@@ -32,9 +36,9 @@ impl BearerToken {
         let mut bytes = Zeroizing::new(Vec::new());
         file.take((MAX_TOKEN_BYTES + 3) as u64)
             .read_to_end(&mut bytes)
-            .map_err(|_| ServerError::Credential)?;
+            .map_err(|_| refused(CredentialRefuse::Unreadable))?;
         if bytes.len() > MAX_TOKEN_BYTES + 2 {
-            return Err(ServerError::Credential);
+            return Err(refused(CredentialRefuse::InvalidMaterial));
         }
         if bytes.ends_with(b"\r\n") {
             let body_len = bytes.len() - 2;
@@ -46,7 +50,7 @@ impl BearerToken {
             || bytes.len() > MAX_TOKEN_BYTES
             || !bytes.iter().all(u8::is_ascii_graphic)
         {
-            return Err(ServerError::Credential);
+            return Err(refused(CredentialRefuse::InvalidMaterial));
         }
         Ok(Self {
             digest: Sha256::digest(&bytes).into(),
@@ -92,21 +96,32 @@ fn open_secret(path: &Path) -> Result<File, ServerError> {
         Mode::empty(),
     )
     .map(File::from)
-    .map_err(|_| ServerError::Credential)
+    .map_err(|errno| {
+        if errno == nix::errno::Errno::ELOOP {
+            refused(CredentialRefuse::FollowRefused)
+        } else {
+            refused(CredentialRefuse::Unreadable)
+        }
+    })
 }
 
 #[cfg(not(unix))]
 fn open_secret(path: &Path) -> Result<File, ServerError> {
-    File::open(path).map_err(|_| ServerError::Credential)
+    File::open(path).map_err(|_| refused(CredentialRefuse::Unreadable))
 }
 
 #[cfg(unix)]
 fn validate_file_mode(file: &File) -> Result<(), ServerError> {
     use std::os::unix::fs::MetadataExt as _;
 
-    let metadata = file.metadata().map_err(|_| ServerError::Credential)?;
-    if metadata.mode() & 0o077 != 0 || !metadata.is_file() {
-        return Err(ServerError::Credential);
+    let metadata = file
+        .metadata()
+        .map_err(|_| refused(CredentialRefuse::Unreadable))?;
+    if !metadata.is_file() {
+        return Err(refused(CredentialRefuse::FollowRefused));
+    }
+    if metadata.mode() & 0o077 != 0 {
+        return Err(refused(CredentialRefuse::InsecureMode));
     }
     Ok(())
 }
@@ -116,6 +131,6 @@ fn validate_file_mode(file: &File) -> Result<(), ServerError> {
     if file.metadata().is_ok_and(|meta| meta.is_file()) {
         Ok(())
     } else {
-        Err(ServerError::Credential)
+        Err(refused(CredentialRefuse::FollowRefused))
     }
 }

--- a/crates/nika-serve/src/server/credential_tests.rs
+++ b/crates/nika-serve/src/server/credential_tests.rs
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::future::Future;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::Duration;
+
+use super::tests::TestWorld;
+use super::{
+    BoundServer, CredentialRefuse, ExecutionBackend, ExecutionContext, ExecutionDisposition,
+    ExecutionOutcome, ServerConfig, ServerError,
+};
+
+struct CompletingBackend;
+
+impl ExecutionBackend for CompletingBackend {
+    fn execute<'a>(
+        &'a self,
+        _context: ExecutionContext<'a>,
+    ) -> Pin<Box<dyn Future<Output = ExecutionOutcome> + Send + 'a>> {
+        Box::pin(async move { ExecutionDisposition::Succeeded.into() })
+    }
+}
+
+fn backend() -> Arc<CompletingBackend> {
+    Arc::new(CompletingBackend)
+}
+
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread")]
+async fn credential_world_readable_refuses_insecure_mode() {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let world = TestWorld::new();
+    std::fs::set_permissions(&world.token, std::fs::Permissions::from_mode(0o644)).expect("mode");
+    let config = ServerConfig::new(
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
+        &world.workflows,
+        &world.state,
+        &world.token,
+    );
+
+    assert!(matches!(
+        BoundServer::bind(config, backend()).await,
+        Err(ServerError::Credential(CredentialRefuse::InsecureMode))
+    ));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn credential_short_material_refuses_invalid_material() {
+    let world = TestWorld::new();
+    std::fs::write(&world.token, "too-short\n").expect("token");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        std::fs::set_permissions(&world.token, std::fs::Permissions::from_mode(0o600))
+            .expect("mode");
+    }
+    let config = ServerConfig::new(
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
+        &world.workflows,
+        &world.state,
+        &world.token,
+    );
+
+    assert!(matches!(
+        BoundServer::bind(config, backend()).await,
+        Err(ServerError::Credential(CredentialRefuse::InvalidMaterial))
+    ));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn credential_missing_file_refuses_unreadable() {
+    let world = TestWorld::new();
+    let missing = world.root.path().join("absent.token");
+    let config = ServerConfig::new(
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
+        &world.workflows,
+        &world.state,
+        missing,
+    );
+
+    assert!(matches!(
+        BoundServer::bind(config, backend()).await,
+        Err(ServerError::Credential(CredentialRefuse::Unreadable))
+    ));
+}
+
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread")]
+async fn credential_symlink_refuses_follow() {
+    use std::os::unix::fs::symlink;
+
+    let world = TestWorld::new();
+    let linked = world.root.path().join("linked.token");
+    symlink(&world.token, &linked).expect("token symlink");
+    let config = ServerConfig::new(
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
+        &world.workflows,
+        &world.state,
+        linked,
+    );
+
+    assert!(matches!(
+        BoundServer::bind(config, backend()).await,
+        Err(ServerError::Credential(CredentialRefuse::FollowRefused))
+    ));
+}
+
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread")]
+async fn credential_fifo_refuses_without_waiting_for_a_writer() {
+    use nix::sys::stat::Mode;
+    use nix::unistd::mkfifo;
+
+    let world = TestWorld::new();
+    let fifo = world.root.path().join("fifo.token");
+    mkfifo(&fifo, Mode::from_bits_truncate(0o600)).expect("token fifo");
+    let config = ServerConfig::new(
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
+        &world.workflows,
+        &world.state,
+        fifo,
+    );
+
+    let result = tokio::time::timeout(
+        Duration::from_millis(100),
+        BoundServer::bind(config, backend()),
+    )
+    .await
+    .expect("FIFO acquisition must not block");
+    assert!(matches!(
+        result,
+        Err(ServerError::Credential(CredentialRefuse::FollowRefused))
+    ));
+}

--- a/crates/nika-serve/src/server/error.rs
+++ b/crates/nika-serve/src/server/error.rs
@@ -2,6 +2,7 @@
 // Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
 
 use std::convert::Infallible;
+use std::fmt;
 use std::io;
 
 use bytes::Bytes;
@@ -12,6 +13,31 @@ use hyper::{Response, StatusCode};
 use thiserror::Error;
 
 use crate::JobStoreError;
+
+/// Why a credential source was refused. Never carries a path or secret bytes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum CredentialRefuse {
+    /// The file could not be opened or read.
+    Unreadable,
+    /// The path is a symlink, FIFO, or other non-regular file.
+    FollowRefused,
+    /// Group or world bits are set; owner-only mode 0600 is required.
+    InsecureMode,
+    /// Length is outside 32–512 or a byte is not ASCII graphic.
+    InvalidMaterial,
+}
+
+impl fmt::Display for CredentialRefuse {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Unreadable => "unreadable",
+            Self::FollowRefused => "not a regular file",
+            Self::InsecureMode => "insecure mode",
+            Self::InvalidMaterial => "invalid material",
+        })
+    }
+}
 
 pub(crate) type ResponseBody = UnsyncBoxBody<Bytes, Infallible>;
 
@@ -27,8 +53,8 @@ pub enum ServerError {
     #[error("server configuration refused: {0}")]
     InvalidConfig(&'static str),
     /// The credential source could not be acquired safely.
-    #[error("server credential source refused")]
-    Credential,
+    #[error("server credential source refused: {0}")]
+    Credential(CredentialRefuse),
     /// The held workflow registry could not be opened.
     #[error("workflow registry could not be opened: {0}")]
     WorkflowRoot(io::ErrorKind),

--- a/crates/nika-serve/src/server/mod.rs
+++ b/crates/nika-serve/src/server/mod.rs
@@ -32,8 +32,8 @@ use crate::{EventPageLimit, JobId, JobStatus, JobStore, MAX_EVENT_PAGE_LEN};
 
 use auth::BearerToken;
 pub use config::{ServerConfig, ServerLimits};
-pub use error::ServerError;
 use error::diagnose_capture;
+pub use error::{CredentialRefuse, ServerError};
 use listen::listen_line;
 use store::{StoreActor, StoreHandle};
 
@@ -598,6 +598,8 @@ fn execution_result(
     }
 }
 
+#[cfg(test)]
+mod credential_tests;
 #[cfg(test)]
 mod failure_tests;
 #[cfg(test)]

--- a/crates/nika-serve/src/server/tests.rs
+++ b/crates/nika-serve/src/server/tests.rs
@@ -21,10 +21,10 @@ pub(super) const TOKEN: &str = "remote-test-token-012345678901234567890123456789
 const WORKFLOW: &str = "nika: root\npermits:\n  tools: [\"nika:jq\"]\ntasks:\n  value:\n    invoke:\n      tool: nika:jq\n      args: { input: 1, expression: \".\" }\n";
 
 pub(super) struct TestWorld {
-    root: tempfile::TempDir,
+    pub(super) root: tempfile::TempDir,
     pub(super) workflows: PathBuf,
-    state: PathBuf,
-    token: PathBuf,
+    pub(super) state: PathBuf,
+    pub(super) token: PathBuf,
 }
 
 impl TestWorld {
@@ -809,54 +809,6 @@ async fn non_loopback_bind_requires_explicit_acknowledgement_before_io() {
         BoundServer::bind(config, backend).await,
         Err(ServerError::InvalidConfig(_))
     ));
-}
-
-#[cfg(unix)]
-#[tokio::test(flavor = "multi_thread")]
-async fn credential_symlink_refuses_before_listener_bind() {
-    use std::os::unix::fs::symlink;
-
-    let world = TestWorld::new();
-    let linked = world.root.path().join("linked.token");
-    symlink(&world.token, &linked).expect("token symlink");
-    let backend = Arc::new(TestBackend::completes(ExecutionDisposition::Succeeded));
-    let config = ServerConfig::new(
-        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
-        &world.workflows,
-        &world.state,
-        linked,
-    );
-
-    assert!(matches!(
-        BoundServer::bind(config, backend).await,
-        Err(ServerError::Credential)
-    ));
-}
-
-#[cfg(unix)]
-#[tokio::test(flavor = "multi_thread")]
-async fn credential_fifo_refuses_without_waiting_for_a_writer() {
-    use nix::sys::stat::Mode;
-    use nix::unistd::mkfifo;
-
-    let world = TestWorld::new();
-    let fifo = world.root.path().join("fifo.token");
-    mkfifo(&fifo, Mode::from_bits_truncate(0o600)).expect("token fifo");
-    let backend = Arc::new(TestBackend::completes(ExecutionDisposition::Succeeded));
-    let config = ServerConfig::new(
-        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
-        &world.workflows,
-        &world.state,
-        fifo,
-    );
-
-    let result = tokio::time::timeout(
-        Duration::from_millis(100),
-        BoundServer::bind(config, backend),
-    )
-    .await
-    .expect("FIFO acquisition must not block");
-    assert!(matches!(result, Err(ServerError::Credential)));
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Why

`nika serve --bind` already printed the openssl mint on any token-file refuse, but every cause collapsed to one `ServerError::Credential`. A 0644 file, a symlink, a short secret, and a missing file all looked the same.

## What

`ServerError::Credential` now carries `CredentialRefuse`: unreadable, not a regular file, insecure mode, or invalid material. The CLI prefix names the cause and still prints the mint. Paths and secret bytes stay dropped.

## Proof

- `cargo test -p nika-serve --lib` (79)
- CLI tests for short / 0644 / symlink / missing
- clippy -D warnings on nika-serve + nika-cli
- pre-push gate green (YELLOW hygiene only)

Cancel, artifacts, and POST `/v1/run` stay 404.