### PR TITLE
feat(cli): ship access-harness in the downloadable binary

### DIFF
--- a/.github/workflows/diamond-ci.yml
+++ b/.github/workflows/diamond-ci.yml
@@ -261,6 +261,64 @@ jobs:
           PROPTEST_CASES: "1"
         run: cargo miri test --lib -p nika-error
 
+  # W4 · first-contact. cargo-hack --feature-powerset --no-dev-deps only
+  # `check`s; it never runs the feature-gated tests. This job EXECUTES
+  # them on the crates that declare `access-harness`, which is the
+  # config release.yml now ships. `--lib` so a Keychain popup cannot
+  # appear if someone mirrors the job locally (the house law).
+  access-harness:
+    name: access-harness tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # master
+        with:
+          toolchain: "1.91"
+      - uses: Swatinem/rust-cache@258712b0b7b1ddf8bddc9fc3b0faca682b2736c3 # v2
+        with:
+          shared-key: diamond-access-harness
+      - name: test the harness feature (the release config)
+        env:
+          NIKA_KEYCHAIN: "off"
+        run: >
+          cargo test --lib
+          -p nika-cli -p nika-cli-host -p nika-runtime -p nika-verb-agent
+          --features access-harness
+
+  # W4 · first-contact. crates/nika-acp is a STANDALONE workspace
+  # (root Cargo.toml exclude) on purpose: the official ACP SDK's
+  # serde_json/preserve_order would flip byte-attested goldens if it
+  # unified into the engine (nika-harness/src/lib.rs · spec §2bis).
+  # NEVER lift the exclude. This job is the missing consumer: it
+  # builds the quarantine and runs its five batteries against
+  # nika-harness over a process boundary. Own target dir so the
+  # SDK's feature graph cannot leak into the diamond cache.
+  acp-quarantine:
+    name: acp quarantine
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: crates/nika-acp
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # master
+        with:
+          toolchain: "1.91"
+      - uses: Swatinem/rust-cache@258712b0b7b1ddf8bddc9fc3b0faca682b2736c3 # v2
+        with:
+          shared-key: diamond-acp-quarantine
+          workspaces: crates/nika-acp
+      - name: run the five batteries
+        env:
+          NIKA_KEYCHAIN: "off"
+          CARGO_TARGET_DIR: ${{ github.workspace }}/crates/nika-acp/target
+        # The gate_e2e trio share a mock-agent pipe. Parallel threads
+        # close the pipe mid-run and the out-of-grants case reports 503
+        # instead of the verbatim gate question (measured 2026-08-23:
+        # 1/3 failed in a parallel cargo test, 2/2 green isolated).
+        # The engine was innocent; the instrument was the race.
+        run: cargo test --locked -- --test-threads=1
+
   machete:
     name: cargo-machete (unused deps)
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,11 @@ jobs:
         # purpose, darwin included: candle 0.10's quantized rms-norm Metal
         # kernel is broken, so `--features metal` ships a lane that dies
         # at first token. Revisit when candle fixes the kernel.
-        run: cargo build --release --locked --bin nika-cli --target ${{ matrix.target }} --features local-infer
+        # `access-harness` (D-2026-08-04-N1 · P3): the class has been on
+        # main, API-frozen, since 2026-08-08, and was never in this line.
+        # A downloadable binary that cannot `--access` a seat is a lie
+        # the wiring gate now catches. metal stays off (tombstone).
+        run: cargo build --release --locked --bin nika-cli --target ${{ matrix.target }} --features local-infer,access-harness
       - name: Sign + notarize (macOS)
         # Gatekeeper-trust the binary so browser-downloads do not show
         # "unidentified developer". SAFETY: continue-on-error is MANDATORY —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
 ---
 ## [Unreleased]
 
+### Added
+
+- **The next tagged binary includes the harness access class.**
+  `release.yml` builds `--features local-infer,access-harness`. The
+  160 KB `nika-harness` crate has been on main, API-frozen, since
+  2026-08-08, and was compiled out of every downloadable binary.
+  `agent:` tasks can sit on a detected harness via `--access <seat>`
+  once that tag ships. Infer-grade harness (P4 · `infer:` on a seat)
+  stays parked. `crates/nika-acp` stays a quarantined workspace (the
+  official SDK's `preserve_order` must never unify into the engine);
+  Diamond CI now runs its five batteries against `nika-harness` over
+  a process boundary. `metal` stays off (candle 0.10 kernel dies at
+  first token).
+
 ### Changed
 
 - **Failed HTTP jobs name a NIKA code.** `GET /v1/jobs/{id}` grows an

--- a/scripts/ci/check-funnel.sh
+++ b/scripts/ci/check-funnel.sh
@@ -16,7 +16,7 @@
 # RUNS a `permits:` + `exec:` workflow, which the 0.109 sandbox policy
 # refuses unconfined (NIKA-1710 · what killed v0.109.1's Linux builders):
 # the CI job installs bubblewrap before this script, exactly as the
-# release builders now do.
+# release builders now do. Feature set = release.yml (local-infer,access-harness).
 set -euo pipefail
 
 if grep -qE '^\s*members\s*=\s*\[\s*\]\s*$' Cargo.toml; then
@@ -24,7 +24,10 @@ if grep -qE '^\s*members\s*=\s*\[\s*\]\s*$' Cargo.toml; then
   exit 0
 fi
 
-cargo build -p nika-cli --bin nika-cli --features local-infer
+# Same feature set as release.yml:99. A funnel that builds a thinner
+# binary than the tarball is the 2026-08-08 ACCESS lie (E2E receipt on
+# a local-only shape). metal stays off (tombstone in wiring.yaml).
+cargo build -p nika-cli --bin nika-cli --features local-infer,access-harness
 bin="${CARGO_TARGET_DIR:-target}/debug/nika-cli"
 # Both tag-time gates, in the order release.yml plays them: the stranger's
 # first path, then the operator's trust path (resume · reproduce · chain

--- a/wiring.yaml
+++ b/wiring.yaml
@@ -1,0 +1,67 @@
+# wiring.yaml · DECLARED capabilities of this engine
+# A wiring gate reads this file. in_release_build and status are
+# DERIVED by the gate. Never type them.
+
+schema: 1
+
+# A cargo feature that governs user-visible behaviour must appear on a
+# release build line, or live here with a reason and a date.
+
+tombstones:
+  - id: nika-cli:metal
+    reason: >-
+      candle 0.10 quantized rms-norm Metal kernel dies at first token.
+      release.yml keeps it off on purpose. Revisit when candle ships a
+      working kernel.
+    date: 2026-08-23
+
+# An excluded crate that is a deliberate quarantine (own lockfile, own
+# feature graph) is not an orphan IF a named CI job is its judge.
+# NEVER lift the nika-acp exclude (nika-harness/src/lib.rs · spec §2bis).
+
+quarantine:
+  - id: crates/nika-acp
+    reason: >-
+      Official ACP SDK requires serde_json/preserve_order. Unification
+      would flip byte-attested goldens. The SDK judges nika-harness
+      over a process boundary from this workspace.
+    date: 2026-08-23
+    proven_by: acp-quarantine
+
+capabilities:
+  - id: access.harness
+    kind: cargo-feature
+    declared_at: crates/nika-cli/Cargo.toml:72
+    shipped_when: "--features access-harness"
+    reachable_by: "nika run F --access <seat>"
+    proven_by: access-harness
+  - id: access.seat.gemini-cli
+    kind: access-seat
+    declared_at: crates/nika-harness/src/registry.rs:130
+    shipped_when: "--features access-harness"
+    reachable_by: "nika run F --access gemini-cli"
+    proven_by: acp-quarantine
+  - id: access.seat.qwen-code
+    kind: access-seat
+    declared_at: crates/nika-harness/src/registry.rs:139
+    shipped_when: "--features access-harness"
+    reachable_by: "nika run F --access qwen-code"
+    proven_by: acp-quarantine
+  - id: access.seat.kimi-code
+    kind: access-seat
+    declared_at: crates/nika-harness/src/registry.rs:156
+    shipped_when: "--features access-harness"
+    reachable_by: "nika run F --access kimi-code"
+    proven_by: acp-quarantine
+  - id: access.seat.codex-acp
+    kind: access-seat
+    declared_at: crates/nika-harness/src/registry.rs:178
+    shipped_when: "--features access-harness"
+    reachable_by: "nika run F --access codex-acp"
+    proven_by: acp-quarantine
+  - id: access.seat.claude-agent-acp
+    kind: access-seat
+    declared_at: crates/nika-harness/src/registry.rs:200
+    shipped_when: "--features access-harness"
+    reachable_by: "nika run F --access claude-agent-acp"
+    proven_by: acp-quarantine


### PR DESCRIPTION
## Why

`nika-harness` (160 KB, API-frozen) has been on main since 2026-08-08 and was **compiled out of every downloadable binary**. `release.yml` built `--features local-infer` alone. `--access claude-agent-acp` on a tarball is `NIKA-1802`. Docs taught a capability the binary did not contain.

This is the first-contact W4: three CI/build lines, zero product code.

## What

| claim | proof |
|---|---|
| DECLARED | `crates/nika-cli/Cargo.toml` `access-harness` · `crates/nika-harness/src/registry.rs` five seats |
| SHIPPED (next tag) | `release.yml` `--features local-infer,access-harness` |
| REACHABLE | `nika run F --access <seat>` once that tag ships |
| PROVEN | diamond-ci jobs `access-harness` and `acp-quarantine` |

- Funnel e2e builds the **same** feature set as the tarball (the 2026-08-08 lie was an E2E receipt on a local-only shape).
- `crates/nika-acp` stays **excluded**. The official SDK's `preserve_order` must never unify into the engine (`nika-harness/src/lib.rs`). The new job runs its five batteries from that workspace, `--test-threads=1` (a parallel mock-agent pipe race was the instrument, not the engine: 1/3 red in parallel, 2/2 green isolated, 9/9 green serialized).
- `metal` stays off (candle 0.10 kernel dies at first token). Tombstoned in `wiring.yaml`.
- PR #1137 (route `--access` through access plans) stays parked.

## Not in this PR

Infer-grade harness (P4 · `infer:` on a seat). `serve`/`arm` files. Doctor `acp_runtimes` field.

## Local evidence

```
cargo test --lib -p nika-cli -p nika-cli-host -p nika-runtime -p nika-verb-agent --features access-harness
# green (nika-verb-agent 111 passed)

cargo test --locked -- --test-threads=1   # in crates/nika-acp
# 9 passed (5 batteries)

bash dx/scripts/audit/wiring-gate.sh
# clean · 0 findings (G1 nika-acp quarantined-with-judge · G2 metal tombstoned · G2 access-harness on the release line)
```