### PR TITLE
fix(serve): stamp check-fatal nika codes on capture 422

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,15 +18,13 @@ Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
   fields stay dropped. Succeeded jobs omit `error`.
 - **POST `/v1/jobs` 422 names the capture diagnosis.** A parse-fatal or
   check-fatal world returns `{error:{code,message}}` with the NIKA code
-  when the engine stamped one. Symlink and other capture refuses stay
+  when the engine stamped one, including analysis codes (AUTH/SEC)
+  that live on `finding.code`. Symlink and other capture refuses stay
   `admission_refused`. Paths stay dropped.
 - **Token-file refusal is typed.** `ServerError::Credential` now names
   unreadable, not a regular file, insecure mode, or invalid material.
   `nika serve --bind` still prints the openssl mint and never echoes
   bytes. Missing `--token-file` is unchanged. Paths stay dropped.
-
-
-
 - **`nika doctor` uses the same token-file policy as `nika serve`.** A
   short, non-graphic, or symlink `.nika/serve.token` is a fail with the
   openssl mint, not an owner-only green. Group/world-readable still

--- a/crates/nika-cli-host/src/doctor.rs
+++ b/crates/nika-cli-host/src/doctor.rs
@@ -256,12 +256,12 @@ pub(crate) fn serve_http_door(root: &std::path::Path) -> Vec<Finding> {
     };
     if meta.file_type().is_symlink() {
         return vec![serve_token_refused(
-            "token file is a symlink — `nika serve` will refuse it",
+            "token file is a symlink · `nika serve` will refuse it",
         )];
     }
     if !meta.is_file() {
         return vec![serve_token_refused(
-            "token path is not a regular file — `nika serve` will refuse it",
+            "token path is not a regular file · `nika serve` will refuse it",
         )];
     }
     if let Some(finding) = serve_token_group_readable(&token) {
@@ -300,7 +300,7 @@ fn serve_token_bytes_refused(path: &std::path::Path) -> Option<Finding> {
         return None;
     }
     Some(serve_token_refused(
-        "token file is not 32–512 visible ASCII bytes — `nika serve` will refuse it",
+        "token file is not 32–512 visible ASCII bytes · `nika serve` will refuse it",
     ))
 }
 
@@ -316,7 +316,7 @@ fn serve_token_group_readable(path: &std::path::Path) -> Option<Finding> {
     Some(Finding {
         level: Level::Fail,
         label: "serve".to_owned(),
-        detail: "token file is group/world-readable — `nika serve` will refuse it".to_owned(),
+        detail: "token file is group/world-readable · `nika serve` will refuse it".to_owned(),
         fix: Some("umask 077 && chmod 600 .nika/serve.token".to_owned()),
     })
 }

--- a/crates/nika-execution/src/service.rs
+++ b/crates/nika-execution/src/service.rs
@@ -155,7 +155,7 @@ impl ExecutionService {
         };
         let check = nika_check::check_composed(&workflow, &root, &mut reader);
         if !check.is_clean() {
-            let findings = report_findings(&root, &check);
+            let findings = crate::snapshot::report_findings(&root, &check);
             return Err(ExecutionError::CheckFailed { findings });
         }
         let skills = validate_skills(&snapshot, &root, &workflow)?;
@@ -451,23 +451,12 @@ fn validate_child_worlds(snapshot: &ExecutionSnapshot, root: &str) -> Result<(),
         let report = nika_check::check_composed(&workflow, unit.logical_path(), &mut reader);
         if !report.is_clean() {
             return Err(ExecutionError::CheckFailed {
-                findings: report_findings(unit.logical_path(), &report),
+                findings: crate::snapshot::report_findings(unit.logical_path(), &report),
             });
         }
         validate_skills(snapshot, unit.logical_path(), &workflow)?;
     }
     Ok(())
-}
-
-fn report_findings(logical_path: &str, report: &CheckReport) -> Vec<String> {
-    report
-        .findings
-        .iter()
-        .map(|finding| match finding.code.as_deref() {
-            Some(code) => format!("{code} {logical_path}: {}", finding.message),
-            None => format!("{logical_path}: {}", finding.message),
-        })
-        .collect()
 }
 
 #[cfg(test)]

--- a/crates/nika-execution/src/snapshot.rs
+++ b/crates/nika-execution/src/snapshot.rs
@@ -677,12 +677,9 @@ impl<'a, S: ByteSource> SnapshotBuilder<'a, S> {
             };
             let report = nika_check::check_composed(&workflow, &logical_path, &mut reader);
             if !report.is_clean() {
-                let findings = report
-                    .findings
-                    .iter()
-                    .map(|finding| format!("{logical_path}: {}", finding.message))
-                    .collect();
-                return Err(ExecutionError::CheckFailed { findings });
+                return Err(ExecutionError::CheckFailed {
+                    findings: report_findings(&logical_path, &report),
+                });
             }
         }
         Ok(())
@@ -951,6 +948,17 @@ fn sha256_finish(hasher: Sha256) -> String {
         let _ = write!(output, "{byte:02x}");
     }
     output
+}
+
+pub(crate) fn report_findings(logical_path: &str, report: &nika_check::CheckReport) -> Vec<String> {
+    report
+        .findings
+        .iter()
+        .map(|finding| match finding.code.as_deref() {
+            Some(code) => format!("{code} {logical_path}: {}", finding.message),
+            None => format!("{logical_path}: {}", finding.message),
+        })
+        .collect()
 }
 
 #[cfg(test)]

--- a/crates/nika-execution/src/tests.rs
+++ b/crates/nika-execution/src/tests.rs
@@ -335,6 +335,23 @@ fn parse_refuse_stamps_the_spec_code_in_the_detail() {
 }
 
 #[test]
+fn check_refuse_stamps_the_analysis_code_in_the_detail() {
+    let body = "nika: boom\ntasks:\n  t:\n    exec: { command: [\"true\"] }\n";
+    let (_tmp, owned) = project(&[("boom.nika.yaml", body)]);
+    let error = ExecutionSnapshot::capture(
+        &owned,
+        Path::new("boom.nika.yaml"),
+        SnapshotLimits::default(),
+    )
+    .expect_err("undeclared exec");
+    let text = error.to_string();
+    assert!(
+        text.contains("NIKA-AUTH-006") || text.contains("NIKA-SEC-"),
+        "check refuse must name a spec code: {text}"
+    );
+}
+
+#[test]
 fn depth_count_and_size_limits_fail_closed() {
     let root = parent("child.nika.yaml");
     let (_tmp, owned) = project(&[("root.nika.yaml", &root), ("child.nika.yaml", CHILD)]);

--- a/crates/nika-serve/src/server/failure_tests.rs
+++ b/crates/nika-serve/src/server/failure_tests.rs
@@ -123,3 +123,32 @@ async fn parse_fatal_post_names_the_nika_parse_code() {
     assert!(response.json().get("id").is_none(), "{}", response.body);
     server.stop().await.expect("clean stop");
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn check_fatal_post_names_the_nika_analysis_code() {
+    let world = TestWorld::new();
+    std::fs::write(
+        world.workflows.join("boom.nika.yaml"),
+        "nika: boom\ntasks:\n  t:\n    exec: { command: [\"true\"] }\n",
+    )
+    .expect("check-fatal fixture");
+    let server = world.start(Arc::new(SucceedingBackend), limits()).await;
+    let response = server
+        .request(&post_request(
+            r#"{"workflow":"boom.nika.yaml"}"#,
+            "check-fatal",
+            &auth_header(),
+        ))
+        .await;
+    assert_eq!(response.status, 422, "{}", response.body);
+    let body = response.json();
+    let code = body["error"]["code"].as_str().expect("code");
+    assert!(
+        code.starts_with("NIKA-AUTH-") || code.starts_with("NIKA-SEC-"),
+        "{code} {}",
+        response.body
+    );
+    assert!(!response.body.contains("/tmp"), "{}", response.body);
+    assert!(response.json().get("id").is_none(), "{}", response.body);
+    server.stop().await.expect("clean stop");
+}

--- a/docs/crate-specs/nika-serve.md
+++ b/docs/crate-specs/nika-serve.md
@@ -2,7 +2,7 @@
 
 | | |
 |---|---|
-| Status | **WORKSPACE WIP — W10 OPS**. Durable jobs, loopback HTTP, SSE, OpenAPI 3.1, SIGTERM drain, and an honest doctor row for the token file. Cancel/artifacts stay absent. |
+| Status | **WORKSPACE WIP**. Durable jobs, loopback HTTP, SSE, OpenAPI 3.1, SIGTERM drain, typed token-file refusal, failed-job NIKA codes, and 422 capture diagnosis. Cancel/artifacts/`POST /v1/run` stay absent. 12-gate crate admission still pending. |
 | Layer | L4 — remote execution interface projection |
 | Purpose | Persist request admission, lifecycle status, and resumable event cursors, and project the first authenticated HTTP routes over that state. |
 | LOC budget | ≤5,000 source lines for the state plane; ≤15,000 hard crate cap. |
@@ -87,10 +87,10 @@ No public job mutation accepts a filesystem path. Startup paths live only in
 | `GET` | `/health` | public | status, service, four `EngineIdentity` fields |
 | `GET` | `/v1/workflows` | exactly one Bearer | contained `.nika.yaml` relative names |
 | `GET` | `/v1/workflows/{name}` | exactly one Bearer | `{ "workflow": "<contained name>" }` |
-| `POST` | `/v1/jobs` | exactly one Bearer + `Idempotency-Key` | opaque id + status |
-| `GET` | `/v1/jobs/{id}` | exactly one Bearer | opaque id + status |
+| `POST` | `/v1/jobs` | exactly one Bearer + `Idempotency-Key` | opaque id + status · 422 `{error:{code,message}}` names the capture NIKA code when stamped |
+| `GET` | `/v1/jobs/{id}` | exactly one Bearer | opaque id + status · optional `{error:{code,message}}` on `failed` |
 | `GET` | `/v1/jobs/{id}/status` | exactly one Bearer | status only |
-| `GET` | `/v1/jobs/{id}/events` | exactly one Bearer | SSE `text/event-stream`; `id:` sequence; `data:` `{sequence,kind,status}` |
+| `GET` | `/v1/jobs/{id}/events` | exactly one Bearer | SSE `text/event-stream`; `id:` sequence; `data:` `{sequence,kind,status}` plus optional redacted `{code,message}` |
 | `GET` | `/v1/openapi.json` | exactly one Bearer | OpenAPI 3.1 document of the live routes |
 
 Cancel and artifact routes return 404. No route returns source bytes,
@@ -255,9 +255,10 @@ admission wave closes the gates whose authority does not exist in W05.
 
 ## 6. Explicit non-goals
 
-No TLS · no OpenAPI/SDK projection · no workflow upload · no
-cancellation · no artifact authority · no automatic retry of interrupted
-execution. The store records the lost ownership but cannot prove whether an
+No TLS · no workflow upload · no cancellation route · no artifact
+authority · no `POST /v1/run` · no automatic retry of interrupted
+execution. OpenAPI 3.1 is the live authenticated route table
+(`GET /v1/openapi.json`) and omits cancel, artifacts, and `/v1/run`. The store records the lost ownership but cannot prove whether an
 effect committed before the crash. W05 also provides no concrete durable
 `ApprovalHistory`; an in-process or same-filesystem sidecar that the state
 writer can roll back does not meet the contract. W06's HTTP adapter


### PR DESCRIPTION
## Why

POST `/v1/jobs` 422 named parse codes, but capture dropped `finding.code` on check-fatal worlds. AUTH/SEC analysis rows 422 as `admission_refused`.

## What

Capture and readmit share `report_findings`. HTTP 422 now names AUTH/SEC codes. Crate spec matches the live contract. Doctor token rows use the house separator.

W08 cancel/artifacts/`POST /v1/run` stay 404.

## Proof

- `cargo test -p nika-execution --lib` (29)
- `cargo test -p nika-serve --lib` (80) including `check_fatal_post_names_the_nika_analysis_code`
- pre-push gate green (YELLOW hygiene only)