### PR TITLE
fix(cli): refuse --answer on a settled resume gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
 ---
 ## [Unreleased]
 
+### Security
+
+- **A decided human gate stays decided.** `--resume` of a trace that
+  already journaled a `nika:prompt` success now refuses `--answer` on
+  that same task (environment class). A recorded NO cannot be flipped
+  into a shipment. A paused gate (no `task_completed` yet) still
+  accepts `--answer`. Measured against `nika 0.114.0 (80d62b8f8)` on
+  `human-gated-ship`.
+
 ### Changed
 
 - **Failed HTTP jobs name a NIKA code.** `GET /v1/jobs/{id}` grows an

--- a/crates/nika-cli/src/verbs/run/resume_setup.rs
+++ b/crates/nika-cli/src/verbs/run/resume_setup.rs
@@ -91,6 +91,17 @@ pub(super) fn resume_setup(
                 epilogue::emit_error_envelope(&message, output_json);
                 exit::ENV
             })?;
+    // #1067 · a journaled success is a decision. `--answer` on resume
+    // used to force the prompt to re-run (ADR-099 F4 "operator intent");
+    // that turned a recorded NO into a shipment. Paused gates are not in
+    // the plan (they never completed), so they still accept answers.
+    if let Some(ref l) = loaded {
+        nika_dap::resume::refuse_reopened_settled_gates(&l.plan, &answers).map_err(|message| {
+            eprintln!("nika run: {message}");
+            epilogue::emit_error_envelope(&message, output_json);
+            exit::ENV
+        })?;
+    }
     Ok(match loaded {
         Some(l) => ResumeSetup {
             plan: Some(l.plan),

--- a/crates/nika-dap/public-api.txt
+++ b/crates/nika-dap/public-api.txt
@@ -2514,6 +2514,7 @@ pub fn nika_dap::resume::judge_resume(judgment: &nika_dap::resume::ResumeVersion
 pub fn nika_dap::resume::judge_trust(raw: &str) -> nika_dap::resume::TrustVerdict
 pub fn nika_dap::resume::judge_version(events: &[nika_event::event::Event], current: &str) -> nika_dap::resume::ResumeVersion
 pub fn nika_dap::resume::parse_answers(pairs: &[alloc::string::String], wf: &nika_schema::raw::workflow::RawWorkflow) -> core::result::Result<alloc::collections::btree::map::BTreeMap<alloc::string::String, serde_json::value::Value>, alloc::string::String>
+pub fn nika_dap::resume::refuse_reopened_settled_gates(plan: &nika_runtime::resume::ResumePlan, answers: &alloc::collections::btree::map::BTreeMap<alloc::string::String, serde_json::value::Value>) -> core::result::Result<(), alloc::string::String>
 pub fn nika_dap::resume::source_drifted(yaml: &str, events: &[nika_event::event::Event]) -> core::option::Option<bool>
 pub fn nika_dap::resume::summary_line(cache_hits: usize, ran_live: usize) -> alloc::string::String
 pub fn nika_dap::resume::trace_engine_version(events: &[nika_event::event::Event]) -> core::option::Option<alloc::string::String>

--- a/crates/nika-dap/src/resume.rs
+++ b/crates/nika-dap/src/resume.rs
@@ -318,6 +318,30 @@ pub fn parse_answers(
     Ok(answers)
 }
 
+/// A `--answer` that names a task already journaled as success in the
+/// resume plan would re-open a settled gate (#1067). Fresh runs (`plan`
+/// empty) and paused gates (the prompt never completed, so it is not in
+/// the plan) still accept answers. A decided gate stays decided.
+///
+/// # Errors
+///
+/// A human-readable refusal (environment class).
+pub fn refuse_reopened_settled_gates(
+    plan: &ResumePlan,
+    answers: &BTreeMap<String, serde_json::Value>,
+) -> Result<(), String> {
+    for id in answers.keys() {
+        if plan.contains_key(id) {
+            return Err(format!(
+                "--answer {id}: this gate already settled in the resumed trace · \
+                 a decided gate stays decided. Start a new run (no --resume) to \
+                 ask again"
+            ));
+        }
+    }
+    Ok(())
+}
+
 /// The resume's chain-trust verdict (ADR-099 trust amendment ·
 /// 2026-08-08) — a resume TRUSTS the trace's recorded successes: it
 /// serves them as cache hits and runs live tasks on their values. The
@@ -949,5 +973,41 @@ mod tests {
             panic!("a version token never covers a versionless trace");
         };
         assert!(message.contains("records none"), "{message}");
+    }
+
+    #[test]
+    fn a_settled_prompt_refuses_a_fresh_answer() {
+        let mut plan = ResumePlan::new();
+        plan.insert(
+            "human".to_owned(),
+            PriorSuccess::new("d".repeat(64), "i".repeat(64), serde_json::json!(false)),
+        );
+        let mut answers = BTreeMap::new();
+        answers.insert("human".to_owned(), serde_json::json!(true));
+        let err = refuse_reopened_settled_gates(&plan, &answers).expect_err("settled re-open");
+        assert!(err.contains("human"), "{err}");
+        assert!(err.contains("stays decided"), "{err}");
+    }
+
+    #[test]
+    fn a_paused_or_fresh_gate_still_accepts_an_answer() {
+        let plan = ResumePlan::new();
+        let mut answers = BTreeMap::new();
+        answers.insert("human".to_owned(), serde_json::json!(true));
+        refuse_reopened_settled_gates(&plan, &answers)
+            .expect("an unanswered gate is the legitimate --answer path");
+    }
+
+    #[test]
+    fn answering_a_different_task_than_the_settled_ones_is_fine() {
+        let mut plan = ResumePlan::new();
+        plan.insert(
+            "check_a".to_owned(),
+            PriorSuccess::new("d".repeat(64), "i".repeat(64), serde_json::json!("ok")),
+        );
+        let mut answers = BTreeMap::new();
+        answers.insert("human".to_owned(), serde_json::json!(true));
+        refuse_reopened_settled_gates(&plan, &answers)
+            .expect("the human gate is not in the plan, so it has not settled");
     }
 }


### PR DESCRIPTION
Closes supernovae-st/nika#1067

## Why

Measured on the W0 judge `nika 0.114.0 (80d62b8f8)` with the stock `human-gated-ship` scaffold:

```
nika run g.nika.yaml --model mock/echo --answer human=false   # rc=0, act skipped
nika run g.nika.yaml --model mock/echo --resume <that-trace> --answer human=true
# rc=0, act shipped
```

A recorded NO became a shipment. Anyone holding the trace could flip the gate.

## What

`--resume` of a trace that already journaled a `nika:prompt` (or agent) success now refuses `--answer` on that same task (environment class). A paused gate never completed, so it is not in the resume plan and still accepts `--answer`. Fresh `--answer` without `--resume` is unchanged (the F4 CI one-pass path).

The predicate lives in `nika-dap::resume::refuse_reopened_settled_gates` and is mutation-proved both ways (settled refuses · paused/fresh and a different task still accept).

## Not in this PR

- `run_nonce` single-use (issue 1067 shape 2) · follow-up
- identity of the approver on the trace (shape 3)
- issue 1068 (capture:structured) · did **not** reproduce on this darwin+seatbelt judge (rc=1 NIKA-SEC-001). Needs a linux/landlock measure before a patch.
- crates/nika-serve, nika-arm, serve.rs