### PR TITLE
fix(serve): list live post statuses in openapi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
 
 ### Changed
 
+- **OpenAPI lists the live POST statuses.** `GET /v1/openapi.json` names
+  400, 408, 409, 413, 415, 503, and 507 on `POST /v1/jobs` next to
+  200/202/401/422. `info.description` names that `POST /v1/run` is
+  absent. `GET /v1/jobs/{id}/status` stays `{status}` only; diagnosis
+  lives on `GET /v1/jobs/{id}` and SSE.
 - **Failed HTTP jobs name a NIKA code.** `GET /v1/jobs/{id}` grows an
   optional `{error:{code,message}}` on `failed`. SSE settled/refused
   frames may carry the same redacted pair. Paths and secret-shaped

--- a/crates/nika-serve/src/server/openapi.rs
+++ b/crates/nika-serve/src/server/openapi.rs
@@ -5,14 +5,15 @@ use serde_json::{Value, json};
 
 /// [`OpenAPI`](https://spec.openapis.org/oas/v3.1.0) document of the live HTTP surface.
 ///
-/// Cancel and artifact paths are omitted until those authorities exist.
+/// Cancel, artifact, and `POST /v1/run` paths are omitted until those
+/// authorities exist.
 pub(crate) fn document() -> Value {
     json!({
         "openapi": "3.1.0",
         "info": {
             "title": "nika serve",
             "version": env!("CARGO_PKG_VERSION"),
-            "description": "Authenticated loopback remote execution. Cancel and artifacts are absent."
+            "description": "Authenticated loopback remote execution. Cancel, artifacts, and POST /v1/run are absent."
         },
         "servers": [{"url": "http://127.0.0.1"}],
         "security": [{"bearerAuth": []}],
@@ -72,6 +73,7 @@ fn components() -> Value {
             "JobStatusOnly": {
                 "type": "object",
                 "additionalProperties": false,
+                "description": "Status only. Redacted diagnosis lives on GET /v1/jobs/{id} and SSE, never here.",
                 "required": ["status"],
                 "properties": {
                     "status": {"$ref": "#/components/schemas/JobStatus"}
@@ -147,8 +149,15 @@ fn paths() -> Value {
                 "responses": {
                     "202": {"description": "Created", "content": json_job()},
                     "200": {"description": "Idempotent replay", "content": json_job()},
+                    "400": error_named("Invalid JSON or idempotency key"),
                     "401": error_ref(),
-                    "422": error_ref()
+                    "408": error_named("Request deadline"),
+                    "409": error_named("Idempotency key already bound to another request"),
+                    "413": error_named("Request body exceeds the configured limit"),
+                    "415": error_named("Content-Type or Content-Encoding refused"),
+                    "422": error_named("Admission or contained workflow name refused"),
+                    "503": error_named("Execution queue or durable store unavailable"),
+                    "507": error_named("Durable job capacity exhausted")
                 }
             }
         },
@@ -165,7 +174,7 @@ fn paths() -> Value {
         },
         "/v1/jobs/{id}/status": {
             "get": {
-                "summary": "Status only",
+                "summary": "Status only; diagnosis lives on GET /v1/jobs/{id} and SSE",
                 "parameters": [job_id_param()],
                 "responses": {
                     "200": {"description": "Status", "content": json_status()},
@@ -205,7 +214,11 @@ fn json_status() -> Value {
 }
 
 fn error_ref() -> Value {
-    json!({"description": "Error envelope", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}})
+    error_named("Error envelope")
+}
+
+fn error_named(description: &'static str) -> Value {
+    json!({"description": description, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}})
 }
 
 #[cfg(test)]
@@ -239,12 +252,25 @@ mod tests {
         let rendered = spec.to_string();
         assert!(!rendered.contains("s3cret"));
         assert!(!rendered.contains("Bearer token-value"));
-        assert!(!rendered.contains("/v1/run"));
+        let description = spec["info"]["description"].as_str().expect("description");
         assert!(
-            spec["paths"]["/v1/jobs"]["post"]["responses"]
-                .as_object()
-                .expect("post responses")
-                .contains_key("422")
+            description.contains("POST /v1/run"),
+            "description must name the absent run door"
+        );
+        let post = spec["paths"]["/v1/jobs"]["post"]["responses"]
+            .as_object()
+            .expect("post responses");
+        for status in [
+            "200", "202", "400", "401", "408", "409", "413", "415", "422", "503", "507",
+        ] {
+            assert!(post.contains_key(status), "missing POST {status}");
+        }
+        let status_summary = spec["paths"]["/v1/jobs/{id}/status"]["get"]["summary"]
+            .as_str()
+            .expect("status summary");
+        assert!(
+            status_summary.contains("diagnosis"),
+            "status route must say diagnosis lives elsewhere"
         );
     }
 }

--- a/docs/crate-specs/nika-serve.md
+++ b/docs/crate-specs/nika-serve.md
@@ -87,9 +87,9 @@ No public job mutation accepts a filesystem path. Startup paths live only in
 | `GET` | `/health` | public | status, service, four `EngineIdentity` fields |
 | `GET` | `/v1/workflows` | exactly one Bearer | contained `.nika.yaml` relative names |
 | `GET` | `/v1/workflows/{name}` | exactly one Bearer | `{ "workflow": "<contained name>" }` |
-| `POST` | `/v1/jobs` | exactly one Bearer + `Idempotency-Key` | opaque id + status · 422 `{error:{code,message}}` names the capture NIKA code when stamped |
+| `POST` | `/v1/jobs` | exactly one Bearer + `Idempotency-Key` | opaque id + status · 422 `{error:{code,message}}` names the capture NIKA code when stamped · also 400/408/409/413/415/503/507 |
 | `GET` | `/v1/jobs/{id}` | exactly one Bearer | opaque id + status · optional `{error:{code,message}}` on `failed` |
-| `GET` | `/v1/jobs/{id}/status` | exactly one Bearer | status only |
+| `GET` | `/v1/jobs/{id}/status` | exactly one Bearer | status only · diagnosis lives on GET job and SSE |
 | `GET` | `/v1/jobs/{id}/events` | exactly one Bearer | SSE `text/event-stream`; `id:` sequence; `data:` `{sequence,kind,status}` plus optional redacted `{code,message}` |
 | `GET` | `/v1/openapi.json` | exactly one Bearer | OpenAPI 3.1 document of the live routes |
 
@@ -258,8 +258,10 @@ admission wave closes the gates whose authority does not exist in W05.
 No TLS · no workflow upload · no cancellation route · no artifact
 authority · no `POST /v1/run` · no automatic retry of interrupted
 execution. OpenAPI 3.1 is the live authenticated route table
-(`GET /v1/openapi.json`) and omits cancel, artifacts, and `/v1/run`. The store records the lost ownership but cannot prove whether an
-effect committed before the crash. W05 also provides no concrete durable
+(`GET /v1/openapi.json`): it names the live POST statuses and omits
+cancel, artifacts, and `POST /v1/run`. The store records the lost
+ownership but cannot prove whether an effect committed before the
+crash. W05 also provides no concrete durable
 `ApprovalHistory`; an in-process or same-filesystem sidecar that the state
 writer can roll back does not meet the contract. W06's HTTP adapter
 establishes the exclusive server incarnation and calls crate-internal


### PR DESCRIPTION
## Summary

OpenAPI listed only 200/202/401/422 on POST `/v1/jobs` while the listener also returns 400/408/409/413/415/503/507.

The document now names those statuses, says POST `/v1/run` is absent, and points JobStatusOnly diagnosis at GET job and SSE. Paths for cancel, artifacts, and `/v1/run` stay omitted (RFC 9110 404, no 501 stub).

nika-serve `--lib`: 80 passed.

## Test plan

- [x] `cargo test -p nika-serve --lib`
- [x] `cargo clippy -p nika-serve --all-targets -- -D warnings`