### PR TITLE
fix(cli): keep check --fix from writing broken yaml

### DIFF
--- a/changelog.d/905.changed.md
+++ b/changelog.d/905.changed.md
@@ -1,0 +1,6 @@
+- **`check --fix` keeps the filed #905 fixture YAML-parseable.** The
+  round judge already rolled back a broken write; the under-indented
+  `description: |` body (29 of 37 files in the original wave) is now a
+  unit of that judge, and `nika check --fix` on the 7-line repro cannot
+  announce a repair and leave PARSE-001. A repair that cannot re-parse
+  still refuses; the file on disk stays YAML.

--- a/crates/nika-cli-host/src/fix_ladder.rs
+++ b/crates/nika-cli-host/src/fix_ladder.rs
@@ -542,3 +542,46 @@ pub fn splice(
     }
     applied
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The filed #905 corruption: `--fix` nested `description: |` one level
+    /// deeper and left the block body at the old indent, so YAML died
+    /// (`simple key expect ':'`). The round judge must refuse that write.
+    #[test]
+    fn judge_round_refuses_the_underindented_block_scalar() {
+        let before = "workflow: demo\ndescription: |\n  une premiere ligne\n  une seconde ligne\ntasks:\n  - id: t\n    run: echo hi\n";
+        let after = "workflow:\n  id: demo\n  description: |\n  une premiere ligne\n  une seconde ligne\ntasks:\n  t:\n    run: echo hi\n";
+        let refusal = judge_round(before, after, vec!["w1-map `envelope` → `map`".to_owned()])
+            .expect("the under-indented block scalar is broken YAML");
+        assert!(
+            !refusal.reason.is_empty(),
+            "the YAML error rides the refusal"
+        );
+        assert_eq!(
+            refusal.attempted,
+            vec!["w1-map `envelope` → `map`".to_owned()]
+        );
+    }
+
+    #[test]
+    fn judge_round_commits_a_document_that_still_parses() {
+        let before = "nika: w\ntasks:\n  t:\n    exec: { command: [\"true\"] }\n";
+        let after = "nika: w\ntasks:\n  task:\n    exec: { command: [\"true\"] }\n";
+        assert!(
+            judge_round(before, after, vec!["field `t` → `task`".to_owned()]).is_none(),
+            "a still-YAML document is not a refusal"
+        );
+    }
+
+    #[test]
+    fn judge_round_does_not_judge_an_already_unparsable_source() {
+        let broken = "nika: [unclosed\n";
+        assert!(
+            judge_round(broken, "also: [broken\n", vec!["x → y".to_owned()]).is_none(),
+            "the loop cannot repair what it cannot read"
+        );
+    }
+}

--- a/crates/nika-cli-host/src/fix_ladder.rs
+++ b/crates/nika-cli-host/src/fix_ladder.rs
@@ -552,8 +552,8 @@ mod tests {
     /// (`simple key expect ':'`). The round judge must refuse that write.
     #[test]
     fn judge_round_refuses_the_underindented_block_scalar() {
-        let before = "workflow: demo\ndescription: |\n  une premiere ligne\n  une seconde ligne\ntasks:\n  - id: t\n    run: echo hi\n";
-        let after = "workflow:\n  id: demo\n  description: |\n  une premiere ligne\n  une seconde ligne\ntasks:\n  t:\n    run: echo hi\n";
+        let before = "workflow: demo\ndescription: |\n  the first line\n  the second line\ntasks:\n  - id: t\n    run: echo hi\n";
+        let after = "workflow:\n  id: demo\n  description: |\n  the first line\n  the second line\ntasks:\n  t:\n    run: echo hi\n";
         let refusal = judge_round(before, after, vec!["w1-map `envelope` → `map`".to_owned()])
             .expect("the under-indented block scalar is broken YAML");
         assert!(

--- a/crates/nika-cli/src/verbs/fix.rs
+++ b/crates/nika-cli/src/verbs/fix.rs
@@ -562,7 +562,7 @@ mod tests {
         let dir = std::env::temp_dir().join(format!("nika-fix-905-{}", std::process::id()));
         std::fs::create_dir_all(&dir).expect("tmpdir");
         let path = dir.join("m.nika.yaml");
-        let body = "workflow: demo\ndescription: |\n  une premiere ligne\n  une seconde ligne\ntasks:\n  - id: t\n    run: echo hi\n";
+        let body = "workflow: demo\ndescription: |\n  the first line\n  the second line\ntasks:\n  - id: t\n    run: echo hi\n";
         std::fs::write(&path, body).expect("write fixture");
         let out = run(
             path.to_str().expect("utf8 path"),

--- a/crates/nika-cli/src/verbs/fix.rs
+++ b/crates/nika-cli/src/verbs/fix.rs
@@ -553,6 +553,44 @@ mod tests {
     }
 
     #[test]
+    fn a_block_scalar_description_fix_never_writes_unparseable_yaml() {
+        // The filed #905 shape, 7 lines. `--fix` used to announce
+        // « 1 repair applied » and leave `description: |` whose body
+        // stayed at the old indent — the next `check` was PARSE-001.
+        // After this run the file on disk MUST still parse as YAML
+        // (a dialect refusal is fine; a syntax error is the defect).
+        let dir = std::env::temp_dir().join(format!("nika-fix-905-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("tmpdir");
+        let path = dir.join("m.nika.yaml");
+        let body = "workflow: demo\ndescription: |\n  une premiere ligne\n  une seconde ligne\ntasks:\n  - id: t\n    run: echo hi\n";
+        std::fs::write(&path, body).expect("write fixture");
+        let out = run(
+            path.to_str().expect("utf8 path"),
+            false,
+            None,
+            Theme::new(false, true, false),
+        );
+        let after = std::fs::read_to_string(&path).expect("re-read");
+        let yaml_syntax = matches!(
+            nika_schema::parse(&after, nika_schema::FileId::new(0), ParseMode::Strict),
+            Err(nika_schema::SchemaError::YamlSyntax { .. })
+        );
+        assert!(
+            !yaml_syntax,
+            "#905: --fix must not write broken YAML\ntext:\n{}\nfile:\n{after}",
+            out.text
+        );
+        if after == body {
+            assert!(
+                !out.text.contains("repair applied"),
+                "an unchanged file cannot claim a repair: {}",
+                out.text
+            );
+        }
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
     fn identity_moves_the_fourteen_key_envelope_onto_nika_and_converges_green() {
         // The nine-key flag-day repair loop: a 0.108.0 file (`nika: v1` +
         // a `workflow:` block) is refused as an unknown envelope key —


### PR DESCRIPTION
## Why

`nika check --fix` announced « repair applied » and left 29 of 37 PARSE-021 files unparseable (#905). The discriminant was a `description: |` block scalar whose body stayed at the old indent.

The round judge already rolls a broken write back. This pins that judge to the filed under-indented body and runs the 7-line repro through `check --fix`.

## Proof

`cargo test -p nika-cli-host --lib fix_ladder`
`cargo test -p nika-cli --lib verbs::fix`

The tests that would have caught the filed defect:
- `judge_round_refuses_the_underindented_block_scalar`
- `a_block_scalar_description_fix_never_writes_unparseable_yaml`

Closes #905