### PR TITLE
fix(check): give the models rung a spec code

### DIFF
--- a/crates/nika-cli/src/verbs/check/mod.rs
+++ b/crates/nika-cli/src/verbs/check/mod.rs
@@ -567,17 +567,23 @@ fn parse_fatal_json(out: &VerbOutput) -> VerbOutput {
     }
 }
 
-/// Shared `--json` MODELS row shape.
+/// Shared `--json` MODELS row shape. `code` rides only when the refusal
+/// is a spec claim (`NIKA-PROVIDER` for a missing/unknown prefix); the
+/// azure class stays engine-local (#761).
 fn model_finding_rows(findings: &[ModelFinding]) -> serde_json::Value {
     serde_json::Value::Array(
         findings
             .iter()
             .map(|f| {
-                serde_json::json!({
+                let mut row = serde_json::json!({
                     "model": f.model,
                     "tasks": f.tasks,
                     "why": f.why,
-                })
+                });
+                if let Some(code) = &f.code {
+                    row["code"] = serde_json::json!(code);
+                }
+                row
             })
             .collect(),
     )

--- a/crates/nika-cli/src/verbs/check/models_rung.rs
+++ b/crates/nika-cli/src/verbs/check/models_rung.rs
@@ -171,18 +171,19 @@ pub(crate) fn unresolvable_models(
         // The ONE law, shared with the MCP lane (#320 follow-up: the two
         // machine surfaces consult the same fn beside the resolver —
         // they cannot drift apart again).
-        if let Some(why) = nika_providers::resolve_refusal(judged) {
-            audit.findings.push(ModelFinding::new(
-                m.model.clone(),
-                m.tasks.clone(),
-                // A via-default refusal names BOTH halves: the template
-                // the author wrote and the default that was judged.
-                if via_default {
-                    format!("declared default `{judged}` — {why}")
-                } else {
-                    why
-                },
-            ));
+        if let Some(refusal) = nika_providers::resolve_refusal(judged) {
+            // A via-default refusal names BOTH halves: the template
+            // the author wrote and the default that was judged.
+            let why = if via_default {
+                format!("declared default `{judged}` — {}", refusal.why)
+            } else {
+                refusal.why
+            };
+            let mut finding = ModelFinding::new(m.model.clone(), m.tasks.clone(), why);
+            if let Some(code) = refusal.code {
+                finding = finding.with_code(code);
+            }
+            audit.findings.push(finding);
         } else {
             // B-5's sibling: a resolvable model on a server-backed
             // keyless engine earns the green line's liveness nuance —

--- a/crates/nika-cli/src/verbs/check/tests.rs
+++ b/crates/nika-cli/src/verbs/check/tests.rs
@@ -421,6 +421,16 @@ fn checked_output_profile(
     )
 }
 
+/// `--json` twin of a fixture already written by [`checked_output`].
+fn checked_json(name: &str) -> (VerbOutput, serde_json::Value) {
+    let dir = std::env::temp_dir().join(format!("nika-cli-killtests-{}", std::process::id()));
+    let path = dir.join(name);
+    let theme = Theme::new(false, true, false);
+    let out = run(path.to_str().expect("utf8 path"), true, false, None, theme);
+    let payload = serde_json::from_str(&out.text).expect("json");
+    (out, payload)
+}
+
 /// #320 repro 1: a CATALOGED-but-unresolvable provider (`azure/…` —
 /// the vendor listing knows it, the resolver does not) must be a
 /// finding, exit 2 — never a green audit that dies at run.
@@ -440,6 +450,14 @@ fn models_rung_reds_a_cataloged_but_unresolvable_provider() {
         out.text.contains("MODELS") && out.text.contains("`azure`"),
         "the rung names the provider: {}",
         out.text
+    );
+    // #761: cataloged-but-unresolvable is engine-local — no spec code.
+    let (json_out, payload) = checked_json("models-azure.nika.yaml");
+    assert_eq!(json_out.code, 2, "{}", json_out.text);
+    assert_eq!(payload["model_findings"][0]["model"], "azure/gpt-4o");
+    assert!(
+        payload["model_findings"][0].get("code").is_none(),
+        "azure class stays engine-local: {payload:#}"
     );
 }
 
@@ -607,10 +625,38 @@ fn models_rung_reds_a_bare_model_id_and_never_conjures_a_price() {
         payload["model_findings"][0]["model"], "gpt-5-turbo",
         "{payload:#}"
     );
+    let code = payload["model_findings"][0]["code"].as_str().unwrap_or("");
+    assert!(
+        code.contains("NIKA-PROVIDER"),
+        "bare id is the FORM law: {payload:#}"
+    );
     let row = &payload["pricing"]["models"][0];
     assert!(
         row["input_per_million"].is_null() && row["output_per_million"].is_null(),
         "an unresolvable model is never priced: {row:#}"
+    );
+}
+
+/// #761: an unknown provider prefix is the same FORM law as a bare id
+/// — `check --json` stamps `NIKA-PROVIDER` so the spec harness can match.
+#[test]
+fn models_rung_stamps_nika_provider_on_an_unknown_prefix() {
+    let out = checked_output(
+        "models-unknown-prefix.nika.yaml",
+        "nika: m\ntasks:\n  think:\n    infer: { prompt: hi, max_tokens: 10, model: \"not-a-provider/gpt-4\" }\n",
+        false,
+    );
+    assert_eq!(out.code, 2, "unknown prefix is a finding: {}", out.text);
+    let (json_out, payload) = checked_json("models-unknown-prefix.nika.yaml");
+    assert_eq!(json_out.code, 2, "{}", json_out.text);
+    assert_eq!(
+        payload["model_findings"][0]["model"], "not-a-provider/gpt-4",
+        "{payload:#}"
+    );
+    let code = payload["model_findings"][0]["code"].as_str().unwrap_or("");
+    assert!(
+        code.contains("NIKA-PROVIDER"),
+        "unknown prefix is the FORM law: {payload:#}"
     );
 }
 

--- a/crates/nika-display/public-api.txt
+++ b/crates/nika-display/public-api.txt
@@ -55,11 +55,13 @@ impl<T> tracing::instrument::WithSubscriber for nika_display::check_render::Repa
 impl<T> typenum::type_operators::Same for nika_display::check_render::RepairTarget
 pub type nika_display::check_render::RepairTarget::Output = T
 #[non_exhaustive] pub struct nika_display::check_render::ModelFinding
+pub nika_display::check_render::ModelFinding::code: core::option::Option<alloc::string::String>
 pub nika_display::check_render::ModelFinding::model: alloc::string::String
 pub nika_display::check_render::ModelFinding::tasks: alloc::vec::Vec<alloc::string::String>
 pub nika_display::check_render::ModelFinding::why: alloc::string::String
 impl nika_display::check_render::ModelFinding
 pub fn nika_display::check_render::ModelFinding::new(model: alloc::string::String, tasks: alloc::vec::Vec<alloc::string::String>, why: alloc::string::String) -> Self
+pub fn nika_display::check_render::ModelFinding::with_code(self, code: impl core::convert::Into<alloc::string::String>) -> Self
 impl core::clone::Clone for nika_display::check_render::ModelFinding
 pub fn nika_display::check_render::ModelFinding::clone(&self) -> nika_display::check_render::ModelFinding
 impl core::cmp::Eq for nika_display::check_render::ModelFinding

--- a/crates/nika-display/src/check_models.rs
+++ b/crates/nika-display/src/check_models.rs
@@ -28,6 +28,11 @@ pub struct ModelFinding {
     pub tasks: Vec<String>,
     /// The resolver's own refusal reason.
     pub why: String,
+    /// Spec code when the refusal is a spec claim (`NIKA-PROVIDER` for a
+    /// missing or unknown canonical prefix). `None` for engine-local
+    /// refusals (cataloged vendor this binary cannot drive) and for
+    /// catalog-warning rows.
+    pub code: Option<String>,
 }
 
 impl ModelFinding {
@@ -35,7 +40,20 @@ impl ModelFinding {
     /// struct).
     #[must_use]
     pub fn new(model: String, tasks: Vec<String>, why: String) -> Self {
-        Self { model, tasks, why }
+        Self {
+            model,
+            tasks,
+            why,
+            code: None,
+        }
+    }
+
+    /// Attach a spec code (consuming builder — `new()` stays frozen,
+    /// INV-019).
+    #[must_use]
+    pub fn with_code(mut self, code: impl Into<String>) -> Self {
+        self.code = Some(code.into());
+        self
     }
 }
 
@@ -116,15 +134,18 @@ pub(crate) fn models(out: &mut String, report: &CheckReport, audit: &ModelsAudit
     }
     if !audit.findings.is_empty() {
         for f in &audit.findings {
+            let detail = match f.code.as_deref() {
+                Some(code) => format!("[{code}] {}", f.why),
+                None => f.why.clone(),
+            };
             let _ = writeln!(
                 out,
-                " {} {}   `{}` (task{} {}) — {}",
+                " {} {}   `{}` (task{} {}) — {detail}",
                 mark(t, false),
                 t.paint(Role::Strong, "MODELS"),
                 f.model,
                 if f.tasks.len() == 1 { "" } else { "s" },
                 f.tasks.join(", "),
-                f.why
             );
         }
         return;

--- a/crates/nika-mcp/src/tools.rs
+++ b/crates/nika-mcp/src/tools.rs
@@ -343,8 +343,17 @@ fn model_crosscheck(report: &nika_check::CheckReport) -> (Vec<Value>, Vec<Value>
         .models
         .iter()
         .filter_map(|m| {
-            nika_providers::resolve_refusal(&m.model)
-                .map(|why| serde_json::json!({ "model": m.model, "tasks": m.tasks, "why": why }))
+            nika_providers::resolve_refusal(&m.model).map(|refusal| {
+                let mut row = serde_json::json!({
+                    "model": m.model,
+                    "tasks": m.tasks,
+                    "why": refusal.why,
+                });
+                if let Some(code) = refusal.code {
+                    row["code"] = serde_json::json!(code);
+                }
+                row
+            })
         })
         .collect();
     let warnings = report
@@ -817,6 +826,10 @@ mod tests {
             err.contains("gpt-5-turbo") && err.contains("bare model id"),
             "{err}"
         );
+        assert!(
+            err.contains("\"code\": \"NIKA-PROVIDER\""),
+            "the prefix half stamps the FORM law: {err}"
+        );
     }
 
     #[test]
@@ -826,6 +839,10 @@ mod tests {
         assert!(
             err.contains("`azure` does not resolve") || err.contains("provider `azure`"),
             "{err}"
+        );
+        assert!(
+            !err.contains("NIKA-PROVIDER"),
+            "azure class stays engine-local: {err}"
         );
     }
 

--- a/crates/nika-providers/public-api.txt
+++ b/crates/nika-providers/public-api.txt
@@ -296,10 +296,50 @@ impl<T> core::convert::From<T> for nika_providers::profile::Profile
 pub fn nika_providers::profile::Profile::from(t: T) -> T
 impl<T> nika_error::traits::AsAny for nika_providers::profile::Profile where T: 'static
 pub fn nika_providers::profile::Profile::as_any(&self) -> &(dyn core::any::Any + 'static)
+#[non_exhaustive] pub struct nika_providers::profile::ResolveRefusal
+pub nika_providers::profile::ResolveRefusal::code: core::option::Option<&'static str>
+pub nika_providers::profile::ResolveRefusal::why: alloc::string::String
+impl nika_providers::profile::ResolveRefusal
+pub fn nika_providers::profile::ResolveRefusal::new(why: alloc::string::String) -> Self
+pub fn nika_providers::profile::ResolveRefusal::with_code(self, code: &'static str) -> Self
+impl core::clone::Clone for nika_providers::profile::ResolveRefusal
+pub fn nika_providers::profile::ResolveRefusal::clone(&self) -> nika_providers::profile::ResolveRefusal
+impl core::cmp::Eq for nika_providers::profile::ResolveRefusal
+impl core::cmp::PartialEq for nika_providers::profile::ResolveRefusal
+pub fn nika_providers::profile::ResolveRefusal::eq(&self, other: &nika_providers::profile::ResolveRefusal) -> bool
+impl core::fmt::Debug for nika_providers::profile::ResolveRefusal
+pub fn nika_providers::profile::ResolveRefusal::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for nika_providers::profile::ResolveRefusal
+impl<D> owo_colors::OwoColorize for nika_providers::profile::ResolveRefusal
+impl<T, U> core::convert::Into<U> for nika_providers::profile::ResolveRefusal where U: core::convert::From<T>
+pub fn nika_providers::profile::ResolveRefusal::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_providers::profile::ResolveRefusal where U: core::convert::Into<T>
+pub type nika_providers::profile::ResolveRefusal::Error = core::convert::Infallible
+pub fn nika_providers::profile::ResolveRefusal::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_providers::profile::ResolveRefusal where U: core::convert::TryFrom<T>
+pub type nika_providers::profile::ResolveRefusal::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_providers::profile::ResolveRefusal::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_providers::profile::ResolveRefusal where T: core::clone::Clone
+pub type nika_providers::profile::ResolveRefusal::Owned = T
+pub fn nika_providers::profile::ResolveRefusal::clone_into(&self, target: &mut T)
+pub fn nika_providers::profile::ResolveRefusal::to_owned(&self) -> T
+impl<T> core::any::Any for nika_providers::profile::ResolveRefusal where T: 'static + ?core::marker::Sized
+pub fn nika_providers::profile::ResolveRefusal::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_providers::profile::ResolveRefusal where T: ?core::marker::Sized
+pub fn nika_providers::profile::ResolveRefusal::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_providers::profile::ResolveRefusal where T: ?core::marker::Sized
+pub fn nika_providers::profile::ResolveRefusal::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_providers::profile::ResolveRefusal where T: core::clone::Clone
+pub unsafe fn nika_providers::profile::ResolveRefusal::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_providers::profile::ResolveRefusal
+pub fn nika_providers::profile::ResolveRefusal::from(t: T) -> T
+impl<T> nika_error::traits::AsAny for nika_providers::profile::ResolveRefusal where T: 'static
+pub fn nika_providers::profile::ResolveRefusal::as_any(&self) -> &(dyn core::any::Any + 'static)
 pub const nika_providers::profile::CANONICAL_IDS: [&str; 16]
+pub const nika_providers::profile::PREFIX_REFUSAL_CODE: &str
 pub fn nika_providers::profile::access_class_for(provider: &str) -> nika_types::access::AccessClass
 pub fn nika_providers::profile::catalog_warning(model: &str) -> core::option::Option<alloc::string::String>
-pub fn nika_providers::profile::resolve_refusal(model: &str) -> core::option::Option<alloc::string::String>
+pub fn nika_providers::profile::resolve_refusal(model: &str) -> core::option::Option<nika_providers::profile::ResolveRefusal>
 pub fn nika_providers::profile::seed() -> alloc::vec::Vec<nika_providers::profile::Profile>
 pub fn nika_providers::profile::server_backed_local(provider: &str) -> bool
 pub mod nika_providers::registry
@@ -886,6 +926,45 @@ impl<T> core::convert::From<T> for nika_providers::registry::ProvidersConfig
 pub fn nika_providers::registry::ProvidersConfig::from(t: T) -> T
 impl<T> nika_error::traits::AsAny for nika_providers::registry::ProvidersConfig where T: 'static
 pub fn nika_providers::registry::ProvidersConfig::as_any(&self) -> &(dyn core::any::Any + 'static)
+#[non_exhaustive] pub struct nika_providers::ResolveRefusal
+pub nika_providers::ResolveRefusal::code: core::option::Option<&'static str>
+pub nika_providers::ResolveRefusal::why: alloc::string::String
+impl nika_providers::profile::ResolveRefusal
+pub fn nika_providers::profile::ResolveRefusal::new(why: alloc::string::String) -> Self
+pub fn nika_providers::profile::ResolveRefusal::with_code(self, code: &'static str) -> Self
+impl core::clone::Clone for nika_providers::profile::ResolveRefusal
+pub fn nika_providers::profile::ResolveRefusal::clone(&self) -> nika_providers::profile::ResolveRefusal
+impl core::cmp::Eq for nika_providers::profile::ResolveRefusal
+impl core::cmp::PartialEq for nika_providers::profile::ResolveRefusal
+pub fn nika_providers::profile::ResolveRefusal::eq(&self, other: &nika_providers::profile::ResolveRefusal) -> bool
+impl core::fmt::Debug for nika_providers::profile::ResolveRefusal
+pub fn nika_providers::profile::ResolveRefusal::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for nika_providers::profile::ResolveRefusal
+impl<D> owo_colors::OwoColorize for nika_providers::profile::ResolveRefusal
+impl<T, U> core::convert::Into<U> for nika_providers::profile::ResolveRefusal where U: core::convert::From<T>
+pub fn nika_providers::profile::ResolveRefusal::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_providers::profile::ResolveRefusal where U: core::convert::Into<T>
+pub type nika_providers::profile::ResolveRefusal::Error = core::convert::Infallible
+pub fn nika_providers::profile::ResolveRefusal::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_providers::profile::ResolveRefusal where U: core::convert::TryFrom<T>
+pub type nika_providers::profile::ResolveRefusal::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_providers::profile::ResolveRefusal::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_providers::profile::ResolveRefusal where T: core::clone::Clone
+pub type nika_providers::profile::ResolveRefusal::Owned = T
+pub fn nika_providers::profile::ResolveRefusal::clone_into(&self, target: &mut T)
+pub fn nika_providers::profile::ResolveRefusal::to_owned(&self) -> T
+impl<T> core::any::Any for nika_providers::profile::ResolveRefusal where T: 'static + ?core::marker::Sized
+pub fn nika_providers::profile::ResolveRefusal::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_providers::profile::ResolveRefusal where T: ?core::marker::Sized
+pub fn nika_providers::profile::ResolveRefusal::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_providers::profile::ResolveRefusal where T: ?core::marker::Sized
+pub fn nika_providers::profile::ResolveRefusal::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_providers::profile::ResolveRefusal where T: core::clone::Clone
+pub unsafe fn nika_providers::profile::ResolveRefusal::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_providers::profile::ResolveRefusal
+pub fn nika_providers::profile::ResolveRefusal::from(t: T) -> T
+impl<T> nika_error::traits::AsAny for nika_providers::profile::ResolveRefusal where T: 'static
+pub fn nika_providers::profile::ResolveRefusal::as_any(&self) -> &(dyn core::any::Any + 'static)
 pub struct nika_providers::ResolvedProvider<H>
 impl<H> nika_providers::registry::ResolvedProvider<H>
 pub fn nika_providers::registry::ResolvedProvider<H>::strict_schema_rejects_underspecified(&self) -> bool
@@ -925,12 +1004,13 @@ pub async fn nika_providers::registry::ResolvedProvider<H>::infer(&self, request
 impl<TraitVariantBlanketType> nika_kernel_ai::provider::ProviderStream for nika_providers::registry::ResolvedProvider<H> where TraitVariantBlanketType: nika_kernel_ai::provider::ProviderStreamDyn
 pub async fn nika_providers::registry::ResolvedProvider<H>::infer_stream(&self, request: nika_kernel_ai::provider::InferRequest) -> core::result::Result<core::pin::Pin<alloc::boxed::Box<(dyn futures_core::stream::Stream<Item = core::result::Result<nika_kernel_ai::provider::InferEvent, nika_kernel_ai::provider::ProviderError>> + core::marker::Send)>>, nika_kernel_ai::provider::ProviderError>
 pub const nika_providers::CANONICAL_IDS: [&str; 16]
+pub const nika_providers::PREFIX_REFUSAL_CODE: &str
 pub fn nika_providers::access_plan_map(models: &[alloc::string::String], probes: &[nika_providers::probe::ProviderProbe], pin: core::option::Option<&str>) -> alloc::collections::btree::map::BTreeMap<alloc::string::String, nika_types::access::AccessPlan>
 pub fn nika_providers::candidates_for(probes: &[nika_providers::probe::ProviderProbe], provider: &str) -> alloc::vec::Vec<nika_providers::resolve_access::AccessCandidate>
 pub fn nika_providers::catalog_warning(model: &str) -> core::option::Option<alloc::string::String>
 pub fn nika_providers::provider_of(model: &str) -> &str
 pub fn nika_providers::refuse_pin<'m>(models: impl core::iter::traits::collect::IntoIterator<Item = &'m str>, probes: &[nika_providers::probe::ProviderProbe], pin: &str) -> core::option::Option<nika_providers::resolve_access::PinRefusal>
 pub fn nika_providers::resolve_access(model: &str, candidates: &[nika_providers::resolve_access::AccessCandidate], allow_providers: core::option::Option<&[alloc::string::String]>, pin: core::option::Option<&str>) -> core::result::Result<nika_types::access::AccessPlan, nika_providers::resolve_access::AccessRefusal>
-pub fn nika_providers::resolve_refusal(model: &str) -> core::option::Option<alloc::string::String>
+pub fn nika_providers::resolve_refusal(model: &str) -> core::option::Option<nika_providers::profile::ResolveRefusal>
 pub fn nika_providers::seed() -> alloc::vec::Vec<nika_providers::profile::Profile>
 pub fn nika_providers::server_backed_local(provider: &str) -> bool

--- a/crates/nika-providers/src/lib.rs
+++ b/crates/nika-providers/src/lib.rs
@@ -51,7 +51,8 @@ mod test_support;
 pub mod wire;
 
 pub use profile::{
-    CANONICAL_IDS, Profile, WireFormat, catalog_warning, resolve_refusal, seed, server_backed_local,
+    CANONICAL_IDS, PREFIX_REFUSAL_CODE, Profile, ResolveRefusal, WireFormat, catalog_warning,
+    resolve_refusal, seed, server_backed_local,
 };
 pub use registry::{NoHttp, ProviderRegistry, ProvidersConfig, ResolvedProvider};
 pub use resolve_access::{

--- a/crates/nika-providers/src/profile.rs
+++ b/crates/nika-providers/src/profile.rs
@@ -211,21 +211,62 @@ pub fn access_class_for(provider: &str) -> nika_types::access::AccessClass {
     }
 }
 
+/// Spec namespace for a `model:` that lacks a canonical provider prefix
+/// (the FORM law · stdlib/providers-v0.1.md · #761). Numbered
+/// `NIKA-PROVIDER-NNN` codes stay per-adapter runtime errors (spec 05).
+pub const PREFIX_REFUSAL_CODE: &str = "NIKA-PROVIDER";
+
+/// Why a `model:` cannot resolve in THIS binary (#320 / #761).
+///
+/// `code` is `Some(PREFIX_REFUSAL_CODE)` when the claim is a spec claim
+/// (bare id · unknown prefix). `None` when the claim is engine-local
+/// (a cataloged vendor this binary does not drive — the azure class).
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct ResolveRefusal {
+    /// The resolver's own refusal reason.
+    pub why: String,
+    /// Spec code when the refusal is a spec claim.
+    pub code: Option<&'static str>,
+}
+
+impl ResolveRefusal {
+    /// Construct (INV-019 · `new()` on every `#[non_exhaustive]` struct).
+    #[must_use]
+    pub fn new(why: String) -> Self {
+        Self { why, code: None }
+    }
+
+    /// Stamp a spec code (consuming builder — `new()` stays frozen).
+    #[must_use]
+    pub fn with_code(mut self, code: &'static str) -> Self {
+        self.code = Some(code);
+        self
+    }
+}
+
 /// The MODELS-rung law (#320): why a `<provider>/<model>` string cannot
 /// resolve in THIS binary — `None` when it can. Lives beside the resolver
 /// (the set it interrogates is [`CANONICAL_IDS`]) and is shared by every
 /// audit surface (CLI check · MCP `nika_check`): a hallucinated model
 /// must red the audit on EVERY lane, never only one — the vendor catalog
 /// advertising a provider does not make it runnable (the azure class).
+///
+/// The spec half (#761): a missing or unknown canonical prefix is the
+/// FORM law and carries [`PREFIX_REFUSAL_CODE`]. A cataloged vendor this
+/// binary cannot drive stays engine-local (`code` is `None`).
 #[must_use]
-pub fn resolve_refusal(model: &str) -> Option<String> {
+pub fn resolve_refusal(model: &str) -> Option<ResolveRefusal> {
     match model.split_once('/') {
-        None => Some(format!(
-            "`{model}` is a bare model id — the contract is `<provider>/<model>` \
-             (pick the provider that serves it; `nika doctor` names the \
-             {} runnable providers)",
-            CANONICAL_IDS.len()
-        )),
+        None => Some(
+            ResolveRefusal::new(format!(
+                "`{model}` is a bare model id — the contract is `<provider>/<model>` \
+                 (pick the provider that serves it; `nika doctor` names the \
+                 {} runnable providers)",
+                CANONICAL_IDS.len()
+            ))
+            .with_code(PREFIX_REFUSAL_CODE),
+        ),
         Some((provider, _)) if !CANONICAL_IDS.contains(&provider) => {
             // The shared did-you-mean metric (nika-types::suggest — the
             // same threshold the parser/checker suggest with): `antropic`
@@ -234,12 +275,20 @@ pub fn resolve_refusal(model: &str) -> Option<String> {
             let guess = nika_types::suggest::did_you_mean(provider, CANONICAL_IDS)
                 .map(|p| format!(" — did you mean `{p}`?"))
                 .unwrap_or_default();
-            Some(format!(
+            let why = format!(
                 "provider `{provider}` does not resolve in THIS binary \
                  ({} runnable — `nika doctor` names them); a cataloged \
                  vendor is not a runnable one{guess}",
                 CANONICAL_IDS.len()
-            ))
+            );
+            let mut refusal = ResolveRefusal::new(why);
+            // Spec claim: the prefix is not a known vendor at all.
+            // Engine-local: the vendor is cataloged but this binary
+            // cannot drive it (azure · moonshot-until-wired · aliases).
+            if nika_catalog::find_provider(provider).is_none() {
+                refusal = refusal.with_code(PREFIX_REFUSAL_CODE);
+            }
+            Some(refusal)
         }
         Some(_) => None,
     }
@@ -436,15 +485,30 @@ mod tests {
     fn resolve_refusal_names_the_two_classes_and_clears_the_runnable() {
         // bare id — teaches the contract
         let bare = resolve_refusal("gpt-5-turbo").expect("bare id refused");
-        assert!(bare.contains("bare model id") && bare.contains("16 runnable"));
+        assert!(bare.why.contains("bare model id") && bare.why.contains("16 runnable"));
         // cataloged-but-unresolvable provider — the azure class
         let azure = resolve_refusal("azure/gpt-4o").expect("azure refused");
-        assert!(azure.contains("`azure`") && azure.contains("not a runnable one"));
+        assert!(azure.why.contains("`azure`") && azure.why.contains("not a runnable one"));
         // azure is far from every canonical id — no guess appended
-        assert!(!azure.contains("did you mean"), "{azure}");
+        assert!(!azure.why.contains("did you mean"), "{}", azure.why);
         // every canonical provider clears, inner slashes included
         assert!(resolve_refusal("mock/echo").is_none());
         assert!(resolve_refusal("huggingface/Qwen/Qwen3.5-9B:groq").is_none());
+    }
+
+    /// #761: the prefix half is a spec claim; a cataloged vendor this
+    /// binary cannot drive stays engine-local.
+    #[test]
+    fn resolve_refusal_stamps_the_prefix_code_and_spares_the_azure_class() {
+        let bare = resolve_refusal("gpt-5-turbo").expect("bare id refused");
+        assert_eq!(bare.code, Some(PREFIX_REFUSAL_CODE));
+        let unknown = resolve_refusal("not-a-provider/gpt-4").expect("unknown prefix refused");
+        assert_eq!(unknown.code, Some(PREFIX_REFUSAL_CODE));
+        let azure = resolve_refusal("azure/gpt-4o").expect("azure refused");
+        assert_eq!(azure.code, None, "cataloged-but-unresolvable stays local");
+        let typo = resolve_refusal("antropic/claude-sonnet-4-6").expect("typo refused");
+        assert_eq!(typo.code, Some(PREFIX_REFUSAL_CODE));
+        assert!(resolve_refusal("mock/echo").is_none());
     }
 
     #[test]
@@ -453,9 +517,17 @@ mod tests {
         // from the most-used provider id — the refusal now carries the
         // rename, through the SAME shared metric as the parser/checker.
         let typo = resolve_refusal("antropic/claude-sonnet-4-6").expect("typo refused");
-        assert!(typo.contains("did you mean `anthropic`?"), "{typo}");
+        assert!(
+            typo.why.contains("did you mean `anthropic`?"),
+            "{}",
+            typo.why
+        );
         let gemni = resolve_refusal("gemni/gemini-2.5-flash").expect("typo refused");
-        assert!(gemni.contains("did you mean `gemini`?"), "{gemni}");
+        assert!(
+            gemni.why.contains("did you mean `gemini`?"),
+            "{}",
+            gemni.why
+        );
     }
 
     /// The two-strike class (audit UX 2026-07-31): a ghost model on a


### PR DESCRIPTION
## Why

`nika check --json` refused a missing/unknown provider prefix correctly but emitted `{model, tasks, why}` with **no spec code**, so the spec oracle-parity harness could not match (`{namespace: NIKA-PROVIDER}`). Closes #761.

## What

- `resolve_refusal` now returns a `ResolveRefusal { why, code }`.
- The **FORM** half (bare id · unknown prefix) stamps `NIKA-PROVIDER`.
- A **cataloged-but-unwired** provider (azure class) stays engine-local — no spec code.
- `check --json` `model_findings[]` carries `"code"` when present; MCP `nika_check` agrees.

## Tests

- bare `gpt-5-turbo` → `model_findings[0].code` contains `NIKA-PROVIDER`
- unknown prefix `not-a-provider/gpt-4` → same
- `azure/gpt-4o` → no `code` key

## Skipped

**NIKA-VAR-003** on the remaining check-side `schema_type` did-you-mean rows — not cheap. The coded walk in `analyze()` already owns `NIKA-VAR-003` (2026-07-30 lock); leftover `schema_findings` include other classes (`for_each` → `NIKA-VAR-006`). Stamping VAR-003 on the whole `schema_type` fold would mix codes.