### PR TITLE
fix(check): expose one-obvious-way lints on check json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
 
 ### Added
 
+- **`nika check --json` carries one-obvious-way lints.** `hints[]`
+  rows with `kind: "one-obvious-way"` and `code: "one-obvious-way/NNN"`
+  (advice starts with the rule id), the same door native-first already
+  had. Warnings, never errors — `clean` stays true.
+
 - **The next tagged binary includes the harness access class.**
   `release.yml` builds `--features local-infer,access-harness`. The
   160 KB `nika-harness` crate has been on main, API-frozen, since

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4303,6 +4303,7 @@ dependencies = [
  "nika-http",
  "nika-kernel",
  "nika-kernel-mock",
+ "nika-lints",
  "nika-lsp",
  "nika-mcp",
  "nika-migrate",

--- a/crates/nika-cli/Cargo.toml
+++ b/crates/nika-cli/Cargo.toml
@@ -24,6 +24,7 @@ nika-service-execution = { path = "../nika-service-execution", version = "0.114.
 nika-serve   = { path = "../nika-serve", version = "0.114.0" }      # loopback HTTP mode of `nika serve` (W06)
 jiff        = { workspace = true }  # the CLOCK — nika-cadence is pure and takes a Zoned; reading one is an L4 act  # the project file (ceiling — the --max-cost-usd flag's default rung · D-2026-08-11-N5)
 nika-check  = { path = "../nika-check", version = "0.114.0" }  # the ADR-092 check ladder (the check verb · run gates · fix loop)
+nika-lints  = { path = "../nika-lints", version = "0.114.0" }  # one-obvious-way preference lints on `check --json` hints (#763)
 nika-graph = { path = "../nika-graph", version = "0.114.0" }   # the canonical projection (inspect --format json renders it)
 nika-error  = { path = "../nika-error", version = "0.114.0" }  # the code registry (`nika explain`)
 nika-pack   = { path = "../nika-pack", version = "0.114.0" }   # the embedded language pack (`nika spec|schema|examples|new`)

--- a/crates/nika-cli/src/verbs/check/lints_surface.rs
+++ b/crates/nika-cli/src/verbs/check/lints_surface.rs
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! #763 — one-obvious-way lints on `check --json` `hints[]`.
+//! Sibling of `tests.rs` (that file sits on the 1500-LOC wall).
+
+use super::*;
+
+/// One-obvious-way lints ride `check --json` `hints[]` (warnings, never
+/// errors). A skip-for-dependents file names the rule; infer-only does
+/// not grow the kind.
+#[test]
+fn json_exposes_one_obvious_way_hints_as_warnings() {
+    let theme = Theme::new(false, true, false);
+    let dir = std::env::temp_dir().join(format!("nika-cli-oow-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("tmp");
+    let run_json = |name: &str, yaml: &str| {
+        let path = dir.join(name);
+        std::fs::write(&path, yaml).expect("write");
+        run(path.to_str().expect("utf8"), true, false, None, theme)
+    };
+
+    let dirty = run_json(
+        "d.nika.yaml",
+        "nika: skip\npermits: { exec: [\"true\"] }\ntasks:\n  a:\n    exec: { command: [\"true\"] }\n    on_error: { skip: true }\n  b:\n    with: { data: \"${{ tasks.a.output }}\" }\n    exec: { command: [\"true\", \"${{ with.data }}\"] }\n",
+    );
+    assert_eq!(dirty.code, 0, "{}", dirty.text);
+    let payload: serde_json::Value = serde_json::from_str(&dirty.text).expect("json");
+    assert_eq!(payload["clean"], true, "{payload:#}");
+    let hit = payload["hints"]
+        .as_array()
+        .expect("hints")
+        .iter()
+        .find(|h| h["kind"] == "one-obvious-way")
+        .expect("one-obvious-way hint");
+    assert_eq!(hit["code"], "one-obvious-way/002", "{payload:#}");
+    assert_eq!(hit["task"], "a", "{payload:#}");
+    assert!(
+        hit["advice"]
+            .as_str()
+            .expect("advice")
+            .starts_with("one-obvious-way/002"),
+        "{payload:#}"
+    );
+
+    let clean = run_json(
+        "c.nika.yaml",
+        "nika: ok\ntasks:\n  t:\n    infer: { prompt: hi, max_tokens: 10, model: \"mock/echo\" }\n",
+    );
+    assert_eq!(clean.code, 0, "{}", clean.text);
+    let clean_payload: serde_json::Value = serde_json::from_str(&clean.text).expect("json");
+    assert!(
+        clean_payload["hints"]
+            .as_array()
+            .expect("hints")
+            .iter()
+            .all(|h| h["kind"] != "one-obvious-way"),
+        "{clean_payload:#}"
+    );
+}

--- a/crates/nika-cli/src/verbs/check/mod.rs
+++ b/crates/nika-cli/src/verbs/check/mod.rs
@@ -440,6 +440,7 @@ fn render_checked_with_profile(
     if json {
         return json_verdict(
             report,
+            wf,
             &models_audit,
             skills,
             &drift_hints,
@@ -583,11 +584,13 @@ fn model_finding_rows(findings: &[ModelFinding]) -> serde_json::Value {
     )
 }
 
-/// `--json` verdict object. Drift rows append to `hints[]` plus
-/// their `code`.
+/// `--json` verdict object. Drift and one-obvious-way rows append to
+/// `hints[]` plus their `code`. Both families are warnings — `clean`
+/// never reads them.
 #[allow(clippy::too_many_arguments)] // the verdict's seams, one each — the render.rs:427 precedent
 fn json_verdict(
     report: &CheckReport,
+    wf: &nika_schema::raw::RawWorkflow,
     models_audit: &ModelsAudit,
     skills: &nika_schema::ResolvedSkills,
     drift_hints: &[String],
@@ -607,9 +610,7 @@ fn json_verdict(
             .get_mut("hints")
             .and_then(serde_json::Value::as_array_mut)
         {
-            for advice in drift_hints {
-                hints.push(serde_json::json!({"kind": "drift", "task": "-", "advice": advice, "code": drift::DRIFT_CODE}));
-            }
+            push_advisory_json_hints(hints, drift_hints, wf);
         }
         obj.insert("clean".to_owned(), serde_json::Value::Bool(clean));
         obj.insert(
@@ -687,6 +688,35 @@ fn json_verdict(
     }
 }
 
+/// Drift + one-obvious-way rows on the machine `hints[]`.
+///
+/// Native-first already rides `CheckReport.hints` (kind + numbered
+/// `code` + task + advice that starts with the rule id). One-obvious-way
+/// lives in `nika-lints` and cannot join that report without a
+/// nika-check → nika-lints cycle, so this edge is the public door (#763).
+fn push_advisory_json_hints(
+    hints: &mut Vec<serde_json::Value>,
+    drift_hints: &[String],
+    wf: &nika_schema::raw::RawWorkflow,
+) {
+    for advice in drift_hints {
+        hints.push(serde_json::json!({
+            "kind": "drift",
+            "task": "-",
+            "advice": advice,
+            "code": drift::DRIFT_CODE,
+        }));
+    }
+    for lint in nika_lints::one_obvious_way(wf) {
+        hints.push(serde_json::json!({
+            "kind": "one-obvious-way",
+            "code": lint.rule,
+            "task": lint.task_id,
+            "advice": format!("{} · {}", lint.rule, lint.message),
+        }));
+    }
+}
+
 /// Several files through the same per-file ladder — the pre-commit / CI
 /// shape (`nika check a.nika.yaml b.nika.yaml`). Each file gets the FULL
 /// [`run`] report (its header names the file), every file still audits
@@ -753,6 +783,8 @@ pub fn run_infer_permits(path: &str, json: bool) -> VerbOutput {
     VerbOutput::ok(text)
 }
 
+#[cfg(test)]
+mod lints_surface;
 #[cfg(test)]
 mod repair_tests;
 #[cfg(test)]


### PR DESCRIPTION
## Why

The one-obvious-way preference linter already judged in-process (`nika_lints::one_obvious_way`) and nowhere a third party could measure. `nika check --json` `hints[]` stayed empty on every firing fixture. Native-first already had this door.

Closes #763

## What

- `nika-cli` now depends on `nika-lints` (L4 → L0; `nika-check` still must not, to avoid a cycle).
- After parse, `check --json` runs `one_obvious_way(wf)` and appends rows to `hints[]`:
  `{kind: "one-obvious-way", code: "one-obvious-way/NNN", task, advice}` with advice starting with the rule id (the `lints-differential.py` native-first shape).
- Warnings, never errors: `clean` stays true.
- Catching test: skip-for-dependents (`/002`) names the rule; an infer-only file does not grow the kind. Lives in `verbs/check/lints_surface.rs` because `tests.rs` sits on the 1500-LOC wall.

Human HINTS card is unchanged — JSON is the owed door.

## Verify

```
export CARGO_TARGET_DIR=/tmp/oly-session-s2-763-target
cargo fmt -p nika-cli
cargo clippy -p nika-cli --all-targets -- -D warnings
cargo test -p nika-cli --lib --quiet
```