### PR TITLE
fix(check): say lift does not open the trifecta

### DIFF
--- a/crates/nika-display/src/check_laws.rs
+++ b/crates/nika-display/src/check_laws.rs
@@ -49,15 +49,32 @@ pub(crate) fn order_rung(out: &mut String, report: &CheckReport, t: Theme) {
 /// guards a law that fires, one code-first row per idle door. Same
 /// 2026-08-19 gap as ORDER: the wire stamped `NIKA-AUTH-011`, the human
 /// lane had no row to print it in.
+///
+/// The green tick is AUTH-011, not the Rule of Two. `lift: taint` opens
+/// permit-parameterization taint; SEC-009's only door is a blocking
+/// `nika:prompt`. Measured on #1065: a valid taint door next to a
+/// complete trifecta read as `✔ LIFT` beside `✖ TRIFECTA [NIKA-SEC-009]`,
+/// and two readers independently concluded the hatch was inert. When the
+/// trifecta lane has findings, the green line names the other law so the
+/// tick cannot stand as a contradiction. The lane stays green: AUTH-011
+/// is satisfied.
 pub(crate) fn lift_rung(out: &mut String, report: &CheckReport, wf: &RawWorkflow, t: Theme) {
     if !wf.tasks.iter().any(|task| !task.value.lift.is_empty()) {
         return;
     }
+    // Two statics, not a format, so the connecting clause is a second
+    // sentence the catching test can grep — not a row that would redden
+    // a door AUTH-011 already cleared.
+    let ok_msg = if report.trifecta_findings.is_empty() {
+        "every authored door guards a law that fires · a taint entry's binding reaches the task · a data-as-code entry meets a code-bearing fetch"
+    } else {
+        "every authored door guards a law that fires · a taint entry's binding reaches the task · a data-as-code entry meets a code-bearing fetch. This door does not open SEC-009; the Rule of Two wants a blocking nika:prompt"
+    };
     section_list(
         out,
         t,
         "LIFT",
-        "every authored door guards a law that fires · a taint entry's binding reaches the task · a data-as-code entry meets a code-bearing fetch",
+        ok_msg,
         report
             .lift_findings
             .iter()

--- a/crates/nika-display/src/check_render/tests.rs
+++ b/crates/nika-display/src/check_render/tests.rs
@@ -136,6 +136,63 @@ tasks:
             "no legs, no trifecta, no reason to withhold:\n{out}"
         );
     }
+
+    /// The complete trifecta plus a live `lift: taint` on the egress —
+    /// AUTH-011 is satisfied (the binding reaches the task), SEC-009 still
+    /// refuses. The hatch the author reached for is the other law.
+    const LIFT_BESIDE_TRIFECTA: &str = "\
+nika: t
+permits:
+  fs: { read: [\"./inbox/**\"], write: [\"./out/**\"] }
+  net: { http: [\"api.example.com\"] }
+  tools: [\"nika:fetch\", \"nika:write\", \"nika:prompt\"]
+tasks:
+  fetch_page:
+    invoke:
+      tool: \"nika:fetch\"
+      args: { url: \"https://api.example.com/data\" }
+  leak:
+    after: { fetch_page: success }
+    with: { body: \"${{ tasks.fetch_page.output }}\" }
+    lift:
+      - law: taint
+        from: with.body
+        because: \"first-party queryset, reviewed at authoring\"
+    invoke:
+      tool: \"nika:write\"
+      args: { path: \"./out/leak.txt\", content: \"${{ with.body }}\" }
+";
+
+    /// MEASURED on #1065 · a valid `lift: taint` door ticks green beside
+    /// the lethal trifecta it looks like it should open. The taint door
+    /// is AUTH-011 (permit-parameterization); SEC-009's only door is a
+    /// blocking `nika:prompt`. Two readers independently concluded the
+    /// hatch was inert because neither line named the other law.
+    ///
+    /// The LIFT line stays green — AUTH-011 is satisfied — and now names
+    /// that this door does not open SEC-009. Deleting the connecting
+    /// clause fails this test.
+    #[test]
+    fn a_valid_lift_door_names_that_it_does_not_open_the_trifecta() {
+        let out = console(LIFT_BESIDE_TRIFECTA);
+        assert!(
+            out.contains("✖ TRIFECTA") && out.contains("NIKA-SEC-009"),
+            "the trifecta must still refuse:\n{out}"
+        );
+        let lift = out
+            .lines()
+            .find(|l| l.contains("LIFT"))
+            .unwrap_or("<LIFT row absent from the report>");
+        assert!(
+            lift.contains('✔') && !lift.contains("NIKA-AUTH-011"),
+            "AUTH-011 is satisfied — the door stays green:\n{lift}\nin:\n{out}"
+        );
+        assert!(
+            lift.contains("SEC-009") || lift.contains("does not open") || lift.contains("prompt"),
+            "the connecting clause must sit on the LIFT line so a green \
+             tick beside SEC-009 cannot read as an inert hatch:\n{lift}\nin:\n{out}"
+        );
+    }
 }
 
 mod hint_dedup_tests {


### PR DESCRIPTION
A valid `lift: taint` door ticked green beside `NIKA-SEC-009`, so authors thought the hatch was inert. The two laws are different: `lift: taint` is AUTH-011 (permit-parameterization); the Rule of Two still wants a blocking `nika:prompt`.

The LIFT line stays green — AUTH-011 is correctly satisfied — and now names the other law when the trifecta is complete. A catching test renders both `✖ TRIFECTA` / `NIKA-SEC-009` and a LIFT line that mentions the connecting clause.

Closes #1065