### PR TITLE
fix(check): refuse an unfilled slot scaffold

### DIFF
--- a/changelog.d/1066.changed.md
+++ b/changelog.d/1066.changed.md
@@ -1,0 +1,5 @@
+- **`nika check` refuses an unfilled SLOT scaffold.** `# SLOT:` comments
+  die with the YAML parse, so a chain template used to check clean and
+  a run could write a file that looked like output. check now names
+  every unfilled marker and exits 2: a scaffold is not a workflow.
+  Fill every SLOT, then delete the comments.

--- a/crates/nika-check/public-api.txt
+++ b/crates/nika-check/public-api.txt
@@ -2384,6 +2384,54 @@ impl<T> dyn_clone::DynClone for nika_check::SinkFinding where T: core::clone::Cl
 pub fn nika_check::SinkFinding::__clone_box(&self, _: dyn_clone::sealed::Private) -> *mut ()
 impl<T> nika_error::traits::AsAny for nika_check::SinkFinding where T: 'static
 pub fn nika_check::SinkFinding::as_any(&self) -> &(dyn core::any::Any + 'static)
+#[non_exhaustive] pub struct nika_check::SlotMarker
+pub nika_check::SlotMarker::body: alloc::string::String
+pub nika_check::SlotMarker::line: u32
+pub nika_check::SlotMarker::span: nika_check::ByteSpan
+impl nika_check::SlotMarker
+pub fn nika_check::SlotMarker::label(&self) -> &str
+pub fn nika_check::SlotMarker::new(line: u32, body: alloc::string::String, span: nika_check::ByteSpan) -> Self
+impl core::clone::Clone for nika_check::SlotMarker
+pub fn nika_check::SlotMarker::clone(&self) -> nika_check::SlotMarker
+impl core::cmp::Eq for nika_check::SlotMarker
+impl core::cmp::PartialEq for nika_check::SlotMarker
+pub fn nika_check::SlotMarker::eq(&self, other: &nika_check::SlotMarker) -> bool
+impl core::fmt::Debug for nika_check::SlotMarker
+pub fn nika_check::SlotMarker::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for nika_check::SlotMarker
+impl serde_core::ser::Serialize for nika_check::SlotMarker
+pub fn nika_check::SlotMarker::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<D> owo_colors::OwoColorize for nika_check::SlotMarker
+impl<Q, K> equivalent::Equivalent<K> for nika_check::SlotMarker where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn nika_check::SlotMarker::equivalent(&self, key: &K) -> bool
+impl<Q, K> hashbrown::Equivalent<K> for nika_check::SlotMarker where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn nika_check::SlotMarker::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for nika_check::SlotMarker where U: core::convert::From<T>
+pub fn nika_check::SlotMarker::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_check::SlotMarker where U: core::convert::Into<T>
+pub type nika_check::SlotMarker::Error = core::convert::Infallible
+pub fn nika_check::SlotMarker::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_check::SlotMarker where U: core::convert::TryFrom<T>
+pub type nika_check::SlotMarker::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_check::SlotMarker::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_check::SlotMarker where T: core::clone::Clone
+pub type nika_check::SlotMarker::Owned = T
+pub fn nika_check::SlotMarker::clone_into(&self, target: &mut T)
+pub fn nika_check::SlotMarker::to_owned(&self) -> T
+impl<T> core::any::Any for nika_check::SlotMarker where T: 'static + ?core::marker::Sized
+pub fn nika_check::SlotMarker::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_check::SlotMarker where T: ?core::marker::Sized
+pub fn nika_check::SlotMarker::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_check::SlotMarker where T: ?core::marker::Sized
+pub fn nika_check::SlotMarker::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_check::SlotMarker where T: core::clone::Clone
+pub unsafe fn nika_check::SlotMarker::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_check::SlotMarker
+pub fn nika_check::SlotMarker::from(t: T) -> T
+impl<T> dyn_clone::DynClone for nika_check::SlotMarker where T: core::clone::Clone
+pub fn nika_check::SlotMarker::__clone_box(&self, _: dyn_clone::sealed::Private) -> *mut ()
+impl<T> nika_error::traits::AsAny for nika_check::SlotMarker where T: 'static
+pub fn nika_check::SlotMarker::as_any(&self) -> &(dyn core::any::Any + 'static)
 #[non_exhaustive] pub struct nika_check::TaintTrace
 pub nika_check::TaintTrace::secret: alloc::string::String
 impl nika_check::TaintTrace
@@ -2748,6 +2796,8 @@ pub fn nika_check::infer_permits(wf: &nika_schema::raw::workflow::RawWorkflow) -
 pub fn nika_check::paid_blockers(hints: &[nika_check::Hint]) -> alloc::vec::Vec<&nika_check::Hint>
 pub fn nika_check::paid_ready(hints: &[nika_check::Hint]) -> bool
 pub fn nika_check::risk_grade(report: &nika_check::CheckReport) -> nika_check::RiskGrade
+pub fn nika_check::scan_unfilled_slots(source: &str) -> alloc::vec::Vec<nika_check::SlotMarker>
+pub fn nika_check::slot_refusal_message(slots: &[nika_check::SlotMarker]) -> alloc::string::String
 pub fn nika_check::stamp_paid_ready(obj: &mut serde_json::map::Map<alloc::string::String, serde_json::value::Value>, hints: &[nika_check::Hint])
 pub fn nika_check::static_literal_of<'w>(wf: &'w nika_schema::raw::workflow::RawWorkflow, expr: &str) -> core::option::Option<&'w serde_json::value::Value>
 pub fn nika_check::static_read_paths(wf: &nika_schema::raw::workflow::RawWorkflow) -> alloc::vec::Vec<(alloc::string::String, alloc::string::String)>

--- a/crates/nika-check/src/lib.rs
+++ b/crates/nika-check/src/lib.rs
@@ -150,6 +150,7 @@ mod run_decl;
 mod schema_lint;
 mod schema_typing;
 mod secrets;
+mod slots;
 mod tools;
 pub mod trifecta;
 mod walk;
@@ -188,6 +189,7 @@ pub use run_decl::RunDeclFinding;
 pub use schema_lint::SchemaLintFinding;
 pub use schema_typing::{SchemaTypeFinding, UnverifiableOutputRef};
 pub use secrets::{SecretEgress, SecretLeak};
+pub use slots::{SlotMarker, scan_unfilled_slots, slot_refusal_message};
 pub use tools::{MissingArg, UnknownArg, UnknownTool};
 pub use walk::{static_literal_of, static_read_paths};
 

--- a/crates/nika-check/src/slots.rs
+++ b/crates/nika-check/src/slots.rs
@@ -1,0 +1,264 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! Unfilled `# SLOT:` comments — YAML comments survive only in the
+//! source, never the AST, so this scan reads the file bytes.
+//!
+//! A `# SLOT:` line inside a block scalar is prompt CONTENT (the
+//! 2026-07-29 pack lesson). The scanner tracks `|` / `>` so those
+//! lines are not counted.
+
+use crate::ByteSpan;
+
+/// One unfilled SLOT comment in the source.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+#[non_exhaustive]
+pub struct SlotMarker {
+    /// 1-based source line of the comment.
+    pub line: u32,
+    /// Comment body after `#`, trimmed (`SLOT: kebab-case workflow id`).
+    pub body: String,
+    /// Byte range of the `SLOT:` marker through the rest of the comment.
+    pub span: ByteSpan,
+}
+
+impl SlotMarker {
+    /// Construct (INV-019 · `new()` on every `#[non_exhaustive]` struct).
+    #[must_use]
+    pub fn new(line: u32, body: String, span: ByteSpan) -> Self {
+        Self { line, body, span }
+    }
+
+    /// The teaching after `SLOT:`, trimmed.
+    #[must_use]
+    pub fn label(&self) -> &str {
+        self.body
+            .strip_prefix("SLOT:")
+            .map_or(self.body.as_str(), str::trim)
+    }
+}
+
+/// Human / JSON finding row: how many markers, that the file is still a
+/// scaffold, and the repair (fill every SLOT, then delete the comments).
+#[must_use]
+pub fn slot_refusal_message(slots: &[SlotMarker]) -> String {
+    let n = slots.len();
+    let word = if n == 1 { "marker" } else { "markers" };
+    let named = slots
+        .iter()
+        .map(|s| format!("line {}: {}", s.line, s.label()))
+        .collect::<Vec<_>>()
+        .join("; ");
+    format!(
+        "{n} unfilled SLOT {word} ({named}) — this file is still a scaffold, \
+         not a workflow. Fill every SLOT then delete the comments."
+    )
+}
+
+/// YAML comments whose body starts with `SLOT:` (`# SLOT:` · inline
+/// `  # SLOT:`). Quoted `#` and block-scalar content are not comments.
+#[must_use]
+pub fn scan_unfilled_slots(source: &str) -> Vec<SlotMarker> {
+    let mut out = Vec::new();
+    let mut byte = 0usize;
+    let mut block: Option<Block> = None;
+    for (idx, raw) in source.split_inclusive('\n').enumerate() {
+        let line = raw
+            .strip_suffix('\n')
+            .unwrap_or(raw)
+            .strip_suffix('\r')
+            .unwrap_or(raw);
+        let skip = block.as_mut().is_some_and(|b| b.skip(line));
+        if skip {
+            byte = byte.saturating_add(raw.len());
+            continue;
+        }
+        block = None;
+        if let Some(hit) = comment_slot(line, idx, byte) {
+            out.push(hit);
+        }
+        if is_block_scalar_value(code_before_comment(line)) {
+            block = Some(Block {
+                parent_indent: leading_indent(line),
+                content_indent: None,
+            });
+        }
+        byte = byte.saturating_add(raw.len());
+    }
+    out
+}
+
+struct Block {
+    parent_indent: usize,
+    content_indent: Option<usize>,
+}
+
+impl Block {
+    /// True while `line` is still inside the scalar (content, not a key).
+    fn skip(&mut self, line: &str) -> bool {
+        if line.trim().is_empty() {
+            return true;
+        }
+        let indent = leading_indent(line);
+        match self.content_indent {
+            None if indent > self.parent_indent => {
+                self.content_indent = Some(indent);
+                true
+            }
+            None => false,
+            Some(ci) => indent >= ci,
+        }
+    }
+}
+
+fn leading_indent(line: &str) -> usize {
+    line.bytes()
+        .take_while(|&b| b == b' ' || b == b'\t')
+        .count()
+}
+
+fn comment_slot(line: &str, idx: usize, line_start: usize) -> Option<SlotMarker> {
+    let (hash_at, comment) = split_comment(line)?;
+    let pad = comment.len() - comment.trim_start().len();
+    let body = comment.trim_start();
+    if !body.starts_with("SLOT:") {
+        return None;
+    }
+    let body = body.trim_end().to_owned();
+    let start = line_start.saturating_add(hash_at.saturating_add(1).saturating_add(pad));
+    let end = start.saturating_add(body.len());
+    Some(SlotMarker::new(
+        u32::try_from(idx.saturating_add(1)).unwrap_or(u32::MAX),
+        body,
+        ByteSpan::new(
+            u32::try_from(start).unwrap_or(u32::MAX),
+            u32::try_from(end).unwrap_or(u32::MAX),
+        ),
+    ))
+}
+
+/// Index of `#` that opens a YAML comment, and the bytes after it.
+fn split_comment(line: &str) -> Option<(usize, &str)> {
+    let trimmed = line.trim_start();
+    if let Some(rest) = trimmed.strip_prefix('#') {
+        let hash_at = line.len() - trimmed.len();
+        return Some((hash_at, rest));
+    }
+    inline_hash(line).map(|hash_at| (hash_at, &line[hash_at.saturating_add(1)..]))
+}
+
+fn code_before_comment(line: &str) -> &str {
+    split_comment(line).map_or(line, |(hash_at, _)| &line[..hash_at])
+}
+
+fn inline_hash(line: &str) -> Option<usize> {
+    let b = line.as_bytes();
+    let mut i = 0;
+    let mut single = false;
+    let mut double = false;
+    let mut escaped = false;
+    while i < b.len() {
+        let c = b[i];
+        if single {
+            if c == b'\'' {
+                if b.get(i.saturating_add(1)) == Some(&b'\'') {
+                    i = i.saturating_add(2);
+                    continue;
+                }
+                single = false;
+            }
+        } else if double {
+            if escaped {
+                escaped = false;
+            } else if c == b'\\' {
+                escaped = true;
+            } else if c == b'"' {
+                double = false;
+            }
+        } else {
+            match c {
+                b'\'' => single = true,
+                b'"' => double = true,
+                b'#' if i > 0 && b[i - 1].is_ascii_whitespace() => return Some(i),
+                _ => {}
+            }
+        }
+        i = i.saturating_add(1);
+    }
+    None
+}
+
+fn is_block_scalar_value(code: &str) -> bool {
+    let Some((_, after)) = code.trim_end().rsplit_once(':') else {
+        return false;
+    };
+    block_header_suffix(after.trim())
+}
+
+/// YAML block-header suffix: `|` / `>` plus optional chomp / indent.
+fn block_header_suffix(s: &str) -> bool {
+    let b = s.as_bytes();
+    let Some((first, rest)) = b.split_first() else {
+        return false;
+    };
+    if *first != b'|' && *first != b'>' {
+        return false;
+    }
+    if rest.is_empty() {
+        return true;
+    }
+    match rest {
+        [b'+' | b'-', digits @ ..] => digits.iter().all(u8::is_ascii_digit),
+        [b'0'..=b'9', ..] => {
+            let n = rest.iter().take_while(|c| c.is_ascii_digit()).count();
+            matches!(&rest[n..], [] | [b'+' | b'-'])
+        }
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{scan_unfilled_slots, slot_refusal_message};
+
+    #[test]
+    fn two_comment_markers_are_named() {
+        let src = "nika: w       # SLOT: kebab-case\n# SLOT: the one model job\ntasks:\n  t:\n    infer: { prompt: hi, max_tokens: 10 }\n";
+        let hits = scan_unfilled_slots(src);
+        assert_eq!(hits.len(), 2, "{hits:?}");
+        assert_eq!(hits[0].line, 1);
+        assert_eq!(hits[0].label(), "kebab-case");
+        assert_eq!(hits[1].line, 2);
+        assert_eq!(hits[1].label(), "the one model job");
+        let msg = slot_refusal_message(&hits);
+        assert!(msg.contains("2 unfilled SLOT markers"), "{msg}");
+        assert!(msg.contains("scaffold"), "{msg}");
+        assert!(msg.contains("delete the comments"), "{msg}");
+    }
+
+    #[test]
+    fn block_scalar_content_is_not_a_marker() {
+        let src = "nika: w\ntasks:\n  t:\n    infer:\n      prompt: |\n        Summarize.\n        # SLOT: not a marker\n";
+        assert!(scan_unfilled_slots(src).is_empty());
+    }
+
+    #[test]
+    fn a_comment_that_mentions_the_marker_is_not_one() {
+        let src = "nika: w\ntasks:\n  t:\n    infer:\n      # `# SLOT:` line is sent to the model verbatim\n      prompt: hi\n";
+        assert!(scan_unfilled_slots(src).is_empty());
+    }
+
+    #[test]
+    fn a_quoted_hash_is_not_a_comment() {
+        let src = "nika: w\nconst:\n  note: \"say # SLOT: hi\"\ntasks:\n  t:\n    infer: { prompt: hi, max_tokens: 10 }\n";
+        assert!(scan_unfilled_slots(src).is_empty());
+    }
+
+    #[test]
+    fn a_comment_above_the_block_still_counts() {
+        let src = "nika: w\ntasks:\n  t:\n    infer:\n      # SLOT: the one model job\n      prompt: |\n        keep slot markers OUT\n";
+        let hits = scan_unfilled_slots(src);
+        assert_eq!(hits.len(), 1, "{hits:?}");
+        assert_eq!(hits[0].label(), "the one model job");
+    }
+}

--- a/crates/nika-cli/src/verbs/check/mod.rs
+++ b/crates/nika-cli/src/verbs/check/mod.rs
@@ -840,4 +840,6 @@ mod lints_surface;
 #[cfg(test)]
 mod repair_tests;
 #[cfg(test)]
+mod slot_tests;
+#[cfg(test)]
 mod tests;

--- a/crates/nika-cli/src/verbs/check/mod.rs
+++ b/crates/nika-cli/src/verbs/check/mod.rs
@@ -182,7 +182,7 @@ pub(crate) mod models_rung;
 mod project;
 use models_rung::{ModelFinding, ModelsAudit, pricing_section, unresolvable_models};
 
-use nika_display::check_render::{RepairTarget, render};
+use nika_display::check_render::{RepairTarget, render, stamp_unfilled_slots};
 #[cfg(test)]
 use nika_display::check_render::{permits, required_inputs};
 
@@ -419,7 +419,14 @@ fn render_checked_with_profile(
     // the exact asymmetry a hallucinating agent hits. A `model:` this
     // binary cannot resolve is a FINDING (exit 2), never a green audit.
     let models_audit = unresolvable_models(report, wf);
-    let clean = report.is_clean() && models_audit.findings.is_empty() && skills.findings.is_empty();
+    // #1066 · `# SLOT:` comments die with the YAML parse, so the AST
+    // cannot refuse a scaffold. Scan the source after a successful
+    // parse: a Hint is the wrong well (hints never fail).
+    let slots = nika_check::scan_unfilled_slots(source);
+    let clean = report.is_clean()
+        && models_audit.findings.is_empty()
+        && skills.findings.is_empty()
+        && slots.is_empty();
     // The risk grade (P0-6): a pure projection of the report — uncapped
     // spend or wildcard grants never turn the verdict green by silence.
     // Advisory by default; the operational profile folds grade ≥ High
@@ -444,6 +451,7 @@ fn render_checked_with_profile(
             &models_audit,
             skills,
             &drift_hints,
+            &slots,
             clean,
             strict_clean,
             native_strict,
@@ -468,6 +476,7 @@ fn render_checked_with_profile(
         // painted `✔ audited` under a `✖ MODELS` rung at exit 2).
         clean,
     );
+    stamp_unfilled_slots(&mut text, &slots, theme);
     strict_footers(
         &mut text,
         theme,
@@ -590,6 +599,44 @@ fn model_finding_rows(findings: &[ModelFinding]) -> serde_json::Value {
     )
 }
 
+/// Fold unfilled SLOT comments into `--json` `findings[]` so a consumer
+/// looping that list sees the same refusal the human card prints.
+fn stamp_slot_findings(
+    obj: &mut serde_json::Map<String, serde_json::Value>,
+    slots: &[nika_check::SlotMarker],
+) {
+    if slots.is_empty() {
+        return;
+    }
+    let mut row = serde_json::Map::new();
+    row.insert("kind".into(), serde_json::Value::String("slot".into()));
+    row.insert("gate".into(), serde_json::Value::String("SLOT".into()));
+    row.insert("severity".into(), serde_json::Value::String("error".into()));
+    row.insert(
+        "message".into(),
+        serde_json::Value::String(nika_check::slot_refusal_message(slots)),
+    );
+    if let Some(first) = slots.first() {
+        row.insert(
+            "span".into(),
+            serde_json::json!({ "start": first.span.start, "end": first.span.end }),
+        );
+    }
+    if let Some(findings) = obj
+        .get_mut("findings")
+        .and_then(serde_json::Value::as_array_mut)
+    {
+        findings.insert(0, serde_json::Value::Object(row));
+    }
+}
+
+fn stamp_engine_identity(obj: &mut serde_json::Map<String, serde_json::Value>) {
+    let identity = nika_runtime::engine_identity();
+    obj.insert("engine_version".into(), identity.engine_version().into());
+    obj.insert("build_sha".into(), identity.build_sha().into());
+    obj.insert("spec_sha".into(), identity.spec_sha().into());
+}
+
 /// `--json` verdict object. Drift and one-obvious-way rows append to
 /// `hints[]` plus their `code`. Both families are warnings — `clean`
 /// never reads them.
@@ -600,6 +647,7 @@ fn json_verdict(
     models_audit: &ModelsAudit,
     skills: &nika_schema::ResolvedSkills,
     drift_hints: &[String],
+    slots: &[nika_check::SlotMarker],
     clean: bool,
     strict_clean: bool,
     native_strict: bool,
@@ -618,6 +666,7 @@ fn json_verdict(
         {
             push_advisory_json_hints(hints, drift_hints, wf);
         }
+        stamp_slot_findings(obj, slots);
         obj.insert("clean".to_owned(), serde_json::Value::Bool(clean));
         obj.insert(
             "models_resolve".to_owned(),
@@ -668,10 +717,6 @@ fn json_verdict(
             "risk_grade".to_owned(),
             serde_json::Value::String(grade.as_str().to_owned()),
         );
-        let identity = nika_runtime::engine_identity();
-        obj.insert("engine_version".into(), identity.engine_version().into());
-        obj.insert("build_sha".into(), identity.build_sha().into());
-        obj.insert("spec_sha".into(), identity.spec_sha().into());
         if profile == Profile::Operational {
             obj.insert(
                 "operational_clean".to_owned(),
@@ -684,6 +729,7 @@ fn json_verdict(
                 serde_json::Value::Bool(strict_clean),
             );
         }
+        stamp_engine_identity(obj);
         nika_check::stamp_paid_ready(obj, &report.hints);
     }
     let text = format!("{payload:#}");

--- a/crates/nika-cli/src/verbs/check/slot_tests.rs
+++ b/crates/nika-cli/src/verbs/check/slot_tests.rs
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The SLOT-scaffold refusal (#1066), in its own module.
+//!
+//! Split out of `tests.rs` because that file reached 1528 LOC — past the
+//! 1500-per-file cap (ADR-023, hygiene vector 12) — the moment this test
+//! landed on it. `mod repair_tests` beside `mod tests` is this file's own
+//! precedent for a topic-named sibling.
+
+use super::tests::checked_output;
+use super::*;
+
+/// #1066 · an unfilled SLOT scaffold is not a workflow. Comments die
+/// with the YAML parse, so check must scan the source after it parses
+/// and refuse (exit 2 · `clean: false`). Deleting the comments greens.
+#[test]
+fn unfilled_slot_comments_fail_check_and_clear_when_deleted() {
+    const BODY: &str = "nika: slot-scaffold\nmodel: mock/echo\ntasks:\n  think:\n    infer: { prompt: hi, max_tokens: 10 }\n";
+    const SLOTS: &str = "nika: slot-scaffold       # SLOT: kebab-case\nmodel: mock/echo\n# SLOT: the one model job\ntasks:\n  think:\n    infer: { prompt: hi, max_tokens: 10 }\n";
+    let red = checked_output("slot-red.nika.yaml", SLOTS, false);
+    assert_eq!(red.code, 2, "{}", red.text);
+    assert!(
+        red.text.contains("SLOT") && red.text.contains("scaffold"),
+        "{}",
+        red.text
+    );
+    let dir = std::env::temp_dir().join(format!("nika-cli-killtests-{}", std::process::id()));
+    let json = run(
+        dir.join("slot-red.nika.yaml").to_str().expect("utf8"),
+        true,
+        false,
+        None,
+        Theme::new(false, true, false),
+    );
+    assert_eq!(json.code, 2, "{}", json.text);
+    let payload: serde_json::Value = serde_json::from_str(&json.text).expect("json");
+    assert_eq!(payload["clean"], false, "{payload:#}");
+    assert!(payload.to_string().contains("SLOT"), "{payload:#}");
+    let green = checked_output("slot-green.nika.yaml", BODY, false);
+    assert_eq!(green.code, 0, "{}", green.text);
+    assert!(!green.text.contains("SLOT"), "{}", green.text);
+}

--- a/crates/nika-cli/src/verbs/check/tests.rs
+++ b/crates/nika-cli/src/verbs/check/tests.rs
@@ -389,7 +389,7 @@ fn idle_door_renders_its_row_in_the_human_lane_and_a_doorless_file_has_no_row() 
 
 /// Same fixture plumbing, full `VerbOutput` (exit-code assertions) —
 /// the `--native-strict` posture tests read `.code`.
-fn checked_output(name: &str, yaml: &str, native_strict: bool) -> VerbOutput {
+pub(super) fn checked_output(name: &str, yaml: &str, native_strict: bool) -> VerbOutput {
     checked_output_profile(name, yaml, native_strict, Profile::Advisory)
 }
 
@@ -1494,35 +1494,4 @@ fn the_naming_note_fires_on_a_copy_and_not_on_an_ordering_prefix() {
     let mut other = String::new();
     naming_note(&mut other, theme, "-", &wf);
     assert!(other.is_empty(), "stdin has no stem: {other}");
-}
-
-/// #1066 · an unfilled SLOT scaffold is not a workflow. Comments die
-/// with the YAML parse, so check must scan the source after it parses
-/// and refuse (exit 2 · `clean: false`). Deleting the comments greens.
-#[test]
-fn unfilled_slot_comments_fail_check_and_clear_when_deleted() {
-    const BODY: &str = "nika: slot-scaffold\nmodel: mock/echo\ntasks:\n  think:\n    infer: { prompt: hi, max_tokens: 10 }\n";
-    const SLOTS: &str = "nika: slot-scaffold       # SLOT: kebab-case\nmodel: mock/echo\n# SLOT: the one model job\ntasks:\n  think:\n    infer: { prompt: hi, max_tokens: 10 }\n";
-    let red = checked_output("slot-red.nika.yaml", SLOTS, false);
-    assert_eq!(red.code, 2, "{}", red.text);
-    assert!(
-        red.text.contains("SLOT") && red.text.contains("scaffold"),
-        "{}",
-        red.text
-    );
-    let dir = std::env::temp_dir().join(format!("nika-cli-killtests-{}", std::process::id()));
-    let json = run(
-        dir.join("slot-red.nika.yaml").to_str().expect("utf8"),
-        true,
-        false,
-        None,
-        Theme::new(false, true, false),
-    );
-    assert_eq!(json.code, 2, "{}", json.text);
-    let payload: serde_json::Value = serde_json::from_str(&json.text).expect("json");
-    assert_eq!(payload["clean"], false, "{payload:#}");
-    assert!(payload.to_string().contains("SLOT"), "{payload:#}");
-    let green = checked_output("slot-green.nika.yaml", BODY, false);
-    assert_eq!(green.code, 0, "{}", green.text);
-    assert!(!green.text.contains("SLOT"), "{}", green.text);
 }

--- a/crates/nika-cli/src/verbs/check/tests.rs
+++ b/crates/nika-cli/src/verbs/check/tests.rs
@@ -1495,3 +1495,34 @@ fn the_naming_note_fires_on_a_copy_and_not_on_an_ordering_prefix() {
     naming_note(&mut other, theme, "-", &wf);
     assert!(other.is_empty(), "stdin has no stem: {other}");
 }
+
+/// #1066 · an unfilled SLOT scaffold is not a workflow. Comments die
+/// with the YAML parse, so check must scan the source after it parses
+/// and refuse (exit 2 · `clean: false`). Deleting the comments greens.
+#[test]
+fn unfilled_slot_comments_fail_check_and_clear_when_deleted() {
+    const BODY: &str = "nika: slot-scaffold\nmodel: mock/echo\ntasks:\n  think:\n    infer: { prompt: hi, max_tokens: 10 }\n";
+    const SLOTS: &str = "nika: slot-scaffold       # SLOT: kebab-case\nmodel: mock/echo\n# SLOT: the one model job\ntasks:\n  think:\n    infer: { prompt: hi, max_tokens: 10 }\n";
+    let red = checked_output("slot-red.nika.yaml", SLOTS, false);
+    assert_eq!(red.code, 2, "{}", red.text);
+    assert!(
+        red.text.contains("SLOT") && red.text.contains("scaffold"),
+        "{}",
+        red.text
+    );
+    let dir = std::env::temp_dir().join(format!("nika-cli-killtests-{}", std::process::id()));
+    let json = run(
+        dir.join("slot-red.nika.yaml").to_str().expect("utf8"),
+        true,
+        false,
+        None,
+        Theme::new(false, true, false),
+    );
+    assert_eq!(json.code, 2, "{}", json.text);
+    let payload: serde_json::Value = serde_json::from_str(&json.text).expect("json");
+    assert_eq!(payload["clean"], false, "{payload:#}");
+    assert!(payload.to_string().contains("SLOT"), "{payload:#}");
+    let green = checked_output("slot-green.nika.yaml", BODY, false);
+    assert_eq!(green.code, 0, "{}", green.text);
+    assert!(!green.text.contains("SLOT"), "{}", green.text);
+}

--- a/crates/nika-cli/src/verbs/init.rs
+++ b/crates/nika-cli/src/verbs/init.rs
@@ -223,10 +223,12 @@ mod tests {
             false,
             PLAIN,
         );
-        assert_eq!(out.code, exit::OK, "{}", out.text);
+        // #1066 · the REAL ladder now refuses unfilled SLOT scaffolds
+        // (exit 2). Init still laid the files; check names the markers.
+        assert_eq!(out.code, exit::FILE, "{}", out.text);
         assert!(
-            out.text.matches("audited").count() >= 2,
-            "the REAL check ladder spoke through the injected seam: {}",
+            out.text.contains("SLOT") && out.text.matches("scaffold").count() >= 2,
+            "the REAL check ladder names unfilled SLOTs through the injected seam: {}",
             out.text
         );
         let settings = std::fs::read_to_string(tmp.join(".vscode/settings.json")).expect("written");
@@ -257,7 +259,7 @@ mod tests {
             true,
             PLAIN,
         );
-        assert_eq!(out.code, exit::OK, "{}", out.text);
+        assert_eq!(out.code, exit::FILE, "{}", out.text);
         assert!(
             out.text
                 .lines()

--- a/crates/nika-cli/tests/verbs_static.rs
+++ b/crates/nika-cli/tests/verbs_static.rs
@@ -456,7 +456,7 @@ fn pack_surface_round_trips_the_embedded_pack() {
 // ─── new · template instantiation (the own-corpus law) ──────────────────
 
 #[test]
-fn new_writes_a_template_that_passes_its_own_check() {
+fn new_writes_a_template_that_names_its_slots() {
     let dir = std::env::temp_dir().join("nika-cli-verbs-static");
     std::fs::create_dir_all(&dir).expect("temp dir");
     let dest = dir.join("from-template.nika.yaml");
@@ -478,12 +478,17 @@ fn new_writes_a_template_that_passes_its_own_check() {
         out.text
     );
 
-    // The own-corpus law: what we scaffold must pass our own ladder.
+    // #1066 · a scaffold with unfilled SLOT comments is not a workflow.
     let checked = check::run(&dest_str, false, false, None, PLAIN);
     assert_eq!(
         checked.code,
-        exit::OK,
-        "the shipped template must be check-clean: {}",
+        exit::FILE,
+        "an unfilled SLOT scaffold must refuse: {}",
+        checked.text
+    );
+    assert!(
+        checked.text.contains("SLOT"),
+        "check names the markers: {}",
         checked.text
     );
 

--- a/crates/nika-display/public-api.txt
+++ b/crates/nika-display/public-api.txt
@@ -168,6 +168,7 @@ pub fn nika_display::check_render::mark(theme: nika_display::theme::Theme, ok: b
 pub fn nika_display::check_render::permits(out: &mut alloc::string::String, report: &nika_check::CheckReport, wf: &nika_schema::raw::workflow::RawWorkflow, t: nika_display::theme::Theme)
 pub fn nika_display::check_render::render(report: &nika_check::CheckReport, wf: &nika_schema::raw::workflow::RawWorkflow, source: &str, path: &str, repair_target: nika_display::check_render::RepairTarget, t: nika_display::theme::Theme, models_audit: &nika_display::check_render::ModelsAudit, skills: &nika_schema::skill::ResolvedSkills, drift_hints: &[alloc::string::String], verdict: bool) -> alloc::string::String
 pub fn nika_display::check_render::required_inputs(wf: &nika_schema::raw::workflow::RawWorkflow) -> alloc::vec::Vec<&str>
+pub fn nika_display::check_render::stamp_unfilled_slots(text: &mut alloc::string::String, slots: &[nika_check::slots::SlotMarker], t: nika_display::theme::Theme)
 pub mod nika_display::chrome
 pub const nika_display::chrome::PULSE: [char; 3]
 pub fn nika_display::chrome::banner(theme: nika_display::theme::Theme, title: &str, tagline: &str, version: &str) -> alloc::vec::Vec<alloc::string::String>

--- a/crates/nika-display/src/check_render.rs
+++ b/crates/nika-display/src/check_render.rs
@@ -1462,7 +1462,9 @@ fn loopback_declassification_lines(out: &mut String, wf: &RawWorkflow, t: Theme)
 }
 mod footer;
 mod permits_glance;
+mod slots;
 use footer::hints_and_verdict;
+pub use slots::stamp_unfilled_slots;
 
 #[cfg(test)]
 mod tests;

--- a/crates/nika-display/src/check_render/slots.rs
+++ b/crates/nika-display/src/check_render/slots.rs
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! SLOT rung — an unfilled scaffold is not a workflow (#1066).
+
+use nika_check::SlotMarker;
+
+use super::{Theme, section_list};
+
+/// Stamp the SLOT rows after the report header. Silent when empty.
+pub fn stamp_unfilled_slots(text: &mut String, slots: &[SlotMarker], t: Theme) {
+    if slots.is_empty() {
+        return;
+    }
+    let mut block = String::new();
+    let mut rows = vec![nika_check::slot_refusal_message(slots)];
+    for slot in slots {
+        rows.push(format!("line {} · {}", slot.line, slot.label()));
+    }
+    section_list(&mut block, t, "SLOT", "", rows);
+    if let Some(at) = text.find('\n') {
+        text.insert_str(at + 1, &block);
+    } else {
+        text.push('\n');
+        text.push_str(&block);
+    }
+}


### PR DESCRIPTION
## Why

`nika new chain` lays `# SLOT:` comments. Those comments die with the YAML parse, so `nika check` used to mention zero of them, and a `nika run` could write `output.md` that looked like a result. An unfilled scaffold is not a workflow.

Closes #1066.

## What

- Scan the **source text** after a successful parse for YAML comments whose body starts with `SLOT:` (`# SLOT:` and inline `  # SLOT:`). Block-scalar content and a comment that only *mentions* `` `# SLOT:` `` are not markers.
- If any remain, `nika check` names the count and each marker, teaches “fill every SLOT then delete the comments”, sets `clean: false`, and exits 2 (human card and `--json` `findings[]`).
- Hints are the wrong well — they never fail.

`nika new` and `nika run` are untouched (S3). The rehearsal affordance of run stays; the lie at the pre-run judge is closed.

## Tests

- `unfilled_slot_comments_fail_check_and_clear_when_deleted` — valid nine-key file with two `# SLOT:` comments: text and JSON mention SLOT, exit 2, `clean: false`. Same file with comments removed: green.
- Scanner unit tests: block scalar skipped, quoted `#` skipped, mention-in-comment skipped.