### PR TITLE
test(cli): traverse the provider, template and verb families (G3's 77)

### DIFF
--- a/crates/nika-cli/tests/catalog_family.rs
+++ b/crates/nika-cli/tests/catalog_family.rs
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+#![allow(clippy::expect_used, clippy::panic)]
+
+//! The provider FAMILY traversal — every catalog row, not a spot check.
+//!
+//! G3 (`wiring-g3-unprobed`) counts 38 provider declarations with no probe
+//! behind them. Thirty-eight ledger rows would be thirty-eight places to
+//! drift; one traversal that walks the whole family is the probe.
+//!
+//! What it pins · the catalog is DATA (38 vendors, their models, prices and
+//! capabilities) and the wire is CODE (`CANONICAL_IDS`). The two are
+//! deliberately different sizes. The defect this catches is the pair moving
+//! apart in silence: a vendor row added with no adapter, or an adapter
+//! removed under a row that still teaches it.
+//!
+//! Every seat is judged the way a user meets it — through `check`'s MODELS
+//! rung, on a real workflow, before a token is spent.
+
+use nika_cli::Theme;
+use nika_cli::verbs::{check, exit};
+
+const PLAIN: Theme = Theme::new(false, false, false);
+
+/// A one-task workflow with the seat written into the envelope.
+///
+/// Not `--model`: that flag is a PRICING lens (« price as if this model
+/// replaced the envelope default ») and leaves the MODELS rung judging the
+/// authored seat. A first cut of this test used it and every row came back
+/// resolvable — a probe that was measuring `mock/mock` 38 times.
+fn fixture(seat: &str) -> String {
+    format!(
+        "nika: catalog-family-probe
+
+permits: {{}}
+
+tasks:
+  t:
+    infer:
+      model: {seat}
+      prompt: hi
+      max_tokens: 16
+
+outputs:
+  a: ${{{{ tasks.t.output }}}}
+"
+    )
+}
+
+/// Cataloged vendors this binary carries NO wire for.
+///
+/// This list is the point of the test. A cataloged vendor that cannot be
+/// seated is a legitimate state — the catalog also serves pricing and
+/// capability lookups for models reached through a gateway. What is NOT
+/// legitimate is the set changing without anyone deciding.
+///
+/// When this fails, exactly one of two things happened, and the fix differs:
+///
+/// - a row was ADDED to `llm-providers.toml` with no adapter → either wire
+///   it in `nika-providers::profile`, or add it here on purpose;
+/// - a provider was WIRED → delete its line here.
+///
+/// Never edit this list to make a red go away without naming which of the
+/// two it was.
+const UNWIRED: &[&str] = &[
+    "ai21",
+    "azure",
+    "bedrock",
+    "cerebras",
+    "cloudflare",
+    "cohere",
+    "databricks",
+    "deepinfra",
+    "fireworks",
+    "hyperbolic",
+    "minimax",
+    "moonshot",
+    "native",
+    "perplexity",
+    "qwen",
+    "replicate",
+    "sambanova",
+    "together",
+    "vertex",
+    "voyage",
+    "writer",
+    "zhipu",
+];
+
+/// One file per seat — the id rides the filename so a failure names the row.
+fn plant(seat: &str, slug: &str) -> String {
+    let dir = std::env::temp_dir().join("nika-cli-catalog-family");
+    std::fs::create_dir_all(&dir).expect("temp dir");
+    let path = dir.join(format!("seat-{slug}.nika.yaml"));
+    std::fs::write(&path, fixture(seat)).expect("write fixture");
+    path.to_str().expect("utf8 path").to_owned()
+}
+
+/// Does a seat resolve in THIS binary? Asked through the audit a user runs,
+/// never through the resolver asking itself.
+fn seat_resolves(seat: &str, slug: &str) -> bool {
+    let path = plant(seat, slug);
+    let out = check::run(&path, true, false, None, PLAIN);
+    let payload: serde_json::Value = serde_json::from_str(&out.text)
+        .unwrap_or_else(|e| panic!("json for {seat}: {e}\n{}", out.text));
+    payload["models_resolve"]
+        .as_bool()
+        .unwrap_or_else(|| panic!("models_resolve is a bool for {seat}: {payload:#}"))
+}
+
+#[test]
+fn every_cataloged_provider_either_seats_or_is_refused_by_name() {
+    let export = nika_catalog::export::catalog_export();
+    let wired: std::collections::BTreeSet<&str> =
+        nika_providers::CANONICAL_IDS.into_iter().collect();
+
+    let mut seats = 0usize;
+    let mut refused: Vec<&str> = Vec::new();
+    for p in &export.providers {
+        let seat = format!("{}/{}", p.id, p.default_model);
+        let resolves = seat_resolves(&seat, p.id);
+        assert_eq!(
+            resolves,
+            wired.contains(p.id),
+            "`{seat}` resolves={resolves} but the wire table says {}. The catalog row \
+             and the adapter disagree — one of them is the lie.",
+            wired.contains(p.id)
+        );
+        if resolves {
+            seats += 1;
+        } else {
+            refused.push(p.id);
+        }
+    }
+
+    // Membership is the invariant, never catalog order — the listing is
+    // free to re-rank its teaching surface without touching the wire.
+    let mut refused_sorted = refused.clone();
+    refused_sorted.sort_unstable();
+    assert_eq!(
+        refused_sorted, UNWIRED,
+        "the cataloged-but-unseatable set moved. Read the UNWIRED doc comment \
+         before touching it: adding a name and adding an adapter are different fixes."
+    );
+    assert_eq!(
+        seats + refused.len(),
+        export.providers.len(),
+        "every catalog row got a verdict — a family probe that skips rows proves nothing"
+    );
+    assert!(
+        seats > 0 && !refused.is_empty(),
+        "both ends of the partition are non-empty ({seats} seated · {} refused) — \
+         a traversal where every row lands on one side is not measuring the split",
+        refused.len()
+    );
+}
+
+#[test]
+fn the_refusal_names_the_runnable_count_and_where_to_get_the_list() {
+    // The MODELS rung tells a refused user how many seats exist and who
+    // names them. Both halves are load-bearing: the count is what makes the
+    // refusal actionable, and the pointer is the only route to the list.
+    let unwired = UNWIRED
+        .first()
+        .expect("the unwired set is never empty here");
+    let path = plant(&format!("{unwired}/whatever"), "refusal");
+    let out = check::run(&path, false, false, None, PLAIN);
+
+    assert_eq!(
+        out.code,
+        exit::FILE,
+        "an unseatable model fails the audit: {}",
+        out.text
+    );
+    assert!(out.text.contains("MODELS"), "the rung speaks: {}", out.text);
+    assert!(
+        out.text.contains(unwired),
+        "the refusal names the provider the user typed: {}",
+        out.text
+    );
+    let runnable = nika_providers::CANONICAL_IDS.len();
+    assert!(
+        out.text.contains(&format!("{runnable} runnable")),
+        "the refusal counts the seats this binary actually carries ({runnable}): {}",
+        out.text
+    );
+    assert!(
+        out.text.contains("nika doctor"),
+        "and points at the surface that NAMES them: {}",
+        out.text
+    );
+}
+
+#[test]
+fn a_wired_seat_audits_clean_through_the_same_door() {
+    // The negative half of the family probe. Without this, a resolver that
+    // refused EVERYTHING would pass the traversal above with a rewritten
+    // UNWIRED list.
+    let path = plant("anthropic/claude-sonnet-4-5", "wired");
+    let out = check::run(&path, false, false, None, PLAIN);
+    assert_eq!(out.code, exit::OK, "a wired seat passes: {}", out.text);
+    assert!(
+        out.text.contains("MODELS"),
+        "the rung still reports: {}",
+        out.text
+    );
+}

--- a/crates/nika-cli/tests/pack_templates_family.rs
+++ b/crates/nika-cli/tests/pack_templates_family.rs
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+#![allow(clippy::expect_used, clippy::panic)]
+
+//! The template FAMILY traversal — every shipped skeleton RUNS, not just
+//! audits.
+//!
+//! G3 (`wiring-g3-unprobed`) counts 14 template declarations with no probe.
+//! `nika check` on all 14 was already green while ten of them had never
+//! executed once in CI: **a check rc=0 proves the audit, never the run**,
+//! which is the whole reason `nika test` exists.
+//!
+//! This walks the family through the mock provider — offline, deterministic,
+//! zero keys, zero spend — because a skeleton a stranger scaffolds with
+//! `nika new` and cannot run is a broken first minute.
+
+use nika_cli::Theme;
+use nika_cli::verbs::{check, exit};
+
+const PLAIN: Theme = Theme::new(false, false, false);
+
+/// Templates that cannot be pinned by an unattended golden, and why.
+///
+/// `etl-state` holds a `nika:prompt` with NO `default:` **on purpose**: it
+/// is the human gate that keeps NEP-0002's Rule of Two closed. Give that
+/// prompt a default and `check` refuses the file with
+/// `NIKA-SEC-009 lethal trifecta complete` — the gate IS the control, so an
+/// unattended run has nothing legitimate to answer with.
+///
+/// A name may only join this list with that shape of reason written down.
+/// "It was red" is not a reason.
+const CANNOT_PIN_UNATTENDED: &[&str] = &["etl-state"];
+
+fn scratch_dir(tag: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!("nika-cli-pack-family-{tag}"));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("temp dir");
+    dir
+}
+
+/// Lay one template down on disk, alone, the way `nika new` hands it over.
+fn plant(dir: &std::path::Path, name: &str) -> String {
+    let body = nika_pack::template(name).unwrap_or_else(|| panic!("pack carries `{name}`"));
+    let path = dir.join(format!("{name}.nika.yaml"));
+    std::fs::write(&path, body).expect("write template");
+    path.to_str().expect("utf8 path").to_owned()
+}
+
+#[test]
+fn every_shipped_template_audits() {
+    let dir = scratch_dir("check");
+    let names = nika_pack::template_names();
+    assert!(!names.is_empty(), "the pack ships templates");
+
+    for name in &names {
+        let path = plant(&dir, name);
+        let out = check::run(&path, false, false, None, PLAIN);
+        assert_eq!(
+            out.code,
+            exit::OK,
+            "`{name}` is a skeleton a stranger is handed — it audits or it does not ship:\n{}",
+            out.text
+        );
+    }
+}
+
+#[test]
+fn every_shipped_template_runs_green_under_mock() {
+    // The leg `check` cannot reach. `--update` writes the golden into the
+    // scratch copy and returns 0 only when the mock run itself was green,
+    // so this asserts EXECUTION, not the presence of a committed file.
+    let dir = scratch_dir("run");
+    let names = nika_pack::template_names();
+
+    let mut ran: Vec<String> = Vec::new();
+    let mut refused: Vec<String> = Vec::new();
+    for name in &names {
+        let path = plant(&dir, name);
+        let code = nika_cli::verbs::test::run(&path, true, PLAIN);
+        if code == exit::OK {
+            ran.push(name.clone());
+        } else {
+            refused.push(name.clone());
+        }
+    }
+
+    assert_eq!(
+        refused,
+        CANNOT_PIN_UNATTENDED,
+        "the set of templates that cannot run unattended moved.\n\
+         ran ({}): {ran:?}\nrefused ({}): {refused:?}\n\
+         Read the CANNOT_PIN_UNATTENDED doc comment — a template joining this list \
+         needs a reason of the same shape, not a rubber stamp.",
+        ran.len(),
+        refused.len()
+    );
+    assert!(
+        !ran.is_empty(),
+        "at least one template actually executed — a traversal where nothing ran \
+         proves the harness, not the pack"
+    );
+}
+
+#[test]
+fn the_gated_template_stays_refusable_for_the_reason_it_is_exempt() {
+    // The exemption above is only honest while its REASON holds. If
+    // `etl-state` ever becomes pinnable, it is because its human gate went
+    // away — and that is a security change, not a test-maintenance chore.
+    let dir = scratch_dir("gate");
+    let name = CANNOT_PIN_UNATTENDED
+        .first()
+        .expect("the exempt set is non-empty");
+    let path = plant(&dir, name);
+
+    let audited = check::run(&path, false, false, None, PLAIN);
+    assert_eq!(
+        audited.code,
+        exit::OK,
+        "`{name}` audits clean as shipped — the exemption is about the RUN, not the audit:\n{}",
+        audited.text
+    );
+    assert!(
+        audited.text.contains("TRIFECTA"),
+        "the rung that makes this template's gate load-bearing is present:\n{}",
+        audited.text
+    );
+    assert_ne!(
+        nika_cli::verbs::test::run(&path, true, PLAIN),
+        exit::OK,
+        "`{name}` still refuses an unattended golden — if this passes, the human gate \
+         it depends on is gone and NEP-0002 needs re-checking"
+    );
+}

--- a/crates/nika-cli/tests/verb_family.rs
+++ b/crates/nika-cli/tests/verb_family.rs
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+#![allow(clippy::expect_used, clippy::panic)]
+// The workspace bans std::process::Command (production spawns ride the
+// kernel ShellExecutor seam). This traversal's WHOLE JOB is to ask the
+// real `nika-cli` binary whether a declared verb is reachable through
+// argv — the same carve-out `bin_smoke.rs` documents, for the same
+// reason: routing through the kernel seam would test the lib, and the
+// v0.106.0 class this catches lives in the dispatcher, not the lib.
+#![allow(clippy::disallowed_types)]
+
+//! The verb FAMILY traversal — every declared verb answers, hidden ones
+//! included.
+//!
+//! G3 (`wiring-g3-unprobed`) counts 25 verb declarations with no probe.
+//! Most are `hide = true`, so `--help` never lists them and a human sweep
+//! cannot see them: the only honest source is the `enum Command` the
+//! prober itself reads, and this test derives from the same place so the
+//! two can never disagree about what the family IS.
+//!
+//! The class this catches is on the record in `main.rs` — the v0.106.0
+//! post-mortem, where `nika lsp` refused a flag its hosts always pass and
+//! exited 2 *before the first byte of JSON-RPC*. The language server had
+//! never once run in production. A verb that cannot be invoked is not a
+//! verb, and nothing was watching that.
+//!
+//! **This axis is narrow, by construction.** `--help` returning 0 proves
+//! clap accepts the verb and the binary dispatches it. It proves nothing
+//! about what the verb then does: `nika lsp --help` is green on the same
+//! binary that accepts `--clientProcessId` and throws it away. Read a pass
+//! here as "reachable", never as "works".
+
+use std::process::Command;
+
+/// Verbs that must be in any honest derivation — the anti-vacuous floor.
+/// If the `enum Command` scan silently returns nothing, every loop below
+/// passes over an empty set and proves the harness instead of the CLI.
+const CORE: &[&str] = &[
+    "catalog", "check", "doctor", "lsp", "mcp", "new", "run", "test",
+];
+
+/// `PascalCase` → kebab, the same shape the prober's `pascal_to_kebab` uses.
+fn kebab(variant: &str) -> String {
+    let mut out = String::with_capacity(variant.len() + 4);
+    for (i, c) in variant.char_indices() {
+        if c.is_ascii_uppercase() && i != 0 {
+            out.push('-');
+        }
+        out.push(c.to_ascii_lowercase());
+    }
+    out
+}
+
+/// Every `enum Command` variant, kebabed — derived from the source the
+/// wiring prober reads, never from `--help` (which hides most of them).
+fn declared_verbs() -> Vec<String> {
+    let main_rs = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/main.rs");
+    let src = std::fs::read_to_string(&main_rs)
+        .unwrap_or_else(|e| panic!("read {}: {e}", main_rs.display()));
+
+    let mut out: Vec<String> = Vec::new();
+    let mut depth = 0i32;
+    let mut inside = false;
+    for line in src.lines() {
+        let trimmed = line.trim();
+        if !inside {
+            inside = trimmed.starts_with("enum Command");
+            continue;
+        }
+        if trimmed == "}" && depth == 0 {
+            break;
+        }
+        let opens = i32::try_from(line.matches('{').count()).unwrap_or(0);
+        let closes = i32::try_from(line.matches('}').count()).unwrap_or(0);
+        let was = depth;
+        depth += opens - closes;
+        // Only the enum's own level declares variants; a variant's inline
+        // struct body is full of fields that also start uppercase.
+        if was != 0 || trimmed.starts_with('#') || trimmed.starts_with("//") || trimmed.is_empty() {
+            continue;
+        }
+        let name: String = trimmed
+            .chars()
+            .take_while(char::is_ascii_alphanumeric)
+            .collect();
+        let leads_upper = name.chars().next().is_some_and(|c| c.is_ascii_uppercase());
+        // `Lsp {` and `Dap,` and `Guard(GuardArgs)` are all variants; the
+        // space before a struct-variant brace is why a first cut of this
+        // scan found 11 of 25 and the floor test below caught it.
+        let tail = trimmed[name.len()..].trim_start();
+        if leads_upper && (tail.is_empty() || tail.starts_with(['{', '(', ','])) {
+            let verb = kebab(&name);
+            if !out.contains(&verb) {
+                out.push(verb);
+            }
+        }
+    }
+    out
+}
+
+#[test]
+fn the_derivation_finds_the_family_it_claims_to_walk() {
+    let verbs = declared_verbs();
+    for want in CORE {
+        assert!(
+            verbs.iter().any(|v| v == want),
+            "the `enum Command` scan lost `{want}` — the parse broke, and a traversal \
+             over a broken parse is a green that measured nothing.\nfound: {verbs:?}"
+        );
+    }
+    assert!(
+        verbs.len() >= CORE.len() * 2,
+        "only {} verbs derived — the family is larger than that; the scan is truncating.\n{verbs:?}",
+        verbs.len()
+    );
+}
+
+#[test]
+fn every_declared_verb_is_reachable_in_the_shipped_dispatcher() {
+    // The v0.106.0 shape: a verb that exits before it speaks. Asked of the
+    // REAL binary (CARGO_BIN_EXE), not of a library call — a verb can be
+    // implemented and still be unreachable through argv, which is exactly
+    // what happened to `lsp`.
+    let verbs = declared_verbs();
+    let mut broken: Vec<(String, Option<i32>)> = Vec::new();
+
+    for verb in &verbs {
+        let out = Command::new(env!("CARGO_BIN_EXE_nika-cli"))
+            .args([verb.as_str(), "--help"])
+            .output()
+            .unwrap_or_else(|e| panic!("spawn `{verb} --help`: {e}"));
+        if !out.status.success() || out.stdout.is_empty() {
+            broken.push((verb.clone(), out.status.code()));
+        }
+    }
+
+    assert!(
+        broken.is_empty(),
+        "{} of {} declared verbs do not answer `--help`: {broken:?}\n\
+         A verb clap declares and the dispatcher cannot reach is the v0.106.0 class — \
+         the flag refusal that kept the language server from ever running.",
+        broken.len(),
+        verbs.len()
+    );
+}
+
+#[test]
+fn an_undeclared_verb_is_still_refused() {
+    // The negative end. Without it, a dispatcher that answered `--help`
+    // for ANY argv would pass the traversal above.
+    let out = Command::new(env!("CARGO_BIN_EXE_nika-cli"))
+        .args(["definitely-not-a-verb", "--help"])
+        .output()
+        .expect("spawn");
+    assert!(
+        !out.status.success(),
+        "an unknown verb still fails: {}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+}


### PR DESCRIPTION
## Why

The G3 baseline in the 0.115.0 convergence MAP (§8) reports **77 undeclared
declarations**: 38 providers · 14 templates · 25 verbs. The operator's framing is the
one this PR takes literally:

> *« Ce n'est pas 77 bugs : c'est 77 lignes de registre sans test qui les traverse.
> Attaque par FAMILLE, jamais ligne à ligne. »*

Thirty-eight hand-written ledger rows would be thirty-eight new places to drift. Three
traversals — one per family — walk every row and give each family a single job that
can stand behind it.

**Tests only. No shipped behaviour changes.**

## What each family probe pins

### `catalog_family.rs` — 38 provider rows

Walks every catalog vendor through the MODELS rung of a real workflow (not through the
resolver asking itself) and pins the partition against the wire table: **16 seat, 22 are
cataloged with no adapter.** That split is legitimate — the catalog also serves pricing
and capability lookups — but it was invisible and unguarded.

- resolvability of each row must equal its `CANONICAL_IDS` membership, so a catalog row
  and its adapter can no longer disagree in silence;
- the 22 are an explicit named list with a doc comment saying which of two fixes applies
  when it moves, so a vendor added with no adapter turns the suite red rather than
  growing a silent set;
- both ends asserted non-empty — a resolver that refused everything cannot pass by
  rewriting the list.

A first cut used `check --model` and every row came back resolvable: that flag is a
**pricing** lens and leaves MODELS judging the authored seat, so the probe was measuring
`mock/mock` 38 times. The fixture now writes the seat into the envelope; the story is in
the doc comment so the next person does not repeat it.

### `pack_templates_family.rs` — 14 templates

`nika check` on all 14 was already green while **ten of them had never executed once**.
A check rc=0 proves the audit, never the run — which is the whole reason `nika test`
exists. Worth noting: `verbs::test::run` had exactly one caller in the tree
(`main.rs`), so the golden-test verb had no test of its own either.

- every template audits;
- every template runs green under the mock provider — offline, deterministic, zero keys,
  zero spend;
- `etl-state` is exempt **with its reason written down**: its `nika:prompt` carries no
  `default:` on purpose, and giving it one flips TRIFECTA to `NIKA-SEC-009`. A third test
  pins that reason, so if `etl-state` ever becomes pinnable it fails here — because that
  would mean its human gate is gone, which is a security change and not test maintenance.

### `verb_family.rs` — 25 clap verbs

Most are `hide = true`, so neither `--help` nor a human sweep can see them. The
derivation reads the same `enum Command` the wiring prober reads, so the two can never
disagree about what the family *is*.

The class is on the record in `main.rs`: in v0.106.0 `nika lsp` refused a flag every host
passes and exited 2 before the first byte of JSON-RPC — the language server had never
once run in production. Asked of the real binary via `CARGO_BIN_EXE`, because a verb can
be implemented and still be unreachable through argv.

**The module states its own narrowness**: a green here means *reachable*, never *works*.
`nika lsp --help` returns 0 on the same binary that accepts `--clientProcessId` and throws
it away (#1181).

## Mutation-proven, not assumed

Each traversal was shown to go red on a real mutant, then reverted:

| family | mutant | result |
|---|---|---|
| providers | a 39th catalog row with no adapter | red · names `ghostvendor` in the diff |
| templates | a template that audits clean but cannot run unattended | red · `refused (2): ["chain", "etl-state"]` |
| verbs | *(caught itself)* the enum scan found 11 of 25 | the anti-vacuous floor failed before the traversal could pass over a truncated set |

The third row is the honest one: the floor test earned its place on its first run,
against my own parser.

## Gates

- `cargo fmt -p nika-cli --check` clean
- `cargo clippy -p nika-cli --tests -- -D warnings` clean
- `cargo test -p nika-cli --lib` · 310 passed
- the three traversals · 9 passed
- pre-push gate green (534s on the first commit)

`verb_family.rs` carries the same documented `clippy::disallowed_types` carve-out
`bin_smoke.rs` uses, for the same reason: the whole job is to execute the real binary,
and routing through the kernel seam would test the lib instead of the dispatcher.

## What this does NOT do

- **It does not close the projections.** `nika catalog --json` and MCP `nika_catalog`
  still carry no per-row wiredness (#1184) — that needs a facet name decided at
  `machine_truth.rs`, not a fourth number invented in a renderer.
- **No `wiring.yaml` rows.** The ledger is S1's territory in the convergence map. The CI
  job these traversals run under is `rust` (matrix leg `tests` · nextest over every
  target), so the 77 rows now have a live job to point at whenever S1 wants them.
- **No changelog fragment** — tests only, and #1185 is landing the fragment system that
  would own that file anyway. Say the word if one is wanted.

## Territory

Three new files, no existing file touched, checked against every open PR
(#1160 · #1162→#1174 · #1185) before writing.
