### PR TITLE
fix(display): fold the choice arrow into the ascii register

### DIFF
--- a/crates/nika-cli-host/src/choice/tests.rs
+++ b/crates/nika-cli-host/src/choice/tests.rs
@@ -259,9 +259,51 @@ fn tty_and_pipe_project_the_same_product() {
     assert!(a.contains("Local first"));
     assert!(b.contains("Local first"));
     assert!(a.contains("Next:"));
+    // This layer is PRE-fold: `render_human_at` legitimately carries the
+    // unicode glyph under both themes, because `welcome.rs` hands its
+    // finished text to `vocab::sober` at the verb boundary. So this
+    // equality says "the same rung is marked", and the ASCII contract is
+    // the next test's job — on the surface that actually ships.
     assert_eq!(
         a.lines().filter(|l| l.contains("▸")).count(),
         b.lines().filter(|l| l.contains("▸")).count()
+    );
+}
+
+#[test]
+fn the_ascii_render_is_ascii_and_still_says_which_rung_is_selected() {
+    // The unit-level twin of `nika-cli/tests/ascii_contract.rs`. That
+    // integration test is the right judge and it caught this — but only
+    // after the spec-pin failure stopped hiding it, and only after
+    // nextest had already fail-fasted past 4731 other tests. A local
+    // twin fails in one crate and one second instead.
+    //
+    // An ARMED machine: the arrow must land on a rendered rung, else the
+    // second assertion below has nothing to find and passes on an empty
+    // screen.
+    //
+    // Measured through `vocab::sober`, because that is what `welcome.rs`
+    // emits — the raw render still carries `·` separators that the fold
+    // is DESIGNED to absorb (vocab.rs: the Theme seam is primary, this
+    // net catches the literals). A first cut asserted on the raw render
+    // and failed on a `·` the shipped output never shows: the mirror is
+    // not the world.
+    let choice = collect_from(&machine(Some(18), vec![claude()], false, &[], true));
+    let dir = tempfile::tempdir().expect("tmp");
+    let theme = Theme::new(false, true, false);
+    let ascii = nika_display::vocab::sober(theme, &choice.render_human_at(theme, Some(dir.path())));
+
+    let leak = ascii.bytes().enumerate().find(|(_, b)| !b.is_ascii());
+    assert!(
+        leak.is_none(),
+        "non-ascii under --ascii: byte {:#04x} at offset {} — the row: {}",
+        leak.map_or(0, |(_, b)| b),
+        leak.map_or(0, |(i, _)| i),
+        ascii.lines().find(|l| !l.is_ascii()).unwrap_or("<no line>")
+    );
+    assert!(
+        ascii.lines().any(|l| l.starts_with("> ")),
+        "the selected rung is still identifiable without unicode:\n{ascii}"
     );
 }
 

--- a/crates/nika-display/src/vocab.rs
+++ b/crates/nika-display/src/vocab.rs
@@ -111,7 +111,12 @@ pub fn sober(theme: Theme, text: &str) -> String {
             '⚠' => "!".chars().collect(),
             '🦋' => "[nika]".chars().collect(),
             '○' => ".".chars().collect(),
-            '◐' => ">".chars().collect(),
+            // The pointer pair (the running-state glyph · the welcome
+            // cascade's selected rung — one twin, so one arm: clippy's
+            // same-arms law). `▸` rode no `Theme` seam AND was in no
+            // arm, so it leaked through both layers at once and `main`
+            // went red on it (#1193).
+            '◐' | '▸' => ">".chars().collect(),
             '↻' => "r".chars().collect(),
             '↷' => "~>".chars().collect(),
             '⊘' => "x".chars().collect(),


### PR DESCRIPTION
Closes #1193. **`main` has been red since 2026-08-23T21:32Z** — four consecutive
runs — and this is the second of the two reds stacked on it.

## The two reds, and why only one was visible

```
08-23 19:50  7a8b87e2a   main green (last)
08-23 20:09  the inference-choice screen lands
08-23 21:32  55c4e04e0   main red — and stays red
08-24 07:45  0ef70f7f2   main red · rust (tests) dies at 39s
```

On `main` the job dies at **39s** on `crates/nika-pack/pack differs from
nika-spec@SPEC_PIN` and never reaches a test. #1190 repairs that pin, and its job
runs **6m06** and lands here:

```
FAIL nika-cli::ascii_contract welcome_ascii_emits_only_ascii_bytes
welcome --ascii stdout: byte 0xe2 at offset 142 — the row:
  ▸ Nika Gear One          ours - free - 7.4 GB to pull - this machine has 1…
```

`0xe2` is the first byte of `▸`. nextest fail-fasts, so **4731 of 7328 tests never
ran** behind it. The pin failure was buying silence for this one.

## The fix — one arm

`vocab.rs` documents a two-layer design in its own doc comment:

> *"the `Theme` seams (`mark` · `verb_glyph` · `arrow` · `at_most`) are the PRIMARY
> mechanism — but a hardcoded literal (`·` · `—` · `→` · `↳` · `⭐` · `✖`) rides no
> seam, and every one the audit caught was exactly that class. A surface that opted
> into the ASCII register hands its FINISHED text through here once, at the verb
> boundary."*

`choice/mod.rs:545` writes `"▸ "` as a literal, so it rides no seam — and `▸` was in
no fold arm either. It slipped through both layers of a design built for exactly
this pair. It now joins `◐`, which spells the same `>` (one twin, one arm — the
same clippy law the file's other pairs cite).

I first fixed it at the seam instead, making the arrow theme-aware in
`choice/mod.rs`, and **backed that out**: with the arm in place the two produce
identical bytes, and a second parallel mechanism for one glyph makes the surface
inconsistent with every other glyph on it. One mechanism per fact.

## Why the module's own test could not have caught it

```rust
// choice/tests.rs, before
assert_eq!(
    a.lines().filter(|l| l.contains("▸")).count(),   // unicode theme
    b.lines().filter(|l| l.contains("▸")).count()    // ASCII theme
);
```

`b` is the ASCII render. The test did not merely miss the defect — it **required**
it. That assertion is now annotated: this layer is pre-fold, so carrying `▸` in both
is correct there, and the ASCII contract belongs to a test that measures the shipped
surface.

## The new unit twin, and two wrong cuts of it kept in comments

`the_ascii_render_is_ascii_and_still_says_which_rung_is_selected` renders through
`vocab::sober` — what `welcome.rs:312` actually emits — and asserts both that every
byte is ASCII and that the selected rung is still identifiable without unicode.

Two earlier cuts were wrong in ways worth keeping in the comments:

1. asserting on the **raw** render tripped on `·` separators the fold is designed to
   absorb — measuring a layer that never ships;
2. using a fixture where the arrow lands on the filtered `cloud` rung made the
   assertion `0 == 0`.

Both are the kind of green this repo keeps paying for, so the file says so.

## Mutation-proven

Removing the arm turns **both** judges red, each naming the byte and the row:

```
choice::tests::the_ascii_render_… FAILED
  non-ascii under --ascii: byte 0xe2 at offset 142 — the row:
  ▸ Claude Code            here - runs on the plan you already pay for - no API key

nika-cli::ascii_contract::welcome_ascii_emits_only_ascii_bytes FAILED
```

## Gates

- `cargo fmt -p nika-display -p nika-cli-host --check` clean
- `cargo clippy -p nika-display -p nika-cli-host --all-targets -- -D warnings` clean
- `cargo test -p nika-cli-host --lib` · 213 passed · `-p nika-display --lib` · 151 passed
- `cargo test -p nika-cli --test ascii_contract` · 3 passed (was 1 failed)

## Notes

- **Does not unblock `main` alone** — #1190 still owns the spec-pin half. Both are
  needed before `main` goes green; this one is what #1190 will hit next.
- No changelog fragment: `CHANGELOG.md` is contended by eight open PRs and #1185 is
  landing the fragment system that would own it. Say the word if one is wanted.
- Territory: `choice/**` and `vocab.rs` are in no wave's list in the 0.115.0 map, and
  no open PR (#1160 · #1162→#1174 · #1185 · #1190 · #1191) touches either — checked
  before writing.

## Proof for the close

`ascii_contract::welcome_ascii_emits_only_ascii_bytes` — it already existed, it
already failed, and it is green here. `proven_by: rust`
