### PR TITLE
fix(wiring): the silent-drop watches point at their own issues

### DIFF
--- a/wiring.yaml
+++ b/wiring.yaml
@@ -86,10 +86,10 @@ silent_drops:
     parsed_needle: "action.thinking"
     runtime_file: crates/nika-runtime/src/dispatch.rs
     runtime_needle: "action.thinking"
-    issue: 1135
+    issue: 1180
   - id: lsp.client-process-id
     parsed_file: crates/nika-cli/src/main.rs
     parsed_needle: "client_process_id: Option"
     runtime_file: crates/nika-cli/src/main.rs
     runtime_needle: "client_process_id)"
-    issue: null
+    issue: 1181


### PR DESCRIPTION
Two rows of `wiring.yaml`'s `silent_drops` pointed somewhere else.

```diff
   - id: infer.thinking
-    issue: 1135
+    issue: 1180
   - id: lsp.client-process-id
-    issue: null
+    issue: 1181
```

`1135` is the **vision** drop, not the thinking one. The `lsp` watch carried a `null` from before its issue existed. Both were filed since, each with a reproduction on the **wire** rather than at the check:

- **#1180** · a capture server on `127.0.0.1` received byte-identical request bodies with and without the `thinking:` block, while `max_tokens: 777` — the field on the line above it, in the same `infer:` body — arrived. `check` actively *teaches* the field it drops.
- **#1181** · the language server outlived a SIGKILLed parent it had been told to watch (`main.rs:862` discards both `Lsp` fields at the one call site).

**Why it is worth two lines**: `scripts/ci/issue-proof.sh` resolves `issue: N → proven_by` out of this file, and the G6 prober prints these rows in its verdict. A pointer that names the *wrong* issue is worse than a null one — it reads as tracked and sends the next reader to a thread about a different field.

Nothing else moves. `infer.vision` keeps `1135`, which is correct.

Territory: `wiring.yaml` is S1's in the 0.115.0 map; that lane closed 2026-08-24T07:36Z and no open PR touches the file (checked at commit time, on `git diff --name-only` — the lesson from #1194).