### PR TITLE
fix(check): advise --fix only where --fix has something to apply

### DIFF
--- a/crates/nika-display/src/check_render/footer.rs
+++ b/crates/nika-display/src/check_render/footer.rs
@@ -95,15 +95,70 @@ pub(super) fn hints_and_verdict(
             t.paint(Role::Bad, "findings above")
         );
     }
-    if hint_sites > 0 {
-        let next = next_repair_action(path, repair_target);
-        let _ = writeln!(
-            out,
-            " {} {}     {next} · see `nika explain` for coded findings",
-            t.paint(Role::Accent, "↳"),
-            t.paint(Role::Strong, "NEXT"),
-        );
+    render_next(out, report, path, repair_target, hint_sites, t);
+}
+
+/// The ONE next command, when the report left anything to say.
+///
+/// Advises `--fix` on a workspace file only when `--fix` has something to
+/// apply. The trigger used to be `hint_sites > 0` alone, which is a
+/// DIFFERENT set: a file whose only findings are hints (`native-first` ·
+/// `NIKA-DRIFT-001`) has nothing in the ladder, so `--fix` printed « no
+/// machine-applicable repairs » at the top and this line told the reader
+/// to run `--fix` at the bottom — of the same output. Obeying it is a
+/// fixed point: not one byte changes, and the exit it offers is the
+/// command that produced it.
+///
+/// The other three targets are exempt because they CANNOT loop: their
+/// guidance is PROVENANCE (« this cache is read-only · copy it first »),
+/// which holds whether or not a rename exists, and obeying it changes the
+/// state — there is a new file to check. Suppressing them would hide
+/// where a reader may write at all.
+fn render_next(
+    out: &mut String,
+    report: &CheckReport,
+    path: &str,
+    repair_target: RepairTarget,
+    hint_sites: usize,
+    t: Theme,
+) {
+    if hint_sites == 0 {
+        return;
     }
+    let loops_on_itself = repair_target == RepairTarget::WorkspaceFile;
+    let next = if !loops_on_itself || has_machine_applicable_repair(report) {
+        format!(
+            "{} · see `nika explain` for coded findings",
+            next_repair_action(path, repair_target)
+        )
+    } else {
+        "see `nika explain` for coded findings — nothing here is a typed rename, \
+         so these are yours to place"
+            .to_owned()
+    };
+    let _ = writeln!(
+        out,
+        " {} {}     {next}",
+        t.paint(Role::Accent, "↳"),
+        t.paint(Role::Strong, "NEXT"),
+    );
+}
+
+/// Whether `check --fix` would change a byte of THIS file.
+///
+/// The ladder (`nika_cli_host::fix_ladder`) has exactly two sources. The
+/// dead-form arms fire on a `SchemaError` — a file that did not parse, and
+/// so never reaches this render at all. The typed renames read
+/// `unknown_tools` · `unknown_args` · `conformance` for a `suggestion`. On
+/// a file that PARSED, the second set is therefore the whole of it, and
+/// this predicate mirrors `collect_typed_renames` field for field.
+fn has_machine_applicable_repair(report: &CheckReport) -> bool {
+    report.unknown_tools.iter().any(|t| t.suggestion.is_some())
+        || report.unknown_args.iter().any(|a| a.suggestion.is_some())
+        || report
+            .conformance
+            .iter()
+            .any(|v| v.offending.is_some() && v.suggestion.is_some())
 }
 
 fn next_repair_action(path: &str, repair_target: RepairTarget) -> String {

--- a/crates/nika-display/src/check_render/tests.rs
+++ b/crates/nika-display/src/check_render/tests.rs
@@ -248,9 +248,51 @@ tasks:
         );
         assert!(out.contains("2 sites across 2 tasks"), "{out}");
         assert!(out.contains("1 distinct hint across 2 sites"), "{out}");
+        // The footer gives the next REAL command. `native-first` is not in
+        // the fix ladder, so for this file that command is `nika explain`
+        // and never `--fix` — which would change nothing and print this
+        // same line again (#1182).
+        assert!(out.contains("nika explain"), "{out}");
         assert!(
-            out.contains("nika check --fix repeated.nika.yaml"),
-            "the footer gives the next real command:\n{out}"
+            !out.contains("--fix"),
+            "no repair is machine-applicable here, so none is advised:\n{out}"
+        );
+    }
+
+    /// #1182 · `--fix` used to be advised on any file carrying a hint,
+    /// which is a different set from the files `--fix` can repair. A file
+    /// whose findings are all hints got « no machine-applicable repairs »
+    /// at the top of a `--fix` run and « run `--fix` » at the bottom of the
+    /// same output — a fixed point advertising itself as the exit.
+    #[test]
+    fn a_file_with_no_typed_rename_is_never_sent_to_fix() {
+        let hints_only = "nika: drifty
+permits: { exec: [curl], net: { http: [example.com] } }
+tasks:
+  t:
+    exec: { command: [curl, https://example.com/a] }
+";
+        let out = rendered(hints_only, "drifty.nika.yaml");
+        assert!(out.contains("NEXT"), "the footer still speaks:\n{out}");
+        assert!(
+            !out.contains("--fix"),
+            "a hint the ladder cannot touch must not route to `--fix`:\n{out}"
+        );
+
+        // The other end, so this cannot pass by never advising anything: a
+        // typed rename IS machine-applicable, and keeps its advice.
+        let renameable = "nika: fixable
+permits: { tools: [nika:read], exec: [curl], net: { http: [example.com] } }
+tasks:
+  t:
+    exec: { command: [curl, https://example.com/a] }
+  u:
+    invoke: { tool: nika:raed, args: { path: ./x } }
+";
+        let out = rendered(renameable, "fixable.nika.yaml");
+        assert!(
+            out.contains("nika check --fix fixable.nika.yaml"),
+            "a typed rename still earns the advice:\n{out}"
         );
     }
 
@@ -277,8 +319,19 @@ tasks:
 
     #[test]
     fn next_command_quotes_paths_and_never_offers_fix_for_stdin() {
-        let yaml =
-            "nika: q\npermits: { exec: [date] }\ntasks:\n  t:\n    exec: { command: [date] }\n";
+        // The fixture needs BOTH halves the NEXT line is gated on: a hint
+        // (so the line renders at all) and a typed rename (so advising
+        // `--fix` is true). `nika:raed` carries the suggestion; `date`
+        // carries the native-first hint. This test is about the QUOTING of
+        // the path in that advice — it needs the advice to be honest first.
+        let yaml = "nika: q
+permits: { exec: [date], tools: [nika:read] }
+tasks:
+  t:
+    exec: { command: [date] }
+  u:
+    invoke: { tool: nika:raed, args: { path: ./x } }
+";
         let spaced = rendered(yaml, "my workflow.nika.yaml");
         assert!(
             spaced.contains("nika check --fix 'my workflow.nika.yaml'"),


### PR DESCRIPTION
Closes #1182.

## The defect, in one output

```
$ nika check --fix loop.nika.yaml
 ○ FIX  no machine-applicable repairs (typed rename suggestions only — structural findings stay yours)
 …
 ↳ NEXT     run `nika check --fix loop.nika.yaml` to apply safe repairs, then re-check · …
```

Line one and the last line, same invocation. Obeying the last one is a **fixed point** —
three passes, `md5` unchanged, identical output every time, and the exit it offers is the
command that produced it.

## Cause

`footer.rs` fired the NEXT line on `hint_sites > 0`. That is a *different set* from the
files the ladder can repair. `nika_cli_host::fix_ladder` has exactly two sources:

- `apply_dead_form_arm(&SchemaError, …)` — a file that did **not parse**, and therefore
  never reaches this render at all;
- `collect_typed_renames(&report)` — `unknown_tools` · `unknown_args` · `conformance`,
  each read for a `suggestion`.

So on a file that parsed, the second set is the whole of it. `native-first/001` — the
hint the display tests use as their fixture, and the one `--native-strict` gates on — is
in neither. The trigger and the capability were disjoint for the most common hint kinds.

The new predicate mirrors `collect_typed_renames` field for field, in a doc comment that
says why.

## Only the workspace form is gated, and that is the whole point

A first cut gated all four repair targets and broke three tests in `nika-cli`
(`registry_cache_provenance_survives_acquisition_into_the_footer` et al.). Those tests
were right and the cut was wrong:

| target | can it loop? | why |
|---|---|---|
| `WorkspaceFile` | **yes** | obeying re-runs the same command on the same bytes |
| `Stdin` | no | obeying means *saving to a file* — new state, new check |
| `RegistryArtifact` | no | obeying means *copying out of a read-only cache* |
| `NonRegularSource` | no | obeying means *copying to a regular file* |

Their guidance is **provenance**, not repair: it says where a reader may write *at all*,
which is true whether or not a rename exists. Suppressing it would have hidden the
read-only teaching on a digest-pinned artifact — a real loss, to fix a loop those targets
cannot have.

## Measured on the real binary, both ends

```
### hints only, workspace file — the loop
 ○ FIX  no machine-applicable repairs …
 ↳ NEXT     see `nika explain` for coded findings — nothing here is a typed rename,
            so these are yours to place

### a typed rename — the advice is kept, and it is true
 ↳ NEXT     run `nika check --fix renameable.nika.yaml` to apply safe repairs, then re-check · …
 ✔ FIX  tool `nika:raed` → `nika:read`
 ✔ FIX  1 repair applied · re-audit below
```

## Mutation-proven

Restoring the old trigger (`if true`) turns **both** guards red —
`a_file_with_no_typed_rename_is_never_sent_to_fix` (the new one) and
`repeated_hint_code_renders_once_with_site_count_and_next_command` (the existing one,
whose `--fix` assertion this corrects).

## The test fixture change, and why it is not a weakening

`next_command_quotes_paths_and_never_offers_fix_for_stdin` tests the **quoting** of the
advised path — spaces, apostrophes, a leading dash, stdin, the cache, a non-regular
source. Its fixture carried only a `native-first` hint, so it was asserting the quoting
of advice that was never true. It now carries `nika:raed` as well: the hint keeps the
NEXT line rendering, the rename makes the advice honest, and every quoting assertion is
unchanged.

## Gates

- `cargo test -p nika-display --lib` · 154 passed
- `cargo test -p nika-cli --lib` · 312 passed
- `cargo test -p nika-cli --test verbs_static --test bin_smoke --test ascii_contract` · 43 + 3 + 23 passed
- `cargo clippy -p nika-display --all-targets -- -D warnings` clean · `cargo fmt --check` clean

## Territory

`footer.rs` is touched by no open PR. `check_render/tests.rs` is also in #1165 — measured
rather than assumed: its only hunk there is `@@ -360,6 +360,50 @@`, and these edits sit at
228-330. No textual overlap. No changelog fragment: `CHANGELOG.md` is contended by five
open PRs and #1185 is landing the fragment system that owns it.

proven_by: rust
