### PR TITLE
fix(release): the fold stages the deletions it makes

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -18,11 +18,16 @@ without an explicit operator decision.
    ```
 
    That splices the assembled body in as `## [<NEXT>]` with its compare
-   link, restores the `[Unreleased]` stub, and deletes the fragments it
-   consumed. Hand-curated narrative (a BREAKING window, an era note) may
-   still be edited into the section afterwards: the section, not the release
-   page, is where curation lives. `CHANGELOG.md` stays the single source the
-   release body renders from.
+   link, restores the `[Unreleased]` stub, and **`git rm`s** the fragments it
+   consumed — the deletions land STAGED, so `git add CHANGELOG.md` beside
+   them and the fold is one commit. (Plain `rm` left them unstaged, and since
+   this file stages by explicit path and never `git add -A`, the release
+   would have shipped the assembled section *and* the fragments it was made
+   from; the next fold would then emit each one twice.) Hand-curated
+   narrative (a BREAKING window, an era note) may still be edited into the
+   section afterwards: the section, not the release page, is where curation
+   lives. `CHANGELOG.md` stays the single source the release body renders
+   from.
 
    **Why fragments.** `CHANGELOG.md` was a shared append target, so two
    branches that shared no source file still collided there — measured

--- a/scripts/release/changelog-assemble.sh
+++ b/scripts/release/changelog-assemble.sh
@@ -220,9 +220,24 @@ fold_release() {
   } >"$tmp"
   mv "$tmp" "$CHANGELOG"
 
+  # `git rm`, not `rm`. The fold is ONE act: the section appears and the
+  # fragments that made it go away together, in the same index. A plain
+  # `rm` leaves the deletions unstaged, and the house forbids `git add -A`
+  # (RELEASING.md stages by explicit path), so a releaser commits
+  # CHANGELOG.md and the fragments stay TRACKED -- the release ships the
+  # assembled section AND its own inputs, and the next fold emits every
+  # one of them a second time. Measured 2026-08-24 on a scratch clone of
+  # this tree: 13 deletions, 0 staged.
+  #
+  # A fragment written but never committed is not `git rm`-able; it is
+  # still ours to remove, so the untracked case falls back to `rm`.
   while IFS= read -r frag; do
     [ -n "$frag" ] || continue
-    rm -f "$frag"
+    if git -C "$ROOT" ls-files --error-unmatch -- "$frag" >/dev/null 2>&1; then
+      git -C "$ROOT" rm -q -- "$frag"
+    else
+      rm -f -- "$frag"
+    fi
   done < <(all_fragments)
 
   printf 'changelog-assemble: folded %s fragment(s) into ## [%s] · changelog.d/ is empty\n' \


### PR DESCRIPTION
## Found reviewing my own change from earlier today

`--fold` (shipped in #1185) removed the consumed fragments with a plain `rm`,
so the deletions never reached the index.

**Measured on a scratch clone of this tree, before:**

```
tracked fragments before: 14
changelog-assemble: folded 13 fragment(s) into ## [0.115.0]

 M CHANGELOG.md
 D changelog.d/0001-nika-check-json-carries-one-obvious.added.md     <- leading space
 D changelog.d/0002-the-next-tagged-binary-includes-the.added.md        = UNSTAGED
 ...
staged (index) changes: NONE
```

**Why that is not cosmetic.** `RELEASING.md` stages by explicit path and this
repo forbids `git add -A`. So the ceremony is: run the fold, `git add
CHANGELOG.md`, commit — and every fragment stays **tracked**. The release would
ship the assembled section *and* the thirteen inputs it was assembled from, and
the next fold would emit each of them a second time.

The fold is one act: the section appears and its fragments go away together, in
the same index. `git rm` makes that true. A fragment written but never committed
is not `git rm`-able and still falls back to a plain remove, so an author who
drafts one and folds before committing is not left with a stray file.

**After:**

```
D  changelog.d/0001-nika-check-json-carries-one-obvious.added.md     <- staged
D  changelog.d/0002-the-next-tagged-binary-includes-the.added.md
 ...
staged (index) changes:
changelog.d/0001-... (all 13)
```

`RELEASING.md` step 1 now says the deletions land staged, so the releaser knows
what is in the index before committing rather than discovering it at the tag
gate.

## Why it survived review the first time

`--fold` was exercised in a scratch `git init` directory where nothing was ever
committed, so *every* path was untracked and `rm` looked correct. The test
proved the splice and the fragment consumption; it never asked what git thought.
A fold test that does not `git commit` first cannot see this class at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
