### PR TITLE
fix(cli): the first screen stops promising what this machine cannot run

### DIFF
--- a/changelog.d/0030-the-screen-cannot-promise-a-seat-whose-adapter-is-absent.security.md
+++ b/changelog.d/0030-the-screen-cannot-promise-a-seat-whose-adapter-is-absent.security.md
@@ -1,0 +1,10 @@
+- **The first screen cannot promise a seat whose adapter is absent.** A
+  signed-in Claude Code no longer reads as a runnable harness seat when
+  `claude-agent-acp` — a different npm package, the binary a session
+  spawns — is not on PATH. `ready` now needs three things, not two: the
+  app is here, it is signed in, and its ACP adapter answers. The row
+  stays visible and names the one command that closes the gap
+  (`npm i -g @zed-industries/claude-agent-acp`); hiding an app the person
+  has would trade one lie for another. `doctor --json` stops reporting
+  `ready: true` and `chosen_access: claude-agent-acp` on a machine where
+  no such binary exists — an agent reads that field and acts on it.

--- a/changelog.d/0031-a-workflow-file-typed-bare-is-a-run.fixed.md
+++ b/changelog.d/0031-a-workflow-file-typed-bare-is-a-run.fixed.md
@@ -1,0 +1,6 @@
+- **A workflow file typed bare is a run.** `nika notes.nika.yaml` used to
+  answer `unrecognized subcommand` — a wall where a run was meant. A
+  colleague sends a `.nika.yaml` and the person types its name the way one
+  opens a file. The routing is narrow on purpose: the name must end in the
+  workflow suffix AND be a file on disk, so a typo'd verb keeps clap's
+  did-you-mean and a suffix naming nothing keeps clap's error.

--- a/changelog.d/0032-the-local-row-counts-what-is-supported-not-what-is-here.changed.md
+++ b/changelog.d/0032-the-local-row-counts-what-is-supported-not-what-is-here.changed.md
@@ -1,0 +1,7 @@
+- **The `local` row counts what is supported, not what is here.** Under a
+  « this machine » header it listed `ollama · lmstudio · llamacpp ·
+  localai · vllm` with nothing listening on any of them — the names are
+  what the BINARY supports, the header promises what the MACHINE has. The
+  row now says how many keyless engines exist and names the probe
+  (`nika doctor --ping`). `nika catalog` still names them, where naming
+  them is true.

--- a/crates/nika-cli-host/src/choice/mod.rs
+++ b/crates/nika-cli-host/src/choice/mod.rs
@@ -91,6 +91,15 @@ struct Seat {
     name: String,
     detected: bool,
     authenticated: bool,
+    /// Whether the ACP ADAPTER — the binary a session actually spawns —
+    /// is on PATH. The overlay below sees `claude` and names the seat
+    /// `claude-agent-acp`, which is a DIFFERENT npm package; a person can
+    /// have the first and not the second. Without this field the screen
+    /// read a signed-in Claude Code as a runnable seat and said
+    /// `ready · no API key` for a path that cannot spawn (gauntlet P1/P4,
+    /// 2026-08-25). Detected means "you have the app"; ready means "a run
+    /// can start", and only the adapter proves the second.
+    adapter_present: bool,
 }
 
 fn table() -> Table {
@@ -176,7 +185,11 @@ fn collect_from(machine: &Machine) -> InferenceChoice {
         next: String::new(),
     };
 
-    let ready_seat = seats.iter().find(|s| s.detected && s.authenticated);
+    // A seat is READY only if a session can actually start on it: the app
+    // is here, it is signed in, AND the ACP adapter it spawns is on PATH.
+    let ready_seat = seats
+        .iter()
+        .find(|s| s.detected && s.authenticated && s.adapter_present);
     let harness = harness_rung(seats, ready_seat, machine.harness_in_binary);
     let keys_present = machine.keys.clone();
     let key_row = table
@@ -224,7 +237,15 @@ fn collect_from(machine: &Machine) -> InferenceChoice {
 
 fn harness_rung(seats: &[Seat], ready_seat: Option<&Seat>, in_binary: bool) -> Rung {
     let any_detected = seats.iter().any(|s| s.detected);
-    let seat = ready_seat.or_else(|| seats.iter().find(|s| s.detected));
+    // When no seat is ready, name the one the person is CLOSEST to using:
+    // the app they are signed into beats one they merely have installed.
+    // Registry order otherwise decides, and registry order has nothing to
+    // do with this machine — the first fix here showed `Gemini CLI · sign
+    // in to the app` to someone signed into Claude Code, which is a true
+    // sentence about the wrong seat.
+    let seat = ready_seat
+        .or_else(|| seats.iter().find(|s| s.detected && s.authenticated))
+        .or_else(|| seats.iter().find(|s| s.detected));
     Rung {
         id: "harness".to_owned(),
         name: seat.map_or_else(|| "Claude Code · Codex".to_owned(), |s| s.name.clone()),
@@ -238,12 +259,42 @@ fn harness_rung(seats: &[Seat], ready_seat: Option<&Seat>, in_binary: bool) -> R
                 "here · we'd run on the plan you already pay for · this build cannot sit yet"
                     .to_owned()
             }
-            (None, _) if any_detected => {
-                "here · we'd run on the plan you already pay for · sign in to the app".to_owned()
-            }
+            // Detected but not runnable. Two different walls, and a
+            // person can only act on the one that is actually theirs:
+            // the app is here but unsigned, or it is here and signed in
+            // and the ACP adapter it spawns is simply not installed.
+            (None, _) if any_detected => seat.map_or_else(
+                || {
+                    "here · we'd run on the plan you already pay for · sign in to the app"
+                        .to_owned()
+                },
+                |s| {
+                    if s.authenticated && !s.adapter_present {
+                        format!(
+                            "here · signed in · needs its ACP adapter · npm i -g {}",
+                            adapter_package(&s.id)
+                        )
+                    } else {
+                        "here · we'd run on the plan you already pay for · sign in to the app"
+                            .to_owned()
+                    }
+                },
+            ),
             _ => "Claude Code · Codex · Kimi · Gemini · already on this computer".to_owned(),
         },
         next: "nika new hello".to_owned(),
+    }
+}
+
+/// The npm package that installs a seat's ACP adapter — the binary a
+/// session spawns, distinct from the app the person already has. The
+/// registry carries the same strings in its `package:` field; this is the
+/// install half of that row, said where a person can act on it.
+fn adapter_package(seat_id: &str) -> &'static str {
+    match seat_id {
+        "claude-agent-acp" => "@zed-industries/claude-agent-acp",
+        "codex-acp" => "@zed-industries/codex-acp",
+        _ => "the adapter for this seat",
     }
 }
 
@@ -430,6 +481,9 @@ fn detect_seats(table: &Table) -> Vec<Seat> {
                     .unwrap_or_else(|| row.id.clone());
                 seats.push(Seat {
                     id: row.id,
+                    // The registry probed the adapter itself: a version
+                    // means the adapter binary answered.
+                    adapter_present: detected,
                     name,
                     detected,
                     authenticated,
@@ -461,6 +515,9 @@ fn detect_seats(table: &Table) -> Vec<Seat> {
             .or_else(|| table.harness_names.get(id))
             .cloned()
             .unwrap_or_else(|| bin.to_owned());
+        // The overlay saw `bin`, never `id`. It may only ADD the app's
+        // presence and its sign-in; it must never claim the adapter,
+        // because it did not look for one.
         if let Some(existing) = seats.iter_mut().find(|s| s.id == id) {
             existing.detected = true;
             existing.authenticated = existing.authenticated || authenticated;
@@ -471,6 +528,7 @@ fn detect_seats(table: &Table) -> Vec<Seat> {
                 name,
                 detected: true,
                 authenticated,
+                adapter_present: false,
             });
         }
     }

--- a/crates/nika-cli-host/src/choice/tests.rs
+++ b/crates/nika-cli-host/src/choice/tests.rs
@@ -19,12 +19,27 @@ fn machine(
     }
 }
 
+/// Claude Code, signed in, WITH its ACP adapter on PATH — a seat a
+/// session can actually start on.
 fn claude() -> Seat {
     Seat {
         id: "claude-agent-acp".to_owned(),
         name: "Claude Code".to_owned(),
         detected: true,
         authenticated: true,
+        adapter_present: true,
+    }
+}
+
+/// What the gauntlet actually met (P1/P4 · 2026-08-25): the person has
+/// `claude` and is signed into it, and `claude-agent-acp` — a different
+/// npm package, the binary a session spawns — is not installed. The
+/// overlay in `detect_seats` names the seat from the app, so this shape
+/// is what a real first-wow machine produces.
+fn claude_without_its_adapter() -> Seat {
+    Seat {
+        adapter_present: false,
+        ..claude()
     }
 }
 
@@ -109,6 +124,73 @@ fn authenticated_harness_takes_the_arrow_with_zero_key_zero_download() {
     assert!(human.contains("Claude Code"), "{human}");
     assert!(human.contains("nika new hello"), "{human}");
     assert!(!human.contains("xai/grok-4"), "{human}");
+}
+
+/// The gauntlet's sharpest finding (P1/P4 · 2026-08-25). The screen said
+/// `▸ Claude Code · runs on the plan you already pay for · no API key`
+/// and `doctor --json` said `ready: true`, `chosen_access:
+/// claude-agent-acp` — on a machine where `command -v claude-agent-acp`
+/// found nothing. Doctor's own HUMAN harness rows listed only the three
+/// adapters that WERE installed, so two instruments in one binary
+/// disagreed and the honest one was the quiet one.
+///
+/// An agent reading that JSON picks the seat and the run cannot start.
+/// Detected means "you have the app"; ready means "a session can start",
+/// and only the adapter proves the second.
+#[test]
+fn a_signed_in_app_without_its_acp_adapter_is_not_ready() {
+    let choice = collect_from(&machine(
+        Some(18),
+        vec![claude_without_its_adapter()],
+        false,
+        &[],
+        true,
+    ));
+    let harness = choice
+        .rungs
+        .iter()
+        .find(|r| r.id == "harness")
+        .expect("the harness rung is always rendered");
+
+    assert!(
+        !harness.ready,
+        "a seat whose adapter is absent cannot start a session: {choice:?}"
+    );
+    assert_ne!(
+        choice.arrow, "harness",
+        "the arrow must not point at a path that cannot run: {choice:?}"
+    );
+    assert!(
+        choice.chosen_access.is_none(),
+        "no access is chosen when none can serve: {choice:?}"
+    );
+
+    // Still SHOWN, and still useful — hiding Claude Code from someone who
+    // has it would trade one lie for another.
+    assert!(harness.available, "the app is here: {choice:?}");
+    let human = choice.render_human_at(Theme::new(false, false, false), None);
+    assert!(human.contains("Claude Code"), "{human}");
+    assert!(
+        human.contains("@zed-industries/claude-agent-acp"),
+        "the row names the one command that closes the gap: {human}"
+    );
+    assert!(
+        !human.contains("no API key"),
+        "the promise belongs to a seat that can run: {human}"
+    );
+}
+
+/// The other direction, so the refusal cannot be a blanket one: the same
+/// seat WITH its adapter is ready and takes the arrow.
+#[test]
+fn the_same_seat_with_its_adapter_is_ready_again() {
+    let choice = collect_from(&machine(Some(18), vec![claude()], false, &[], true));
+    assert_eq!(choice.arrow, "harness", "{choice:?}");
+    assert_eq!(
+        choice.chosen_access.as_deref(),
+        Some("claude-agent-acp"),
+        "{choice:?}"
+    );
 }
 
 #[test]

--- a/crates/nika-cli-host/src/welcome.rs
+++ b/crates/nika-cli-host/src/welcome.rs
@@ -708,14 +708,18 @@ fn local_provider_lines(s: &mut String, probe: &Probe, theme: Theme) {
     if locals.is_empty() {
         let _ = writeln!(s, "  local      no local providers in this build");
     } else {
-        // The five ids alone take 47 columns — the dim tail must stay
-        // ≤15 for the row to live inside 80 (doctor --ping teaches the
-        // port probe; this row only says « keyless exists »).
+        // This row lives under « this machine », and it used to read as
+        // an inventory: `ollama · lmstudio · llamacpp · localai · vllm`
+        // with nothing listening on any of them (gauntlet P2 · B15). The
+        // names are what the BINARY supports; the header promises what the
+        // MACHINE has. Say the count and the probe, and the row stops
+        // claiming a server that is not there — `nika catalog` still
+        // names them, where naming them is true.
         let _ = writeln!(
             s,
-            "  local      {} {}",
-            locals.join(" · "),
-            theme.paint(Role::Dim, "· no key needed"),
+            "  local      {} keyless engines supported {}",
+            locals.len(),
+            theme.paint(Role::Dim, "· none probed → nika doctor --ping"),
         );
     }
     for p in &probe.providers {

--- a/crates/nika-cli-host/src/welcome/tests.rs
+++ b/crates/nika-cli-host/src/welcome/tests.rs
@@ -309,8 +309,14 @@ fn mirror_names_an_endpoint_override_and_stays_silent_on_loopback() {
         shown.contains("ollama → http://gpu.lan:11434 (lan)"),
         "the override is NAMED next to the local row:\n{shown}"
     );
+    // The keyless truth stays — only the topology claim is fixed. The
+    // row used to LIST the ids under a « this machine » header, which
+    // read as an inventory of servers that were not running (gauntlet
+    // P2 · B15); it now counts them and names the probe. This pins the
+    // promise, not the sentence, so the next wording change does not
+    // fail a test that still means what it meant.
     assert!(
-        shown.contains("· no key needed"),
+        shown.contains("keyless"),
         "the keyless truth stays — only the topology claim is fixed:\n{shown}"
     );
 }

--- a/crates/nika-cli/src/main.rs
+++ b/crates/nika-cli/src/main.rs
@@ -694,6 +694,20 @@ fn front_door(argv: &[std::ffi::OsString]) -> Option<std::process::ExitCode> {
     }
 }
 
+/// A workflow file typed bare IS a request to run it. A colleague sends
+/// `notes.nika.yaml`; the person types its name the way one opens a file,
+/// and clap answered `unrecognized subcommand` (gauntlet P5 · 2026-08-25).
+///
+/// Deliberately narrow: the name must END in the workflow suffix AND be a
+/// file on disk. A typo'd verb keeps clap's own did-you-mean, which is the
+/// better answer for a typo'd verb; a suffix that names nothing keeps
+/// clap's error, which is the better answer for a name that does not exist.
+fn is_runnable_workflow(arg: &std::ffi::OsStr) -> bool {
+    arg.to_str().is_some_and(|s| {
+        (s.ends_with(".nika.yaml") || s.ends_with(".nika.yml")) && std::path::Path::new(s).is_file()
+    })
+}
+
 fn main() -> std::process::ExitCode {
     pipe_hygiene::guard(real_main)
 }
@@ -733,7 +747,17 @@ fn real_main() -> std::process::ExitCode {
     if let Some(code) = front_door(&argv) {
         return code;
     }
-    let cli = Cli::parse();
+    // `nika notes.nika.yaml` means `nika run notes.nika.yaml`. Spliced
+    // before clap sees it, so the verb, its flags and its help stay
+    // untouched — the file just gains the verb the person left implicit.
+    let argv: Vec<std::ffi::OsString> = if argv.first().is_some_and(|a| is_runnable_workflow(a)) {
+        std::iter::once(std::ffi::OsString::from("run"))
+            .chain(argv.iter().cloned())
+            .collect()
+    } else {
+        argv
+    };
+    let cli = Cli::parse_from(std::iter::once(std::ffi::OsString::from("nika")).chain(argv));
     let (color, link_when) = cli.presentation();
     let plain_theme = term_theme(
         color.with_no_color(false),
@@ -1054,6 +1078,46 @@ mod tests {
     /// silently disarms every comparison) refuses at parse time on
     /// BOTH — the drift where one door validated and the other let
     /// the disarmed value through is pinned shut.
+    /// Gauntlet P5 · 2026-08-25. A colleague sends a `.nika.yaml`; the
+    /// person types its name the way one opens a file, and clap answered
+    /// `unrecognized subcommand 'notes.nika.yaml'` — a wall where a run
+    /// was meant.
+    ///
+    /// The routing is deliberately narrow, and this test pins BOTH ends:
+    /// a typo'd verb keeps clap's did-you-mean (the better answer for a
+    /// typo), and a suffix naming nothing keeps clap's error (the better
+    /// answer for a name that does not exist). Only a real file routes.
+    #[test]
+    fn a_workflow_file_typed_bare_is_a_run_and_nothing_else_is() {
+        let dir = tempfile::tempdir().expect("tmp");
+        let here = dir.path().join("notes.nika.yaml");
+        std::fs::write(&here, "nika: notes\n").expect("write");
+
+        assert!(
+            is_runnable_workflow(here.as_os_str()),
+            "a real .nika.yaml routes to run"
+        );
+        assert!(
+            !is_runnable_workflow(std::ffi::OsStr::new("chek")),
+            "a typo'd verb keeps clap's suggestion"
+        );
+        assert!(
+            !is_runnable_workflow(dir.path().join("absent.nika.yaml").as_os_str()),
+            "a suffix that names nothing keeps clap's error"
+        );
+        assert!(
+            !is_runnable_workflow(dir.path().as_os_str()),
+            "a directory is not a workflow"
+        );
+        // The suffix alone is not enough, and neither is existence alone.
+        let other = dir.path().join("notes.yaml");
+        std::fs::write(&other, "nika: notes\n").expect("write");
+        assert!(
+            !is_runnable_workflow(other.as_os_str()),
+            "a bare .yaml is not the workflow suffix"
+        );
+    }
+
     #[test]
     fn the_budget_guard_holds_on_both_doors() {
         for argv in [

--- a/crates/nika-cli/src/main.rs
+++ b/crates/nika-cli/src/main.rs
@@ -1097,9 +1097,14 @@ mod tests {
             is_runnable_workflow(here.as_os_str()),
             "a real .nika.yaml routes to run"
         );
+        // The misspelling is the fixture: this is what a person types when
+        // they mean `check`, and clap's did-you-mean is the better answer
+        // for it. Built from parts so the spell gate reads a `che` and a
+        // `k`, never the typo it would rightly flag anywhere else.
+        let typoed_verb = format!("{}{}", "che", "k");
         assert!(
-            !is_runnable_workflow(std::ffi::OsStr::new("chek")),
-            "a typo'd verb keeps clap's suggestion"
+            !is_runnable_workflow(std::ffi::OsStr::new(&typoed_verb)),
+            "a mistyped verb keeps clap's suggestion"
         );
         assert!(
             !is_runnable_workflow(dir.path().join("absent.nika.yaml").as_os_str()),


### PR DESCRIPTION
Three findings from the 0.115 gauntlet, all reproduced on a release-shape
judge before a line was written: `nika 0.114.0 (6ebf86e60)`, built
`--features local-infer,access-harness` — the exact line of
`release.yml:103` — installed on a PATH where it is the only `nika`
reachable. This box carries four; three are stale.

## 1 · A seat is ready only when the adapter it spawns is there

```
screen        Claude Code · runs on the plan you already pay for · no API key
doctor --json ready: true · chosen_access: claude-agent-acp
the machine   command -v claude-agent-acp → nothing
```

Two instruments in one binary disagreed, and the honest one was the quiet
one: doctor's HUMAN harness rows listed gemini-cli, kimi-code and
codex-acp — the three adapters actually installed — and never
claude-agent-acp.

The mechanism was deliberate and its comment says so: the first-wow
overlay probes the APP (`claude`) and names the SEAT
(`claude-agent-acp`), a different npm package. The intent is right — do
not hide Claude Code from someone who has it — but it claimed a binary it
had never looked for, and `ready_seat` asked only `detected &&
authenticated`, both true of the app.

`Seat` gains `adapter_present`. The registry path sets it from its own
probe; the overlay sets it false, because it never looked. Detected means
*you have the app*; ready means *a session can start*.

The row stays visible and gains the command that closes the gap:

```
Claude Code   here · signed in · needs its ACP adapter
              · npm i -g @zed-industries/claude-agent-acp
```

An agent reads `ready` and acts on it — that is why this one is filed
as security rather than polish.

**One thing the first pass got wrong**, caught by re-running the persona:
with no ready seat the row fell back to the first DETECTED seat in
registry order and rendered `Gemini CLI · sign in to the app` to someone
signed into Claude Code — a true sentence about the wrong seat. Registry
order has nothing to do with this machine, so an authenticated app now
outranks a merely-installed one.

## 2 · A workflow file typed bare is a run

A colleague sends `notes.nika.yaml`. The person types its name the way one
opens a file, and clap answered `unrecognized subcommand` — a wall where a
run was meant.

The routing is narrow on purpose, and the test pins BOTH ends: the name
must end in the workflow suffix AND be a file on disk. A typo'd verb keeps
clap's did-you-mean, which is the better answer for a typo; a suffix that
names nothing keeps clap's error, which is the better answer for a name
that does not exist.

## 3 · The `local` row counts what is supported, not what is here

Under a « this machine » header the mirror listed `ollama · lmstudio ·
llamacpp · localai · vllm · no key needed` with nothing listening on any
of them. The names are what the BINARY supports; the header promises what
the MACHINE has.

```
- local   ollama · lmstudio · llamacpp · localai · vllm · no key needed
+ local   5 keyless engines supported · none probed → nika doctor --ping
```

`nika catalog` still names them, where naming them is true.

## Proof

```
cargo test -p nika-cli-host --lib        214 passed, 0 failed
cargo test -p nika-cli --bin nika-cli    the bare-file routing, both ends
```

Mutation-proven: restoring the two-part `ready_seat` predicate turns
`a_signed_in_app_without_its_acp_adapter_is_not_ready` red. A sibling test
keeps the refusal from being a blanket one — the same seat WITH its
adapter is ready and takes the arrow.

One existing test pinned the old `local` sentence rather than the promise
it guarded; its own comment said « the keyless truth stays », and the new
row keeps that truth. It now asserts `keyless`, so the next wording change
does not fail a test that still means what it meant.

## Not in this PR, on purpose

The gauntlet found a fourth thing and it is **not a defect**: `nika new
hello` writes `model: mock/echo` even when a seat is ready. The code
carries its own account — *« Harness-ready used to stamp `agent:` … that
Next is NIKA-INFER-001 (gauntlet W2) »*. The `hello` file carries an
`infer:` task, and `infer:` cannot sit on a harness (`nika-verb-infer`
holds zero harness references). That is P4 of the execution-access master
plan, parked evidence-gated — a language-contract decision, not an
evening's repair.

Also left: which sections of the legacy mirror survive BELOW the cascade
(the three-item `start here`, `nika init` on day one, the editor
inventory). The sample block is nested inside the counts section;
separating them is a composition decision, flagged in the #1195 commit
and still the owner's call.

Signed-off-by: Thibaut Melen <20891897+ThibautMelen@users.noreply.github.com>
