### PR TITLE
fix(catalog): a count that does not project from the binary disappears from the surface

### DIFF
--- a/changelog.d/1179.changed.md
+++ b/changelog.d/1179.changed.md
@@ -1,0 +1,7 @@
+- **`nika doctor` stops calling price rows models (#1179).** The pricing
+  line formatted the vendored snapshot's rule count as « 633 models »,
+  one command away from `nika catalog`'s « 69 models » — two inventories
+  under one word, an order of magnitude apart, both on a first session.
+  It now reads `633 price rules · 10 providers priced`. Same numbers,
+  each naming the facet it counts: several patterns can price one model,
+  and a pattern can price models this catalog never lists.

--- a/changelog.d/1184.changed.md
+++ b/changelog.d/1184.changed.md
@@ -1,0 +1,15 @@
+- **The catalog marks what this build can actually run (#1184).** `nika
+  catalog` ships 38 vendors and this binary seats 16; until now the human
+  list, the `catalog_version: 1` JSON and the MCP `nika_catalog` tool
+  rendered a reachable and an unreachable vendor identically. Every
+  provider row now carries a `wired` boolean, derived from
+  `nika_providers::CANONICAL_IDS` and never typed: the JSON emits the
+  field (additive within v1 — no envelope bump), the human column reads
+  `catalog only — no wire in this build`, and the MCP tool description
+  tells an agent to pick only from rows where `wired` is true. `native`
+  no longer invites `nika model pull` into a door that refuses at
+  `check`. The header names the one-row gap between its « 15 wired » and
+  `check`'s « 16 runnable » — the `mock` test lane. One traversal
+  (`catalog_family.rs`, the `rust` CI job) holds all 38 rows to the same
+  answer across the two projections and the MODELS rung, and is the
+  `proven_by` for their 38 ledger rows.

--- a/changelog.d/1184.changed.md
+++ b/changelog.d/1184.changed.md
@@ -1,15 +1,18 @@
 - **The catalog marks what this build can actually run (#1184).** `nika
-  catalog` ships 38 vendors and this binary seats 16; until now the human
-  list, the `catalog_version: 1` JSON and the MCP `nika_catalog` tool
-  rendered a reachable and an unreachable vendor identically. Every
-  provider row now carries a `wired` boolean, derived from
+  catalog` ships 38 vendors and this binary carries adapters for 16;
+  until now the human list, the `catalog_version: 1` JSON and the MCP
+  `nika_catalog` tool rendered a reachable and an unreachable vendor
+  identically, so the fact only arrived after the choice, at the MODELS
+  rung. Every provider row now carries `resolves`, derived from
   `nika_providers::CANONICAL_IDS` and never typed: the JSON emits the
   field (additive within v1 — no envelope bump), the human column reads
-  `catalog only — no wire in this build`, and the MCP tool description
-  tells an agent to pick only from rows where `wired` is true. `native`
-  no longer invites `nika model pull` into a door that refuses at
-  `check`. The header names the one-row gap between its « 15 wired » and
-  `check`'s « 16 runnable » — the `mock` test lane. One traversal
-  (`catalog_family.rs`, the `rust` CI job) holds all 38 rows to the same
-  answer across the two projections and the MODELS rung, and is the
-  `proven_by` for their 38 ledger rows.
+  `catalog only — does not resolve in this build`, and the MCP tool
+  description tells an agent to pick only from rows where it is true.
+  The word is the refusal rung's own — « wired » already names a
+  different set (the run registry, `mock` excluded) one line above, and
+  a synonym there would re-create the confusion `machine_truth.rs`
+  exists to cure. `native` no longer invites `nika model pull` into a
+  door that refuses at `check`. One traversal (`catalog_family.rs`, the
+  `rust` CI job) holds all 38 rows to the same answer across both
+  projections and the MODELS rung, and is the `proven_by` for their 38
+  ledger rows.

--- a/crates/nika-catalog/public-api.txt
+++ b/crates/nika-catalog/public-api.txt
@@ -994,7 +994,7 @@ pub fn nika_catalog::export::CapabilitiesExport::as_any(&self) -> &(dyn core::an
 pub nika_catalog::export::CatalogExport::catalog_version: u32
 pub nika_catalog::export::CatalogExport::providers: alloc::vec::Vec<nika_catalog::export::ProviderExport>
 impl nika_catalog::export::CatalogExport
-pub fn nika_catalog::export::CatalogExport::with_wiring(self, wired_ids: &[&str]) -> Self
+pub fn nika_catalog::export::CatalogExport::with_resolvable(self, resolvable_ids: &[&str]) -> Self
 impl core::clone::Clone for nika_catalog::export::CatalogExport
 pub fn nika_catalog::export::CatalogExport::clone(&self) -> nika_catalog::export::CatalogExport
 impl core::fmt::Debug for nika_catalog::export::CatalogExport
@@ -1075,8 +1075,8 @@ pub nika_catalog::export::ProviderExport::local: bool
 pub nika_catalog::export::ProviderExport::models: alloc::vec::Vec<nika_catalog::export::ModelExport>
 pub nika_catalog::export::ProviderExport::name: &'static str
 pub nika_catalog::export::ProviderExport::requires_key: bool
+pub nika_catalog::export::ProviderExport::resolves: bool
 pub nika_catalog::export::ProviderExport::tags: alloc::vec::Vec<&'static str>
-pub nika_catalog::export::ProviderExport::wired: bool
 impl core::clone::Clone for nika_catalog::export::ProviderExport
 pub fn nika_catalog::export::ProviderExport::clone(&self) -> nika_catalog::export::ProviderExport
 impl core::fmt::Debug for nika_catalog::export::ProviderExport

--- a/crates/nika-catalog/public-api.txt
+++ b/crates/nika-catalog/public-api.txt
@@ -993,6 +993,8 @@ pub fn nika_catalog::export::CapabilitiesExport::as_any(&self) -> &(dyn core::an
 #[non_exhaustive] pub struct nika_catalog::export::CatalogExport
 pub nika_catalog::export::CatalogExport::catalog_version: u32
 pub nika_catalog::export::CatalogExport::providers: alloc::vec::Vec<nika_catalog::export::ProviderExport>
+impl nika_catalog::export::CatalogExport
+pub fn nika_catalog::export::CatalogExport::with_wiring(self, wired_ids: &[&str]) -> Self
 impl core::clone::Clone for nika_catalog::export::CatalogExport
 pub fn nika_catalog::export::CatalogExport::clone(&self) -> nika_catalog::export::CatalogExport
 impl core::fmt::Debug for nika_catalog::export::CatalogExport
@@ -1074,6 +1076,7 @@ pub nika_catalog::export::ProviderExport::models: alloc::vec::Vec<nika_catalog::
 pub nika_catalog::export::ProviderExport::name: &'static str
 pub nika_catalog::export::ProviderExport::requires_key: bool
 pub nika_catalog::export::ProviderExport::tags: alloc::vec::Vec<&'static str>
+pub nika_catalog::export::ProviderExport::wired: bool
 impl core::clone::Clone for nika_catalog::export::ProviderExport
 pub fn nika_catalog::export::ProviderExport::clone(&self) -> nika_catalog::export::ProviderExport
 impl core::fmt::Debug for nika_catalog::export::ProviderExport

--- a/crates/nika-catalog/src/export.rs
+++ b/crates/nika-catalog/src/export.rs
@@ -68,6 +68,23 @@ pub struct ProviderExport {
     /// Wire-protocol dialect family (`"openai-chat"` · `"anthropic"` · …),
     /// `None` for bespoke protocols.
     pub api_dialect: Option<&'static str>,
+    /// Whether THIS build's wire layer can seat the provider — `false`
+    /// means the catalog knows the vendor and the engine cannot reach
+    /// it (`nika check` refuses the model at the MODELS rung).
+    ///
+    /// Never typed and never readable here: the catalog is L0 data, the
+    /// wire layer is L1.5 code, and `nika_catalog::export` is gated off
+    /// inside `nika-providers` — so the fact can only be STATED by the
+    /// L4 surface that holds both. [`CatalogExport::with_wiring`] is the
+    /// ONLY path to `true`, and its one honest argument is
+    /// `nika_providers::CANONICAL_IDS`.
+    ///
+    /// A projection built by [`catalog_export`] alone claims no wiring —
+    /// every row reads `false`. The two surfaces that emit this
+    /// projection to a human or an agent (`nika catalog` · the MCP
+    /// `nika_catalog` tool) are pinned to the wire layer by
+    /// `nika-cli/tests/catalog_family.rs`.
+    pub wired: bool,
     /// Typed capability/deployment/economics tags, kebab-case.
     pub tags: Vec<&'static str>,
     /// Known models (nickname → wire id) with resolved capabilities.
@@ -109,12 +126,38 @@ pub struct CapabilitiesExport {
     pub json_mode: Option<&'static str>,
 }
 
+impl CatalogExport {
+    /// State which provider ids THIS build's wire layer can seat.
+    ///
+    /// The ONE setter of [`ProviderExport::wired`] — there is no other
+    /// path to `true`. The wiring arrives as a parameter because the
+    /// fact lives one layer up (`nika_providers::CANONICAL_IDS`) and an
+    /// L0 catalog cannot read it; a hand-maintained mirror of that list
+    /// inside the catalog data would be the next drift.
+    ///
+    /// Ids absent from the catalog are ignored: the runtime seats
+    /// engines the catalog data does not carry, and this projection
+    /// speaks only about rows it has.
+    #[must_use]
+    pub fn with_wiring(mut self, wired_ids: &[&str]) -> Self {
+        for provider in &mut self.providers {
+            provider.wired = wired_ids.contains(&provider.id);
+        }
+        self
+    }
+}
+
 /// Build the full catalog projection from the embedded catalogs.
 ///
 /// Pure over compile-time data: zero I/O, zero network, deterministic
 /// for a given binary. Capabilities are resolved per model through
 /// [`crate::model_capabilities`] using the provider id + WIRE model id
 /// (the rule table matches wire names, not nicknames).
+///
+/// Every row leaves here `wired: false` — this function makes no claim
+/// about what the engine can reach. A surface a human or an agent reads
+/// chains [`CatalogExport::with_wiring`] over the wire layer's own id
+/// list (`nika_providers::CANONICAL_IDS`) before serializing.
 #[must_use]
 pub fn catalog_export() -> CatalogExport {
     CatalogExport {
@@ -136,6 +179,8 @@ fn provider_export(p: &Provider) -> ProviderExport {
         cheap_model: p.cheap_model,
         description: p.description,
         api_dialect: p.api_dialect,
+        // No claim here — `with_wiring` is the only thing that knows.
+        wired: false,
         tags: p.tags.iter().map(|t| t.as_str()).collect(),
         models: p.models.iter().map(|m| model_export(p.id, m)).collect(),
     }
@@ -253,11 +298,68 @@ mod tests {
             "cheap_model",
             "description",
             "api_dialect",
+            "wired",
             "tags",
             "models",
         ] {
             assert!(first.contains_key(key), "provider entry missing `{key}`");
         }
+    }
+
+    #[test]
+    fn the_bare_projection_claims_no_wiring() {
+        let export = catalog_export();
+        assert!(
+            export.providers.iter().all(|p| !p.wired),
+            "catalog_export() alone knows nothing about the wire layer",
+        );
+    }
+
+    #[test]
+    fn with_wiring_marks_exactly_the_named_ids() {
+        let all: Vec<&str> = catalog_export().providers.iter().map(|p| p.id).collect();
+        let named = ["anthropic", "mock"];
+        let export = catalog_export().with_wiring(&named);
+        for p in &export.providers {
+            assert_eq!(
+                p.wired,
+                named.contains(&p.id),
+                "provider `{}`: wired must mirror the named set",
+                p.id,
+            );
+        }
+        assert_eq!(
+            export.providers.iter().filter(|p| p.wired).count(),
+            named.len(),
+            "the wired rows are exactly the named ones, in a catalog of {}",
+            all.len(),
+        );
+    }
+
+    #[test]
+    fn an_id_the_catalog_does_not_carry_marks_nothing() {
+        let export = catalog_export().with_wiring(&["a-provider-no-catalog-row-names"]);
+        assert!(
+            export.providers.iter().all(|p| !p.wired),
+            "the projection speaks only about rows it has",
+        );
+    }
+
+    #[test]
+    fn wiring_replaces_a_previous_claim_rather_than_accumulating() {
+        // Chaining must not leave a stale `true` behind: the last call
+        // IS the build's answer, or a re-annotation would silently keep
+        // a provider marked runnable after it left the wire layer.
+        let export = catalog_export()
+            .with_wiring(&["anthropic", "mock"])
+            .with_wiring(&["mock"]);
+        let wired: Vec<&str> = export
+            .providers
+            .iter()
+            .filter(|p| p.wired)
+            .map(|p| p.id)
+            .collect();
+        assert_eq!(wired, vec!["mock"]);
     }
 
     #[test]

--- a/crates/nika-catalog/src/export.rs
+++ b/crates/nika-catalog/src/export.rs
@@ -68,23 +68,31 @@ pub struct ProviderExport {
     /// Wire-protocol dialect family (`"openai-chat"` · `"anthropic"` · …),
     /// `None` for bespoke protocols.
     pub api_dialect: Option<&'static str>,
-    /// Whether THIS build's wire layer can seat the provider — `false`
-    /// means the catalog knows the vendor and the engine cannot reach
-    /// it (`nika check` refuses the model at the MODELS rung).
+    /// Whether a model of this provider RESOLVES in this build — `false`
+    /// means the catalog knows the vendor and the engine carries no
+    /// adapter, so `nika check` refuses at the MODELS rung with the same
+    /// verb: *"provider `x` does not resolve in THIS binary"*.
+    ///
+    /// The word is the refusal rung's, on purpose. « wired » already
+    /// names a DIFFERENT set one screen away — the run registry behind
+    /// `nika_cli_host::machine_truth::MachineTruth::wired`, which
+    /// excludes the `mock` test lane. Two sets, two words; a synonym
+    /// here would re-create the very A-06 confusion that module exists
+    /// to cure.
     ///
     /// Never typed and never readable here: the catalog is L0 data, the
-    /// wire layer is L1.5 code, and `nika_catalog::export` is gated off
+    /// adapters are L1.5 code, and `nika_catalog::export` is gated off
     /// inside `nika-providers` — so the fact can only be STATED by the
-    /// L4 surface that holds both. [`CatalogExport::with_wiring`] is the
-    /// ONLY path to `true`, and its one honest argument is
+    /// L4 surface that holds both. [`CatalogExport::with_resolvable`] is
+    /// the ONLY path to `true`, and its one honest argument is
     /// `nika_providers::CANONICAL_IDS`.
     ///
-    /// A projection built by [`catalog_export`] alone claims no wiring —
+    /// A projection built by [`catalog_export`] alone claims nothing —
     /// every row reads `false`. The two surfaces that emit this
     /// projection to a human or an agent (`nika catalog` · the MCP
-    /// `nika_catalog` tool) are pinned to the wire layer by
+    /// `nika_catalog` tool) are pinned to the adapter set by
     /// `nika-cli/tests/catalog_family.rs`.
-    pub wired: bool,
+    pub resolves: bool,
     /// Typed capability/deployment/economics tags, kebab-case.
     pub tags: Vec<&'static str>,
     /// Known models (nickname → wire id) with resolved capabilities.
@@ -127,21 +135,21 @@ pub struct CapabilitiesExport {
 }
 
 impl CatalogExport {
-    /// State which provider ids THIS build's wire layer can seat.
+    /// State which provider ids resolve in THIS build.
     ///
-    /// The ONE setter of [`ProviderExport::wired`] — there is no other
-    /// path to `true`. The wiring arrives as a parameter because the
+    /// The ONE setter of [`ProviderExport::resolves`] — there is no
+    /// other path to `true`. The set arrives as a parameter because the
     /// fact lives one layer up (`nika_providers::CANONICAL_IDS`) and an
     /// L0 catalog cannot read it; a hand-maintained mirror of that list
     /// inside the catalog data would be the next drift.
     ///
-    /// Ids absent from the catalog are ignored: the runtime seats
-    /// engines the catalog data does not carry, and this projection
-    /// speaks only about rows it has.
+    /// Ids absent from the catalog are ignored: the runtime carries
+    /// engines the catalog data does not, and this projection speaks
+    /// only about rows it has.
     #[must_use]
-    pub fn with_wiring(mut self, wired_ids: &[&str]) -> Self {
+    pub fn with_resolvable(mut self, resolvable_ids: &[&str]) -> Self {
         for provider in &mut self.providers {
-            provider.wired = wired_ids.contains(&provider.id);
+            provider.resolves = resolvable_ids.contains(&provider.id);
         }
         self
     }
@@ -154,10 +162,10 @@ impl CatalogExport {
 /// [`crate::model_capabilities`] using the provider id + WIRE model id
 /// (the rule table matches wire names, not nicknames).
 ///
-/// Every row leaves here `wired: false` — this function makes no claim
-/// about what the engine can reach. A surface a human or an agent reads
-/// chains [`CatalogExport::with_wiring`] over the wire layer's own id
-/// list (`nika_providers::CANONICAL_IDS`) before serializing.
+/// Every row leaves here `resolves: false` — this function makes no
+/// claim about what the engine can reach. A surface a human or an agent
+/// reads chains [`CatalogExport::with_resolvable`] over the adapter
+/// layer's own id list (`nika_providers::CANONICAL_IDS`) first.
 #[must_use]
 pub fn catalog_export() -> CatalogExport {
     CatalogExport {
@@ -179,8 +187,8 @@ fn provider_export(p: &Provider) -> ProviderExport {
         cheap_model: p.cheap_model,
         description: p.description,
         api_dialect: p.api_dialect,
-        // No claim here — `with_wiring` is the only thing that knows.
-        wired: false,
+        // No claim here — `with_resolvable` is the only setter.
+        resolves: false,
         tags: p.tags.iter().map(|t| t.as_str()).collect(),
         models: p.models.iter().map(|m| model_export(p.id, m)).collect(),
     }
@@ -298,7 +306,7 @@ mod tests {
             "cheap_model",
             "description",
             "api_dialect",
-            "wired",
+            "resolves",
             "tags",
             "models",
         ] {
@@ -307,59 +315,59 @@ mod tests {
     }
 
     #[test]
-    fn the_bare_projection_claims_no_wiring() {
+    fn the_bare_projection_claims_nothing() {
         let export = catalog_export();
         assert!(
-            export.providers.iter().all(|p| !p.wired),
-            "catalog_export() alone knows nothing about the wire layer",
+            export.providers.iter().all(|p| !p.resolves),
+            "catalog_export() alone knows nothing about the adapter set",
         );
     }
 
     #[test]
-    fn with_wiring_marks_exactly_the_named_ids() {
+    fn with_resolvable_marks_exactly_the_named_ids() {
         let all: Vec<&str> = catalog_export().providers.iter().map(|p| p.id).collect();
         let named = ["anthropic", "mock"];
-        let export = catalog_export().with_wiring(&named);
+        let export = catalog_export().with_resolvable(&named);
         for p in &export.providers {
             assert_eq!(
-                p.wired,
+                p.resolves,
                 named.contains(&p.id),
-                "provider `{}`: wired must mirror the named set",
+                "provider `{}`: resolves must mirror the named set",
                 p.id,
             );
         }
         assert_eq!(
-            export.providers.iter().filter(|p| p.wired).count(),
+            export.providers.iter().filter(|p| p.resolves).count(),
             named.len(),
-            "the wired rows are exactly the named ones, in a catalog of {}",
+            "the resolving rows are exactly the named ones, in a catalog of {}",
             all.len(),
         );
     }
 
     #[test]
     fn an_id_the_catalog_does_not_carry_marks_nothing() {
-        let export = catalog_export().with_wiring(&["a-provider-no-catalog-row-names"]);
+        let export = catalog_export().with_resolvable(&["a-provider-no-catalog-row-names"]);
         assert!(
-            export.providers.iter().all(|p| !p.wired),
+            export.providers.iter().all(|p| !p.resolves),
             "the projection speaks only about rows it has",
         );
     }
 
     #[test]
-    fn wiring_replaces_a_previous_claim_rather_than_accumulating() {
+    fn a_second_call_replaces_the_claim_rather_than_accumulating() {
         // Chaining must not leave a stale `true` behind: the last call
         // IS the build's answer, or a re-annotation would silently keep
         // a provider marked runnable after it left the wire layer.
         let export = catalog_export()
-            .with_wiring(&["anthropic", "mock"])
-            .with_wiring(&["mock"]);
-        let wired: Vec<&str> = export
+            .with_resolvable(&["anthropic", "mock"])
+            .with_resolvable(&["mock"]);
+        let resolving: Vec<&str> = export
             .providers
             .iter()
-            .filter(|p| p.wired)
+            .filter(|p| p.resolves)
             .map(|p| p.id)
             .collect();
-        assert_eq!(wired, vec!["mock"]);
+        assert_eq!(resolving, vec!["mock"]);
     }
 
     #[test]

--- a/crates/nika-cli-host/src/doctor.rs
+++ b/crates/nika-cli-host/src/doctor.rs
@@ -452,8 +452,16 @@ fn pricing_finding(p: &PricingProbe) -> Finding {
     // LIST RATES said here on purpose: private/proxy/negotiated pricing
     // is not reflected (the override file is the roadmapped answer) —
     // silent wrong-cost is the honesty law's blind spot otherwise.
+    //
+    // #1179 · `p.rules` counts PRICE ROWS, not models. Calling them
+    // « models » put « 633 models » one command away from `nika
+    // catalog`'s « 69 models » — two inventories under one word, an
+    // order of magnitude apart, both on a first session. Every number
+    // NAMES its facet (RAMS-12 · A-06), and the facet here is the
+    // snapshot's rate table: several patterns can price one model, and
+    // a pattern can price models this catalog never lists.
     let identity = format!(
-        "{} models · {} providers · snapshot {} · {} · list rates (public catalog)",
+        "{} price rules · {} providers priced · snapshot {} · {} · list rates (public catalog)",
         p.rules, p.providers, p.as_of, p.sha
     );
     match p.age_days {
@@ -1070,6 +1078,8 @@ pub fn run(ping: bool, json: bool, verbose: bool, theme: Theme) -> VerbOutput {
     }
 }
 
+#[cfg(test)]
+mod pricing_tests;
 #[cfg(test)]
 mod tests;
 

--- a/crates/nika-cli-host/src/doctor/pricing_tests.rs
+++ b/crates/nika-cli-host/src/doctor/pricing_tests.rs
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The pricing-snapshot line — identity, staleness, and the facet its
+//! counts name.
+//!
+//! Descended from `doctor/tests.rs` at the 1500-line wall (the descent
+//! law: extraction, never exemption), on the commit that stopped the
+//! line calling price rows « models » (#1179). Same `super::*` reach,
+//! same fixtures — a sibling module, not a new contract.
+
+use super::*;
+
+fn pricing(age_days: Option<u32>) -> PricingProbe {
+    PricingProbe {
+        as_of: "2026-07-07".to_owned(),
+        sha: "d31a39603aa5419d".to_owned(),
+        rules: 606,
+        providers: 10,
+        age_days,
+    }
+}
+
+#[test]
+fn pricing_line_names_the_snapshot_identity() {
+    let f = pricing_finding(&pricing(Some(3)));
+    assert_eq!(f.level, Level::Ok);
+    // #1179 · the count NAMES its facet. `rules` are price rows, and
+    // calling them « models » set 633 beside `nika catalog`'s 69 under
+    // one word — two inventories, one session, an order of magnitude.
+    assert!(f.detail.contains("606 price rules"), "{}", f.detail);
+    assert!(
+        !f.detail.contains("models"),
+        "the pricing line counts price rows and priced providers — it \
+         must not speak the word `models` at all, or it lands beside \
+         `nika catalog`'s model count as one word for two inventories: {}",
+        f.detail
+    );
+    assert!(f.detail.contains("10 providers priced"), "{}", f.detail);
+    assert!(f.detail.contains("2026-07-07"), "{}", f.detail);
+    assert!(f.detail.contains("d31a39603aa5419d"), "{}", f.detail);
+    assert!(
+        f.detail.contains("list rates"),
+        "the public-catalog basis is named — private/proxy deals are \
+             not reflected and the line must say so: {}",
+        f.detail
+    );
+    assert!(f.fix.is_none());
+}
+
+#[test]
+fn stale_pricing_snapshot_warns_with_the_upgrade_fix() {
+    // The staleness gap no surveyed tool closes: past the threshold
+    // the line flips ⚠ and prints the exact remedy.
+    let f = pricing_finding(&pricing(Some(PRICING_STALE_DAYS + 1)));
+    assert_eq!(f.level, Level::Warn);
+    assert!(f.detail.contains("days old"), "{}", f.detail);
+    assert!(
+        f.fix.as_deref().is_some_and(|x| x.contains("upgrade nika")),
+        "{:?}",
+        f.fix
+    );
+    // AT the threshold stays green (stale means PAST it).
+    assert_eq!(
+        pricing_finding(&pricing(Some(PRICING_STALE_DAYS))).level,
+        Level::Ok
+    );
+    // An uncomputable age never guesses stale.
+    assert_eq!(pricing_finding(&pricing(None)).level, Level::Ok);
+}

--- a/crates/nika-cli-host/src/doctor/tests.rs
+++ b/crates/nika-cli-host/src/doctor/tests.rs
@@ -449,56 +449,6 @@ fn doctor_json_adds_host_receipts_without_touching_existing_fields() {
     );
 }
 
-// ── The pricing snapshot line (Cost Intelligence 2026-07-08) ──
-
-fn pricing(age_days: Option<u32>) -> PricingProbe {
-    PricingProbe {
-        as_of: "2026-07-07".to_owned(),
-        sha: "d31a39603aa5419d".to_owned(),
-        rules: 606,
-        providers: 10,
-        age_days,
-    }
-}
-
-#[test]
-fn pricing_line_names_the_snapshot_identity() {
-    let f = pricing_finding(&pricing(Some(3)));
-    assert_eq!(f.level, Level::Ok);
-    assert!(f.detail.contains("606 models"), "{}", f.detail);
-    assert!(f.detail.contains("10 providers"), "{}", f.detail);
-    assert!(f.detail.contains("2026-07-07"), "{}", f.detail);
-    assert!(f.detail.contains("d31a39603aa5419d"), "{}", f.detail);
-    assert!(
-        f.detail.contains("list rates"),
-        "the public-catalog basis is named — private/proxy deals are \
-             not reflected and the line must say so: {}",
-        f.detail
-    );
-    assert!(f.fix.is_none());
-}
-
-#[test]
-fn stale_pricing_snapshot_warns_with_the_upgrade_fix() {
-    // The staleness gap no surveyed tool closes: past the threshold
-    // the line flips ⚠ and prints the exact remedy.
-    let f = pricing_finding(&pricing(Some(PRICING_STALE_DAYS + 1)));
-    assert_eq!(f.level, Level::Warn);
-    assert!(f.detail.contains("days old"), "{}", f.detail);
-    assert!(
-        f.fix.as_deref().is_some_and(|x| x.contains("upgrade nika")),
-        "{:?}",
-        f.fix
-    );
-    // AT the threshold stays green (stale means PAST it).
-    assert_eq!(
-        pricing_finding(&pricing(Some(PRICING_STALE_DAYS))).level,
-        Level::Ok
-    );
-    // An uncomputable age never guesses stale.
-    assert_eq!(pricing_finding(&pricing(None)).level, Level::Ok);
-}
-
 /// Each severity prints a DISTINCT glyph — a `Default::default()` mutant
 /// (the null char `'\0'`) would erase the level cue the operator scans for.
 /// The sidecar row is a BUILD fact: present exactly when this binary

--- a/crates/nika-cli/src/verbs/catalog.rs
+++ b/crates/nika-cli/src/verbs/catalog.rs
@@ -59,21 +59,22 @@ fn local_loci(registry: &ProviderRegistry) -> Vec<LocalLocus> {
         .collect()
 }
 
-/// The catalog projection with the wiring fact ON every row (#1184).
+/// The catalog projection with the resolvability fact ON every row
+/// (#1184).
 ///
 /// `catalog_export()` alone claims nothing about what this build can
 /// reach; both surfaces below serialize to a reader who then CHOOSES a
-/// provider, so both chain the wire layer's own id list. The pin lives
-/// in `tests/catalog_family.rs` — a surface that drops the chain fails
-/// there rather than teaching an unreachable vendor.
-fn wired_export() -> CatalogExport {
-    catalog_export().with_wiring(&nika_providers::CANONICAL_IDS)
+/// provider, so both chain the adapter layer's own id list. The pin
+/// lives in `tests/catalog_family.rs` — a surface that drops the chain
+/// fails there rather than teaching an unreachable vendor.
+fn resolvable_export() -> CatalogExport {
+    catalog_export().with_resolvable(&nika_providers::CANONICAL_IDS)
 }
 
 /// `nika catalog` — human listing, or the `--json` machine projection.
 #[must_use]
 pub fn run(json: bool, theme: Theme) -> VerbOutput {
-    let export = wired_export();
+    let export = resolvable_export();
     if json {
         return match serde_json::to_string_pretty(&export) {
             Ok(payload) => VerbOutput::ok(payload),
@@ -94,26 +95,11 @@ pub fn run(json: bool, theme: Theme) -> VerbOutput {
 /// « take a key » for the doctor's cloud rows — three facets of one
 /// machine, never three contradictions. One derivation serves all three
 /// (`MachineTruth`), and `machine_truth_surfaces.rs` pins the renders.
-fn listing_header(
-    export: &CatalogExport,
-    theme: Theme,
-    truth: MachineTruth,
-    models: usize,
-) -> String {
-    // `truth.wired` counts the registry a RUN executes through, which
-    // excludes the `mock` test lane — while the rows below mark mock
-    // runnable (`check` resolves `mock/echo`, and says « 16 runnable »).
-    // Two true numbers one apart read as a contradiction unless the
-    // exception is NAMED. Derived from the rows, never typed.
-    let mock_lane = if export.providers.iter().any(|p| p.id == "mock" && p.wired) {
-        " (+ mock, the test lane)"
-    } else {
-        ""
-    };
+fn listing_header(theme: Theme, truth: MachineTruth, models: usize) -> String {
     let facets = theme.paint(
         Role::Dim,
         &format!(
-            "  {wired} wired in this build{mock_lane} · {slots} take a key — nika doctor shows their state",
+            "  {wired} wired in this build · {slots} take a key — nika doctor shows their state",
             wired = truth.wired,
             slots = truth.cloud_key_slots,
         ),
@@ -138,7 +124,7 @@ fn human_listing(
     let mut cloud: Vec<&ProviderExport> = export.providers.iter().filter(|p| !p.local).collect();
     cloud.sort_by(|a, b| cloud_rank(a.id).cmp(&cloud_rank(b.id)));
 
-    let mut out = listing_header(export, theme, truth, models);
+    let mut out = listing_header(theme, truth, models);
     out.push('\n');
     // « zero network » is EARNED: only when every local engine resolves
     // to loopback. One override off-loopback and the claim falls.
@@ -192,7 +178,7 @@ fn human_listing(
         out.push_str(&provider_line(p, theme, None));
     }
     out.push_str(
-        "\nnika catalog --json → the machine projection (models · capabilities · context windows · wired)",
+        "\nnika catalog --json → the machine projection (models · capabilities · context windows · resolves)",
     );
     out
 }
@@ -221,20 +207,21 @@ fn provider_line(p: &ProviderExport, theme: Theme, locus: Option<&LocalLocus>) -
     // file ON DISK first — the row names the prerequisite and its door,
     // never a bare « no key » that dead-ends at run.
     //
-    // The call to action is gated on `wired`: `native` has no wire in
-    // this build, so « nika model pull » invited a user through a door
-    // that refuses at check. An unreachable row never carries a verb.
+    // The call to action is gated on `resolves`: `native` does not
+    // resolve in this build, so « nika model pull » invited a user
+    // through a door that refuses at check. An unreachable row never
+    // carries a verb.
     let key = if p.requires_key {
         p.env_var
-    } else if p.id == "native" && p.wired {
+    } else if p.id == "native" && p.resolves {
         "no key · needs a local .gguf (nika model pull)"
     } else {
         "no key"
     };
-    let wire_note = if p.wired {
+    let resolve_note = if p.resolves {
         ""
     } else {
-        " · catalog only — no wire in this build"
+        " · catalog only — does not resolve in this build"
     };
     let locus_note = match locus {
         Some(l) if l.locus != ExecutionLocus::Loopback => format!(
@@ -253,7 +240,7 @@ fn provider_line(p: &ProviderExport, theme: Theme, locus: Option<&LocalLocus>) -
                 theme.paint(Role::Strong, &format!("{:<14}", p.id)),
                 theme.paint(
                     Role::Dim,
-                    &format!(" {:>2} models · {key}{wire_note}", p.models.len()),
+                    &format!(" {:>2} models · {key}{resolve_note}", p.models.len()),
                 ),
                 theme.paint(Role::Dim, &locus_note),
             ),
@@ -279,40 +266,40 @@ mod tests {
         let providers = value["providers"].as_array().expect("providers array");
         assert!(!providers.is_empty(), "the embedded catalog is never empty");
         let first = providers[0].as_object().expect("provider object");
-        for key in ["id", "env_var", "models", "local", "tags", "wired"] {
+        for key in ["id", "env_var", "models", "local", "tags", "resolves"] {
             assert!(first.contains_key(key), "provider entry missing `{key}`");
         }
     }
 
     /// #1184 · the machine surface must let a consumer recover the
     /// distinction the human header states. A payload where every row
-    /// reads `wired: false` is `catalog_export()` un-chained — the
+    /// reads `resolves: false` is `catalog_export()` un-chained — the
     /// exact drop this field exists to make impossible.
     #[test]
-    fn json_marks_the_wire_layer_row_by_row() {
+    fn json_marks_the_adapter_set_row_by_row() {
         let out = run(true, PLAIN);
         let value: serde_json::Value = serde_json::from_str(&out.text).expect("parseable JSON");
         let providers = value["providers"].as_array().expect("providers array");
-        let wired: Vec<&str> = providers
+        let resolving: Vec<&str> = providers
             .iter()
-            .filter(|p| p["wired"] == serde_json::Value::Bool(true))
+            .filter(|p| p["resolves"] == serde_json::Value::Bool(true))
             .filter_map(|p| p["id"].as_str())
             .collect();
         assert!(
-            !wired.is_empty(),
-            "a payload with zero wired rows is the un-chained projection",
+            !resolving.is_empty(),
+            "a payload with zero resolving rows is the un-chained projection",
         );
-        for id in &wired {
+        for id in &resolving {
             assert!(
                 nika_providers::CANONICAL_IDS.contains(id),
-                "`{id}` is marked wired but the wire layer does not seat it",
+                "`{id}` is marked resolving but no adapter carries it",
             );
         }
         for id in nika_providers::CANONICAL_IDS {
             if providers.iter().any(|p| p["id"] == id) {
                 assert!(
-                    wired.contains(&id),
-                    "`{id}` is seated by the wire layer but its row is unmarked",
+                    resolving.contains(&id),
+                    "`{id}` has an adapter but its row is unmarked",
                 );
             }
         }
@@ -322,51 +309,36 @@ mod tests {
     /// never carries a call to action (`native` invited « nika model
     /// pull » into a door that refuses at check).
     #[test]
-    fn an_unwired_row_says_so_and_offers_no_verb() {
+    fn a_non_resolving_row_says_so_and_offers_no_verb() {
         let text = run(false, PLAIN).text;
-        let export = wired_export();
-        for p in export.providers.iter().filter(|p| !p.wired) {
+        let export = resolvable_export();
+        for p in export.providers.iter().filter(|p| !p.resolves) {
             let row = text
                 .lines()
                 .find(|l| l.contains(&format!("\u{2502}  {:<14}", p.id)))
                 .unwrap_or_else(|| panic!("provider `{}` missing from the listing", p.id));
             assert!(
                 row.contains("catalog only"),
-                "unwired provider `{}` reads as runnable: {row}",
+                "non-resolving provider `{}` reads as runnable: {row}",
                 p.id,
             );
             assert!(
                 !row.contains("nika model pull"),
-                "unwired provider `{}` still invites a verb: {row}",
+                "non-resolving provider `{}` still invites a verb: {row}",
                 p.id,
             );
         }
-        for p in export.providers.iter().filter(|p| p.wired) {
+        for p in export.providers.iter().filter(|p| p.resolves) {
             let row = text
                 .lines()
                 .find(|l| l.contains(&format!("\u{2502}  {:<14}", p.id)))
                 .unwrap_or_else(|| panic!("provider `{}` missing from the listing", p.id));
             assert!(
                 !row.contains("catalog only"),
-                "wired provider `{}` reads as unreachable: {row}",
+                "resolving provider `{}` reads as unreachable: {row}",
                 p.id,
             );
         }
-    }
-
-    /// The header's 15 and the rows' 16 differ by exactly the test lane
-    /// — so the header NAMES it. Without this clause a reader who
-    /// counts unmarked rows finds a contradiction on one screen.
-    #[test]
-    fn the_header_names_the_test_lane_when_mock_is_wired() {
-        let export = wired_export();
-        let text = human_listing(&export, PLAIN, &loopback_loci(), distinct_truth(&export));
-        let mock_wired = export.providers.iter().any(|p| p.id == "mock" && p.wired);
-        assert!(mock_wired, "the wire layer seats the mock echo lane");
-        assert!(
-            text.contains("(+ mock, the test lane)"),
-            "the wired facet names the lane the run registry excludes:\n{text}",
-        );
     }
 
     #[test]
@@ -414,7 +386,7 @@ mod tests {
 
     #[test]
     fn human_listing_counts_agree_with_the_projection() {
-        let export = wired_export();
+        let export = resolvable_export();
         let truth = distinct_truth(&export);
         let text = human_listing(&export, PLAIN, &loopback_loci(), truth);
         let models: usize = export.providers.iter().map(|p| p.models.len()).sum();
@@ -451,7 +423,7 @@ mod tests {
 
     #[test]
     fn zero_network_is_earned_by_loopback_only() {
-        let export = wired_export();
+        let export = resolvable_export();
         // All locals on loopback → the sovereign claim holds.
         let text = human_listing(&export, PLAIN, &loopback_loci(), distinct_truth(&export));
         assert!(

--- a/crates/nika-cli/src/verbs/catalog.rs
+++ b/crates/nika-cli/src/verbs/catalog.rs
@@ -59,10 +59,21 @@ fn local_loci(registry: &ProviderRegistry) -> Vec<LocalLocus> {
         .collect()
 }
 
+/// The catalog projection with the wiring fact ON every row (#1184).
+///
+/// `catalog_export()` alone claims nothing about what this build can
+/// reach; both surfaces below serialize to a reader who then CHOOSES a
+/// provider, so both chain the wire layer's own id list. The pin lives
+/// in `tests/catalog_family.rs` — a surface that drops the chain fails
+/// there rather than teaching an unreachable vendor.
+fn wired_export() -> CatalogExport {
+    catalog_export().with_wiring(&nika_providers::CANONICAL_IDS)
+}
+
 /// `nika catalog` — human listing, or the `--json` machine projection.
 #[must_use]
 pub fn run(json: bool, theme: Theme) -> VerbOutput {
-    let export = catalog_export();
+    let export = wired_export();
     if json {
         return match serde_json::to_string_pretty(&export) {
             Ok(payload) => VerbOutput::ok(payload),
@@ -74,6 +85,43 @@ pub fn run(json: bool, theme: Theme) -> VerbOutput {
     let registry = ProviderRegistry::without_http(nika_runtime::compose::config_from_env());
     let truth = MachineTruth::from_registry(&registry);
     VerbOutput::ok(human_listing(&export, theme, &local_loci(&registry), truth))
+}
+
+/// The two header lines — the counts, each NAMING its facet.
+///
+/// Every number names what it counts (RAMS-12 · A-06): « catalog
+/// entries » here, « wired in this build » for what welcome counts,
+/// « take a key » for the doctor's cloud rows — three facets of one
+/// machine, never three contradictions. One derivation serves all three
+/// (`MachineTruth`), and `machine_truth_surfaces.rs` pins the renders.
+fn listing_header(
+    export: &CatalogExport,
+    theme: Theme,
+    truth: MachineTruth,
+    models: usize,
+) -> String {
+    // `truth.wired` counts the registry a RUN executes through, which
+    // excludes the `mock` test lane — while the rows below mark mock
+    // runnable (`check` resolves `mock/echo`, and says « 16 runnable »).
+    // Two true numbers one apart read as a contradiction unless the
+    // exception is NAMED. Derived from the rows, never typed.
+    let mock_lane = if export.providers.iter().any(|p| p.id == "mock" && p.wired) {
+        " (+ mock, the test lane)"
+    } else {
+        ""
+    };
+    let facets = theme.paint(
+        Role::Dim,
+        &format!(
+            "  {wired} wired in this build{mock_lane} · {slots} take a key — nika doctor shows their state",
+            wired = truth.wired,
+            slots = truth.cloud_key_slots,
+        ),
+    );
+    format!(
+        "nika catalog — {n} catalog entries · {models} models (embedded · offline)\n{facets}\n",
+        n = truth.catalog_entries,
+    )
 }
 
 /// The human teaching listing — sections LOCAL then CLOUD, doctrine order.
@@ -90,30 +138,7 @@ fn human_listing(
     let mut cloud: Vec<&ProviderExport> = export.providers.iter().filter(|p| !p.local).collect();
     cloud.sort_by(|a, b| cloud_rank(a.id).cmp(&cloud_rank(b.id)));
 
-    // Every number NAMES its facet (RAMS-12 · A-06): « catalog entries »
-    // here, « wired in this build » for what welcome counts, « take a
-    // key » for the doctor's cloud rows — three facets of one machine,
-    // never three contradictions. One derivation serves all three
-    // (`MachineTruth`), and machine_truth_surfaces.rs pins the renders.
-    let mut out = format!(
-        "nika catalog — {n} catalog entries · {models} models (embedded · offline)\n",
-        n = truth.catalog_entries,
-    );
-    {
-        use std::fmt::Write as _;
-        let _ = writeln!(
-            out,
-            "{}",
-            theme.paint(
-                Role::Dim,
-                &format!(
-                    "  {wired} wired in this build · {slots} take a key — nika doctor shows their state",
-                    wired = truth.wired,
-                    slots = truth.cloud_key_slots,
-                ),
-            ),
-        );
-    }
+    let mut out = listing_header(export, theme, truth, models);
     out.push('\n');
     // « zero network » is EARNED: only when every local engine resolves
     // to loopback. One override off-loopback and the claim falls.
@@ -167,7 +192,7 @@ fn human_listing(
         out.push_str(&provider_line(p, theme, None));
     }
     out.push_str(
-        "\nnika catalog --json → the machine projection (models · capabilities · context windows)",
+        "\nnika catalog --json → the machine projection (models · capabilities · context windows · wired)",
     );
     out
 }
@@ -186,18 +211,30 @@ fn cloud_rank(id: &str) -> (u8, &str) {
 
 /// One provider line of the human listing. A local engine whose
 /// EFFECTIVE endpoint sits off-loopback (an operator override) is NAMED
-/// with endpoint + locus — the ink the honest header saved (P0-20).
+/// with endpoint + locus — the ink the honest header saved (P0-20). A
+/// row this build has no wire for says so ON THE ROW (#1184): an
+/// aggregate in the header does not survive the scan a user actually
+/// performs, which is down the column of names.
 fn provider_line(p: &ProviderExport, theme: Theme, locus: Option<&LocalLocus>) -> String {
     // B-6b (the gauntlet's Marta): `native` sits under the « zero key ·
     // zero network » banner, but in-process GGUF inference needs the
     // file ON DISK first — the row names the prerequisite and its door,
     // never a bare « no key » that dead-ends at run.
+    //
+    // The call to action is gated on `wired`: `native` has no wire in
+    // this build, so « nika model pull » invited a user through a door
+    // that refuses at check. An unreachable row never carries a verb.
     let key = if p.requires_key {
         p.env_var
-    } else if p.id == "native" {
+    } else if p.id == "native" && p.wired {
         "no key · needs a local .gguf (nika model pull)"
     } else {
         "no key"
+    };
+    let wire_note = if p.wired {
+        ""
+    } else {
+        " · catalog only — no wire in this build"
     };
     let locus_note = match locus {
         Some(l) if l.locus != ExecutionLocus::Loopback => format!(
@@ -214,7 +251,10 @@ fn provider_line(p: &ProviderExport, theme: Theme, locus: Option<&LocalLocus>) -
             &format!(
                 " {}{}{}",
                 theme.paint(Role::Strong, &format!("{:<14}", p.id)),
-                theme.paint(Role::Dim, &format!(" {:>2} models · {key}", p.models.len())),
+                theme.paint(
+                    Role::Dim,
+                    &format!(" {:>2} models · {key}{wire_note}", p.models.len()),
+                ),
                 theme.paint(Role::Dim, &locus_note),
             ),
         )
@@ -239,9 +279,94 @@ mod tests {
         let providers = value["providers"].as_array().expect("providers array");
         assert!(!providers.is_empty(), "the embedded catalog is never empty");
         let first = providers[0].as_object().expect("provider object");
-        for key in ["id", "env_var", "models", "local", "tags"] {
+        for key in ["id", "env_var", "models", "local", "tags", "wired"] {
             assert!(first.contains_key(key), "provider entry missing `{key}`");
         }
+    }
+
+    /// #1184 · the machine surface must let a consumer recover the
+    /// distinction the human header states. A payload where every row
+    /// reads `wired: false` is `catalog_export()` un-chained — the
+    /// exact drop this field exists to make impossible.
+    #[test]
+    fn json_marks_the_wire_layer_row_by_row() {
+        let out = run(true, PLAIN);
+        let value: serde_json::Value = serde_json::from_str(&out.text).expect("parseable JSON");
+        let providers = value["providers"].as_array().expect("providers array");
+        let wired: Vec<&str> = providers
+            .iter()
+            .filter(|p| p["wired"] == serde_json::Value::Bool(true))
+            .filter_map(|p| p["id"].as_str())
+            .collect();
+        assert!(
+            !wired.is_empty(),
+            "a payload with zero wired rows is the un-chained projection",
+        );
+        for id in &wired {
+            assert!(
+                nika_providers::CANONICAL_IDS.contains(id),
+                "`{id}` is marked wired but the wire layer does not seat it",
+            );
+        }
+        for id in nika_providers::CANONICAL_IDS {
+            if providers.iter().any(|p| p["id"] == id) {
+                assert!(
+                    wired.contains(&id),
+                    "`{id}` is seated by the wire layer but its row is unmarked",
+                );
+            }
+        }
+    }
+
+    /// The row a user scans carries the fact — and an unreachable row
+    /// never carries a call to action (`native` invited « nika model
+    /// pull » into a door that refuses at check).
+    #[test]
+    fn an_unwired_row_says_so_and_offers_no_verb() {
+        let text = run(false, PLAIN).text;
+        let export = wired_export();
+        for p in export.providers.iter().filter(|p| !p.wired) {
+            let row = text
+                .lines()
+                .find(|l| l.contains(&format!("\u{2502}  {:<14}", p.id)))
+                .unwrap_or_else(|| panic!("provider `{}` missing from the listing", p.id));
+            assert!(
+                row.contains("catalog only"),
+                "unwired provider `{}` reads as runnable: {row}",
+                p.id,
+            );
+            assert!(
+                !row.contains("nika model pull"),
+                "unwired provider `{}` still invites a verb: {row}",
+                p.id,
+            );
+        }
+        for p in export.providers.iter().filter(|p| p.wired) {
+            let row = text
+                .lines()
+                .find(|l| l.contains(&format!("\u{2502}  {:<14}", p.id)))
+                .unwrap_or_else(|| panic!("provider `{}` missing from the listing", p.id));
+            assert!(
+                !row.contains("catalog only"),
+                "wired provider `{}` reads as unreachable: {row}",
+                p.id,
+            );
+        }
+    }
+
+    /// The header's 15 and the rows' 16 differ by exactly the test lane
+    /// — so the header NAMES it. Without this clause a reader who
+    /// counts unmarked rows finds a contradiction on one screen.
+    #[test]
+    fn the_header_names_the_test_lane_when_mock_is_wired() {
+        let export = wired_export();
+        let text = human_listing(&export, PLAIN, &loopback_loci(), distinct_truth(&export));
+        let mock_wired = export.providers.iter().any(|p| p.id == "mock" && p.wired);
+        assert!(mock_wired, "the wire layer seats the mock echo lane");
+        assert!(
+            text.contains("(+ mock, the test lane)"),
+            "the wired facet names the lane the run registry excludes:\n{text}",
+        );
     }
 
     #[test]
@@ -289,7 +414,7 @@ mod tests {
 
     #[test]
     fn human_listing_counts_agree_with_the_projection() {
-        let export = catalog_export();
+        let export = wired_export();
         let truth = distinct_truth(&export);
         let text = human_listing(&export, PLAIN, &loopback_loci(), truth);
         let models: usize = export.providers.iter().map(|p| p.models.len()).sum();
@@ -326,7 +451,7 @@ mod tests {
 
     #[test]
     fn zero_network_is_earned_by_loopback_only() {
-        let export = catalog_export();
+        let export = wired_export();
         // All locals on loopback → the sovereign claim holds.
         let text = human_listing(&export, PLAIN, &loopback_loci(), distinct_truth(&export));
         assert!(

--- a/crates/nika-cli/tests/catalog_family.rs
+++ b/crates/nika-cli/tests/catalog_family.rs
@@ -25,6 +25,13 @@
 //! pass · the shipped `--json` mark · the shipped human row · the MODELS
 //! verdict. A row can no longer be marked runnable and refused, or refused
 //! and rendered inviting.
+//!
+//! The per-row field is `resolves`, deliberately NOT « wired »: that word
+//! already names the run registry (15, `mock` excluded) in the header one
+//! line above, while this set is the 16 the MODELS rung calls runnable. One
+//! word for two sets is the A-06 confusion `machine_truth.rs` exists to
+//! cure, and `the_two_provider_words_name_two_different_sets` below is the
+//! guard that keeps them apart.
 
 use std::io::{BufRead as _, Write as _};
 
@@ -160,13 +167,13 @@ fn every_cataloged_provider_either_seats_or_is_refused_by_name() {
             .find(|r| r["id"] == p.id)
             .unwrap_or_else(|| panic!("`{}` is missing from the shipped payload", p.id));
         assert_eq!(
-            row["wired"],
+            row["resolves"],
             serde_json::Value::Bool(resolves),
-            "`{}` renders wired={} on --json while check says resolves={resolves}. \
+            "`{}` renders resolves={} on --json while check says resolves={resolves}. \
              A machine consumer told to pick from this list would pick a seat that \
              cannot run.",
             p.id,
-            row["wired"],
+            row["resolves"],
         );
 
         // #1184 · and the human column a user actually scans.
@@ -295,7 +302,7 @@ fn the_mcp_catalog_tool_marks_every_row_and_teaches_the_filter() {
         .expect("nika_catalog is advertised over the wire");
     let description = entry["description"].as_str().expect("a description");
     assert!(
-        description.contains("`wired`") && description.contains("wired` is true"),
+        description.contains("`resolves`") && description.contains("resolves` is true"),
         "the advertised description must tell an agent WHICH way to filter: {description}",
     );
 
@@ -315,13 +322,13 @@ fn the_mcp_catalog_tool_marks_every_row_and_teaches_the_filter() {
     let mut marked = 0usize;
     for row in rows {
         let id = row["id"].as_str().expect("every row has an id");
-        let mark = row["wired"]
+        let mark = row["resolves"]
             .as_bool()
-            .unwrap_or_else(|| panic!("`{id}` carries no `wired` field over MCP: {row}"));
+            .unwrap_or_else(|| panic!("`{id}` carries no `resolves` field over MCP: {row}"));
         assert_eq!(
             mark,
             wire.contains(id),
-            "`{id}` is advertised to agents as wired={mark} while the wire layer says {}",
+            "`{id}` is advertised to agents as resolves={mark} while the adapter set says {}",
             wire.contains(id),
         );
         if mark {
@@ -333,6 +340,63 @@ fn the_mcp_catalog_tool_marks_every_row_and_teaches_the_filter() {
         "both sides of the split reach the agent ({marked} of {} marked) — a payload \
          where every row lands on one side is not measuring",
         rows.len(),
+    );
+}
+
+/// The two provider words on one screen must name two different sets,
+/// and must not be the same word (#1184 · the A-06 recurrence guard).
+///
+/// The header's « wired » is the run registry — 15, `mock` excluded.
+/// The rows' `resolves` is what the MODELS rung will accept — 16. Both
+/// are true; a single word for both is the confusion
+/// `nika-cli-host/src/machine_truth.rs` was written to cure, and a
+/// previous attempt at this field was backed out for exactly that.
+///
+/// This is the guard that makes the mistake mechanical rather than a
+/// matter of remembering: rename either concept onto the other's word
+/// and this goes red.
+#[test]
+fn the_two_provider_words_name_two_different_sets() {
+    let json = shipped_json();
+    let human = catalog::run(false, PLAIN).text;
+
+    let resolving = json["providers"]
+        .as_array()
+        .expect("providers array")
+        .iter()
+        .filter(|r| r["resolves"] == serde_json::Value::Bool(true))
+        .count();
+    assert_eq!(
+        resolving,
+        nika_providers::CANONICAL_IDS.len(),
+        "the row word counts the adapter set",
+    );
+
+    let header = human
+        .lines()
+        .find(|l| l.contains("wired in this build"))
+        .expect("the header names its own facet");
+    let header_count: usize = header
+        .chars()
+        .skip_while(|c| !c.is_ascii_digit())
+        .take_while(char::is_ascii_digit)
+        .collect::<String>()
+        .parse()
+        .expect("the header carries a count");
+
+    assert_ne!(
+        header_count, resolving,
+        "the two facets happen to be equal — this test can no longer tell \
+         a real separation from a collapsed one. Re-derive it against \
+         machine_truth.rs before touching either word. Header: {header}",
+    );
+    assert!(
+        !json["providers"][0]
+            .as_object()
+            .expect("provider object")
+            .contains_key("wired"),
+        "the row field must not be spelled `wired` — that word is taken, \
+         one line above, by a set of a different size",
     );
 }
 

--- a/crates/nika-cli/tests/catalog_family.rs
+++ b/crates/nika-cli/tests/catalog_family.rs
@@ -16,9 +16,20 @@
 //!
 //! Every seat is judged the way a user meets it — through `check`'s MODELS
 //! rung, on a real workflow, before a token is spent.
+//!
+//! #1184 widened the traversal from « the wire agrees with the catalog » to
+//! « and every surface a chooser reads SAYS SO ». The refusal rung was
+//! already honest; what was missing is that the three projections rendered a
+//! reachable and an unreachable vendor identically, so the fact only arrived
+//! after the choice was made. The loop below now judges, per row and in one
+//! pass · the shipped `--json` mark · the shipped human row · the MODELS
+//! verdict. A row can no longer be marked runnable and refused, or refused
+//! and rendered inviting.
+
+use std::io::{BufRead as _, Write as _};
 
 use nika_cli::Theme;
-use nika_cli::verbs::{check, exit};
+use nika_cli::verbs::{catalog, check, exit};
 
 const PLAIN: Theme = Theme::new(false, false, false);
 
@@ -108,11 +119,25 @@ fn seat_resolves(seat: &str, slug: &str) -> bool {
         .unwrap_or_else(|| panic!("models_resolve is a bool for {seat}: {payload:#}"))
 }
 
+/// The catalog projection as the binary EMITS it (`nika catalog --json`),
+/// not as a builder would rebuild it. A test that re-derives the payload
+/// cannot see a surface that dropped the wiring chain — which is the whole
+/// defect class here.
+fn shipped_json() -> serde_json::Value {
+    let out = catalog::run(true, PLAIN);
+    assert_eq!(out.code, exit::OK, "`nika catalog --json` runs");
+    serde_json::from_str(&out.text).expect("the shipped payload is JSON")
+}
+
 #[test]
 fn every_cataloged_provider_either_seats_or_is_refused_by_name() {
     let export = nika_catalog::export::catalog_export();
     let wired: std::collections::BTreeSet<&str> =
         nika_providers::CANONICAL_IDS.into_iter().collect();
+
+    // The two SHIPPED projections, rendered once and read per row below.
+    let json = shipped_json();
+    let human = catalog::run(false, PLAIN).text;
 
     let mut seats = 0usize;
     let mut refused: Vec<&str> = Vec::new();
@@ -126,6 +151,38 @@ fn every_cataloged_provider_either_seats_or_is_refused_by_name() {
              and the adapter disagree — one of them is the lie.",
             wired.contains(p.id)
         );
+
+        // #1184 · the machine projection carries the verdict, per row.
+        let row = json["providers"]
+            .as_array()
+            .expect("providers array")
+            .iter()
+            .find(|r| r["id"] == p.id)
+            .unwrap_or_else(|| panic!("`{}` is missing from the shipped payload", p.id));
+        assert_eq!(
+            row["wired"],
+            serde_json::Value::Bool(resolves),
+            "`{}` renders wired={} on --json while check says resolves={resolves}. \
+             A machine consumer told to pick from this list would pick a seat that \
+             cannot run.",
+            p.id,
+            row["wired"],
+        );
+
+        // #1184 · and the human column a user actually scans.
+        let line = human
+            .lines()
+            .find(|l| l.contains(&format!("\u{2502}  {:<14}", p.id)))
+            .unwrap_or_else(|| panic!("`{}` is missing from the human listing", p.id));
+        assert_eq!(
+            !line.contains("catalog only"),
+            resolves,
+            "`{}` reads runnable={} down the column while check says resolves={resolves}. \
+             Row: {line}",
+            p.id,
+            !line.contains("catalog only"),
+        );
+
         if resolves {
             seats += 1;
         } else {
@@ -188,6 +245,94 @@ fn the_refusal_names_the_runnable_count_and_where_to_get_the_list() {
         out.text.contains("nika doctor"),
         "and points at the surface that NAMES them: {}",
         out.text
+    );
+}
+
+/// One JSON-RPC round trip against the REAL `nika mcp` stdio server.
+///
+/// The third projection is the one an AGENT reads, and the only honest way
+/// to judge it is to call the tool the way a client does — reading the code
+/// that serves it proves the code, not the wire.
+fn mcp_roundtrip(request: &serde_json::Value) -> serde_json::Value {
+    // Same carve-out as lsp_transport.rs: driving the shipped binary IS the
+    // contract under test.
+    #[allow(clippy::disallowed_types)]
+    let mut child = std::process::Command::new(env!("CARGO_BIN_EXE_nika-cli"))
+        .arg("mcp")
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .expect("spawn nika mcp");
+    {
+        let mut stdin = child.stdin.take().expect("stdin");
+        writeln!(stdin, "{request}").expect("write request");
+    }
+    let stdout = child.stdout.take().expect("stdout");
+    let line = std::io::BufReader::new(stdout)
+        .lines()
+        .next()
+        .expect("the server answers")
+        .expect("a utf8 reply");
+    let _ = child.wait();
+    serde_json::from_str(&line).expect("the reply is JSON-RPC")
+}
+
+#[test]
+fn the_mcp_catalog_tool_marks_every_row_and_teaches_the_filter() {
+    // The tool description is the instruction an agent OBEYS. « Pick REAL
+    // model ids from here » over an unmarked list is an instruction to
+    // author a workflow that cannot run — 22 of 38 rows, at the time this
+    // was measured.
+    let listed = mcp_roundtrip(&serde_json::json!({
+        "jsonrpc": "2.0", "id": 1, "method": "tools/list"
+    }));
+    let entry = listed["result"]["tools"]
+        .as_array()
+        .expect("tools array")
+        .iter()
+        .find(|t| t["name"] == "nika_catalog")
+        .expect("nika_catalog is advertised over the wire");
+    let description = entry["description"].as_str().expect("a description");
+    assert!(
+        description.contains("`wired`") && description.contains("wired` is true"),
+        "the advertised description must tell an agent WHICH way to filter: {description}",
+    );
+
+    let called = mcp_roundtrip(&serde_json::json!({
+        "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+        "params": { "name": "nika_catalog", "arguments": {} }
+    }));
+    let payload = called["result"]["content"][0]["text"]
+        .as_str()
+        .expect("the tool returns text content");
+    let value: serde_json::Value =
+        serde_json::from_str(payload).expect("the tool's payload is the catalog JSON");
+    let rows = value["providers"].as_array().expect("providers array");
+
+    let wire: std::collections::BTreeSet<&str> =
+        nika_providers::CANONICAL_IDS.into_iter().collect();
+    let mut marked = 0usize;
+    for row in rows {
+        let id = row["id"].as_str().expect("every row has an id");
+        let mark = row["wired"]
+            .as_bool()
+            .unwrap_or_else(|| panic!("`{id}` carries no `wired` field over MCP: {row}"));
+        assert_eq!(
+            mark,
+            wire.contains(id),
+            "`{id}` is advertised to agents as wired={mark} while the wire layer says {}",
+            wire.contains(id),
+        );
+        if mark {
+            marked += 1;
+        }
+    }
+    assert!(
+        marked > 0 && marked < rows.len(),
+        "both sides of the split reach the agent ({marked} of {} marked) — a payload \
+         where every row lands on one side is not measuring",
+        rows.len(),
     );
 }
 

--- a/crates/nika-mcp/src/tools.rs
+++ b/crates/nika-mcp/src/tools.rs
@@ -202,8 +202,8 @@ fn learn_tools() -> Value {
                             windows, and API-key env-var NAMES (values never read). \
                             Versioned wire `catalog_version: 1`. Pick REAL model ids \
                             from here instead of guessing — and pick them ONLY from \
-                            rows where `wired` is true. A cataloged vendor is not a \
-                            runnable one: `wired: false` means this binary has no \
+                            rows where `resolves` is true. A cataloged vendor is not a \
+                            runnable one: `resolves: false` means this binary has no \
                             adapter for it and `nika check` refuses the model at the \
                             MODELS rung.",
             "inputSchema": { "type": "object", "properties": {} }
@@ -690,15 +690,16 @@ fn inspect(args: &Value) -> Result<String, String> {
 }
 
 /// `nika_catalog` — the versioned provider/model projection, with the
-/// wiring fact ON every row (#1184).
+/// resolvability fact ON every row (#1184).
 ///
 /// This tool's whole purpose is to stop an agent guessing model ids, so
 /// it is the surface where an unmarked unreachable vendor costs the
 /// most: the reader is a machine that acts, not a human who shrugs. The
-/// chain over `CANONICAL_IDS` is what makes `wired` true anywhere — drop
-/// it and every row reads `false`.
+/// chain over `CANONICAL_IDS` is what makes `resolves` true anywhere —
+/// drop it and every row reads `false`.
 fn catalog_payload() -> Result<String, String> {
-    let export = nika_catalog::export::catalog_export().with_wiring(&nika_providers::CANONICAL_IDS);
+    let export =
+        nika_catalog::export::catalog_export().with_resolvable(&nika_providers::CANONICAL_IDS);
     serde_json::to_string_pretty(&export).map_err(|e| format!("catalog projection failed: {e}"))
 }
 
@@ -899,7 +900,7 @@ mod tests {
     /// from here » over a list where a fifth of the rows cannot be
     /// reached is an instruction to author a workflow that will not run.
     #[test]
-    fn the_catalog_tool_tells_an_agent_to_filter_on_wired() {
+    fn the_catalog_tool_tells_an_agent_to_filter_on_resolves() {
         let c = catalog();
         let entry = c
             .as_array()
@@ -909,11 +910,11 @@ mod tests {
             .expect("nika_catalog is advertised");
         let text = entry["description"].as_str().expect("a description");
         assert!(
-            text.contains("`wired`"),
+            text.contains("`resolves`"),
             "the description must name the field it wants filtered: {text}",
         );
         assert!(
-            text.contains("wired` is true"),
+            text.contains("resolves` is true"),
             "the description must state the DIRECTION of the filter: {text}",
         );
     }
@@ -922,33 +923,33 @@ mod tests {
     /// they come from nowhere — a projection where every row reads
     /// `false` is `catalog_export()` with the chain dropped.
     #[test]
-    fn the_catalog_payload_marks_what_this_binary_can_seat() {
+    fn the_catalog_payload_marks_what_this_binary_can_resolve() {
         let out = execute("nika_catalog", &json!({})).expect("nika_catalog runs");
         let value: Value = serde_json::from_str(&out).expect("nika_catalog emits JSON");
         let providers = value["providers"].as_array().expect("providers");
-        let wired: Vec<&str> = providers
+        let resolving: Vec<&str> = providers
             .iter()
-            .filter(|p| p["wired"] == Value::Bool(true))
+            .filter(|p| p["resolves"] == Value::Bool(true))
             .filter_map(|p| p["id"].as_str())
             .collect();
         assert!(
-            !wired.is_empty(),
-            "zero wired rows means the wiring chain was dropped",
+            !resolving.is_empty(),
+            "zero resolving rows means the chain was dropped",
         );
         assert!(
-            wired.len() < providers.len(),
+            resolving.len() < providers.len(),
             "this build seats fewer vendors than the catalog carries — \
              a payload marking every row runnable is not measuring",
         );
-        for id in &wired {
+        for id in &resolving {
             assert!(
                 nika_providers::CANONICAL_IDS.contains(id),
-                "`{id}` is marked wired but no adapter seats it",
+                "`{id}` is marked resolving but no adapter carries it",
             );
         }
         for id in nika_providers::CANONICAL_IDS {
             if providers.iter().any(|p| p["id"] == id) {
-                assert!(wired.contains(&id), "`{id}` is seated but unmarked");
+                assert!(resolving.contains(&id), "`{id}` resolves but is unmarked");
             }
         }
     }

--- a/crates/nika-mcp/src/tools.rs
+++ b/crates/nika-mcp/src/tools.rs
@@ -201,7 +201,11 @@ fn learn_tools() -> Value {
                             capabilities (vision · reasoning · json_mode), context \
                             windows, and API-key env-var NAMES (values never read). \
                             Versioned wire `catalog_version: 1`. Pick REAL model ids \
-                            from here instead of guessing.",
+                            from here instead of guessing — and pick them ONLY from \
+                            rows where `wired` is true. A cataloged vendor is not a \
+                            runnable one: `wired: false` means this binary has no \
+                            adapter for it and `nika check` refuses the model at the \
+                            MODELS rung.",
             "inputSchema": { "type": "object", "properties": {} }
         },
         {
@@ -685,9 +689,17 @@ fn inspect(args: &Value) -> Result<String, String> {
     }
 }
 
+/// `nika_catalog` — the versioned provider/model projection, with the
+/// wiring fact ON every row (#1184).
+///
+/// This tool's whole purpose is to stop an agent guessing model ids, so
+/// it is the surface where an unmarked unreachable vendor costs the
+/// most: the reader is a machine that acts, not a human who shrugs. The
+/// chain over `CANONICAL_IDS` is what makes `wired` true anywhere — drop
+/// it and every row reads `false`.
 fn catalog_payload() -> Result<String, String> {
-    serde_json::to_string_pretty(&nika_catalog::export::catalog_export())
-        .map_err(|e| format!("catalog projection failed: {e}"))
+    let export = nika_catalog::export::catalog_export().with_wiring(&nika_providers::CANONICAL_IDS);
+    serde_json::to_string_pretty(&export).map_err(|e| format!("catalog projection failed: {e}"))
 }
 
 /// `nika_tools` — the versioned builtin-tool projection: the SAME payload
@@ -879,6 +891,65 @@ mod tests {
         // Each tool carries a JSON-Schema inputSchema (the client validates args).
         for t in c.as_array().expect("array") {
             assert_eq!(t["inputSchema"]["type"], "object");
+        }
+    }
+
+    /// #1184 · the tool an agent OBEYS must teach the filter, not just
+    /// carry the field. A description that says « pick REAL model ids
+    /// from here » over a list where a fifth of the rows cannot be
+    /// reached is an instruction to author a workflow that will not run.
+    #[test]
+    fn the_catalog_tool_tells_an_agent_to_filter_on_wired() {
+        let c = catalog();
+        let entry = c
+            .as_array()
+            .expect("array")
+            .iter()
+            .find(|t| t["name"] == "nika_catalog")
+            .expect("nika_catalog is advertised");
+        let text = entry["description"].as_str().expect("a description");
+        assert!(
+            text.contains("`wired`"),
+            "the description must name the field it wants filtered: {text}",
+        );
+        assert!(
+            text.contains("wired` is true"),
+            "the description must state the DIRECTION of the filter: {text}",
+        );
+    }
+
+    /// #1184 · the payload itself. Marks come from the wire layer or
+    /// they come from nowhere — a projection where every row reads
+    /// `false` is `catalog_export()` with the chain dropped.
+    #[test]
+    fn the_catalog_payload_marks_what_this_binary_can_seat() {
+        let out = execute("nika_catalog", &json!({})).expect("nika_catalog runs");
+        let value: Value = serde_json::from_str(&out).expect("nika_catalog emits JSON");
+        let providers = value["providers"].as_array().expect("providers");
+        let wired: Vec<&str> = providers
+            .iter()
+            .filter(|p| p["wired"] == Value::Bool(true))
+            .filter_map(|p| p["id"].as_str())
+            .collect();
+        assert!(
+            !wired.is_empty(),
+            "zero wired rows means the wiring chain was dropped",
+        );
+        assert!(
+            wired.len() < providers.len(),
+            "this build seats fewer vendors than the catalog carries — \
+             a payload marking every row runnable is not measuring",
+        );
+        for id in &wired {
+            assert!(
+                nika_providers::CANONICAL_IDS.contains(id),
+                "`{id}` is marked wired but no adapter seats it",
+            );
+        }
+        for id in nika_providers::CANONICAL_IDS {
+            if providers.iter().any(|p| p["id"] == id) {
+                assert!(wired.contains(&id), "`{id}` is seated but unmarked");
+            }
         }
     }
 

--- a/wiring.yaml
+++ b/wiring.yaml
@@ -65,6 +65,248 @@ capabilities:
     shipped_when: "--features access-harness"
     reachable_by: "nika run F --access claude-agent-acp"
     proven_by: acp-quarantine
+  # ── The 38 cataloged providers (#1184) ────────────────────────────────
+  # The catalog is DATA and the wire is CODE, and they are deliberately
+  # different sizes: 38 vendor rows, 16 of which this build can seat. What
+  # was missing is not the adapters — it is that no surface MARKED which,
+  # including the MCP tool whose whole job is telling an agent what to
+  # pick. Each row below is DECLARED at a file:line, states whether it
+  # ships, states how (or whether) a user reaches it, and names ONE job as
+  # its judge: `rust` runs `scripts/ci/check-tests.sh`, whose
+  # `catalog_family.rs` traversal walks all 38 in a single pass and, per
+  # row, holds the `--json` mark, the human column and the MODELS verdict
+  # to the same answer. An `unreachable by design` row is not a gap — a
+  # cataloged vendor legitimately serves pricing and capability lookups.
+  # What is not legitimate is the set moving without anyone deciding, and
+  # the traversal's UNWIRED list is where that decision is recorded.
+  - id: provider.ai21
+    kind: provider
+    declared_at: crates/nika-catalog/data/llm-providers.toml:382
+    shipped_when: "never — catalog data only, no WireFormat seats it"
+    reachable_by: "unreachable by design · nika check refuses at the MODELS rung"
+    proven_by: rust
+  - id: provider.anthropic
+    kind: provider
+    declared_at: crates/nika-catalog/data/llm-providers.toml:23
+    shipped_when: "default build (nika-providers::profile seats it)"
+    reachable_by: "model: anthropic/<id> in a workflow · nika run"
+    proven_by: rust
+  - id: provider.azure
+    kind: provider
+    declared_at: crates/nika-catalog/data/llm-providers.toml:430
+    shipped_when: "never — catalog data only, no WireFormat seats it"
+    reachable_by: "unreachable by design · nika check refuses at the MODELS rung"
+    proven_by: rust
+  - id: provider.bedrock
+    kind: provider
+    declared_at: crates/nika-catalog/data/llm-providers.toml:406
+    shipped_when: "never — catalog data only, no WireFormat seats it"
+    reachable_by: "unreachable by design · nika check refuses at the MODELS rung"
+    proven_by: rust
+  - id: provider.cerebras
+    kind: provider
+    declared_at: crates/nika-catalog/data/llm-providers.toml:309
+    shipped_when: "never — catalog data only, no WireFormat seats it"
+    reachable_by: "unreachable by design · nika check refuses at the MODELS rung"
+    proven_by: rust
+  - id: provider.cloudflare
+    kind: provider
+    declared_at: crates/nika-catalog/data/llm-providers.toml:775
+    shipped_when: "never — catalog data only, no WireFormat seats it"
+    reachable_by: "unreachable by design · nika check refuses at the MODELS rung"
+    proven_by: rust
+  - id: provider.cohere
+    kind: provider
+    declared_at: crates/nika-catalog/data/llm-providers.toml:358
+    shipped_when: "never — catalog data only, no WireFormat seats it"
+    reachable_by: "unreachable by design · nika check refuses at the MODELS rung"
+    proven_by: rust
+  - id: provider.databricks
+    kind: provider
+    declared_at: crates/nika-catalog/data/llm-providers.toml:757
+    shipped_when: "never — catalog data only, no WireFormat seats it"
+    reachable_by: "unreachable by design · nika check refuses at the MODELS rung"
+    proven_by: rust
+  - id: provider.deepinfra
+    kind: provider
+    declared_at: crates/nika-catalog/data/llm-providers.toml:673
+    shipped_when: "never — catalog data only, no WireFormat seats it"
+    reachable_by: "unreachable by design · nika check refuses at the MODELS rung"
+    proven_by: rust
+  - id: provider.deepseek
+    kind: provider
+    declared_at: crates/nika-catalog/data/llm-providers.toml:133
+    shipped_when: "default build (nika-providers::profile seats it)"
+    reachable_by: "model: deepseek/<id> in a workflow · nika run"
+    proven_by: rust
+  - id: provider.fireworks
+    kind: provider
+    declared_at: crates/nika-catalog/data/llm-providers.toml:284
+    shipped_when: "never — catalog data only, no WireFormat seats it"
+    reachable_by: "unreachable by design · nika check refuses at the MODELS rung"
+    proven_by: rust
+  - id: provider.gemini
+    kind: provider
+    declared_at: crates/nika-catalog/data/llm-providers.toml:154
+    shipped_when: "default build (nika-providers::profile seats it)"
+    reachable_by: "model: gemini/<id> in a workflow · nika run"
+    proven_by: rust
+  - id: provider.groq
+    kind: provider
+    declared_at: crates/nika-catalog/data/llm-providers.toml:106
+    shipped_when: "default build (nika-providers::profile seats it)"
+    reachable_by: "model: groq/<id> in a workflow · nika run"
+    proven_by: rust
+  - id: provider.huggingface
+    kind: provider
+    declared_at: crates/nika-catalog/data/llm-providers.toml:206
+    shipped_when: "default build (nika-providers::profile seats it)"
+    reachable_by: "model: huggingface/<id> in a workflow · nika run"
+    proven_by: rust
+  - id: provider.hyperbolic
+    kind: provider
+    declared_at: crates/nika-catalog/data/llm-providers.toml:721
+    shipped_when: "never — catalog data only, no WireFormat seats it"
+    reachable_by: "unreachable by design · nika check refuses at the MODELS rung"
+    proven_by: rust
+  - id: provider.llamacpp
+    kind: provider
+    declared_at: crates/nika-catalog/data/llm-providers.toml:853
+    shipped_when: "default build (nika-providers::profile seats it)"
+    reachable_by: "model: llamacpp/<id> in a workflow · nika run"
+    proven_by: rust
+  - id: provider.lmstudio
+    kind: provider
+    declared_at: crates/nika-catalog/data/llm-providers.toml:833
+    shipped_when: "default build (nika-providers::profile seats it)"
+    reachable_by: "model: lmstudio/<id> in a workflow · nika run"
+    proven_by: rust
+  - id: provider.localai
+    kind: provider
+    declared_at: crates/nika-catalog/data/llm-providers.toml:873
+    shipped_when: "default build (nika-providers::profile seats it)"
+    reachable_by: "model: localai/<id> in a workflow · nika run"
+    proven_by: rust
+  - id: provider.minimax
+    kind: provider
+    declared_at: crates/nika-catalog/data/llm-providers.toml:590
+    shipped_when: "never — catalog data only, no WireFormat seats it"
+    reachable_by: "unreachable by design · nika check refuses at the MODELS rung"
+    proven_by: rust
+  - id: provider.mistral
+    kind: provider
+    declared_at: crates/nika-catalog/data/llm-providers.toml:80
+    shipped_when: "default build (nika-providers::profile seats it)"
+    reachable_by: "model: mistral/<id> in a workflow · nika run"
+    proven_by: rust
+  - id: provider.mock
+    kind: provider
+    declared_at: crates/nika-catalog/data/llm-providers.toml:933
+    shipped_when: "default build (nika-providers::profile seats it)"
+    reachable_by: "model: mock/<id> in a workflow · nika run"
+    proven_by: rust
+  - id: provider.moonshot
+    kind: provider
+    declared_at: crates/nika-catalog/data/llm-providers.toml:532
+    shipped_when: "never — catalog data only, no WireFormat seats it"
+    reachable_by: "unreachable by design · nika check refuses at the MODELS rung"
+    proven_by: rust
+  - id: provider.native
+    kind: provider
+    declared_at: crates/nika-catalog/data/llm-providers.toml:913
+    shipped_when: "never — catalog data only, no WireFormat seats it"
+    reachable_by: "unreachable by design · nika check refuses at the MODELS rung"
+    proven_by: rust
+  - id: provider.nvidia
+    kind: provider
+    declared_at: crates/nika-catalog/data/llm-providers.toml:640
+    shipped_when: "default build (nika-providers::profile seats it)"
+    reachable_by: "model: nvidia/<id> in a workflow · nika run"
+    proven_by: rust
+  - id: provider.ollama
+    kind: provider
+    declared_at: crates/nika-catalog/data/llm-providers.toml:807
+    shipped_when: "default build (nika-providers::profile seats it)"
+    reachable_by: "model: ollama/<id> in a workflow · nika run"
+    proven_by: rust
+  - id: provider.openai
+    kind: provider
+    declared_at: crates/nika-catalog/data/llm-providers.toml:50
+    shipped_when: "default build (nika-providers::profile seats it)"
+    reachable_by: "model: openai/<id> in a workflow · nika run"
+    proven_by: rust
+  - id: provider.openrouter
+    kind: provider
+    declared_at: crates/nika-catalog/data/llm-providers.toml:233
+    shipped_when: "default build (nika-providers::profile seats it)"
+    reachable_by: "model: openrouter/<id> in a workflow · nika run"
+    proven_by: rust
+  - id: provider.perplexity
+    kind: provider
+    declared_at: crates/nika-catalog/data/llm-providers.toml:478
+    shipped_when: "never — catalog data only, no WireFormat seats it"
+    reachable_by: "unreachable by design · nika check refuses at the MODELS rung"
+    proven_by: rust
+  - id: provider.qwen
+    kind: provider
+    declared_at: crates/nika-catalog/data/llm-providers.toml:559
+    shipped_when: "never — catalog data only, no WireFormat seats it"
+    reachable_by: "unreachable by design · nika check refuses at the MODELS rung"
+    proven_by: rust
+  - id: provider.replicate
+    kind: provider
+    declared_at: crates/nika-catalog/data/llm-providers.toml:697
+    shipped_when: "never — catalog data only, no WireFormat seats it"
+    reachable_by: "unreachable by design · nika check refuses at the MODELS rung"
+    proven_by: rust
+  - id: provider.sambanova
+    kind: provider
+    declared_at: crates/nika-catalog/data/llm-providers.toml:334
+    shipped_when: "never — catalog data only, no WireFormat seats it"
+    reachable_by: "unreachable by design · nika check refuses at the MODELS rung"
+    proven_by: rust
+  - id: provider.together
+    kind: provider
+    declared_at: crates/nika-catalog/data/llm-providers.toml:260
+    shipped_when: "never — catalog data only, no WireFormat seats it"
+    reachable_by: "unreachable by design · nika check refuses at the MODELS rung"
+    proven_by: rust
+  - id: provider.vertex
+    kind: provider
+    declared_at: crates/nika-catalog/data/llm-providers.toml:454
+    shipped_when: "never — catalog data only, no WireFormat seats it"
+    reachable_by: "unreachable by design · nika check refuses at the MODELS rung"
+    proven_by: rust
+  - id: provider.vllm
+    kind: provider
+    declared_at: crates/nika-catalog/data/llm-providers.toml:893
+    shipped_when: "default build (nika-providers::profile seats it)"
+    reachable_by: "model: vllm/<id> in a workflow · nika run"
+    proven_by: rust
+  - id: provider.voyage
+    kind: provider
+    declared_at: crates/nika-catalog/data/llm-providers.toml:503
+    shipped_when: "never — catalog data only, no WireFormat seats it"
+    reachable_by: "unreachable by design · nika check refuses at the MODELS rung"
+    proven_by: rust
+  - id: provider.writer
+    kind: provider
+    declared_at: crates/nika-catalog/data/llm-providers.toml:739
+    shipped_when: "never — catalog data only, no WireFormat seats it"
+    reachable_by: "unreachable by design · nika check refuses at the MODELS rung"
+    proven_by: rust
+  - id: provider.xai
+    kind: provider
+    declared_at: crates/nika-catalog/data/llm-providers.toml:180
+    shipped_when: "default build (nika-providers::profile seats it)"
+    reachable_by: "model: xai/<id> in a workflow · nika run"
+    proven_by: rust
+  - id: provider.zhipu
+    kind: provider
+    declared_at: crates/nika-catalog/data/llm-providers.toml:614
+    shipped_when: "never — catalog data only, no WireFormat seats it"
+    reachable_by: "unreachable by design · nika check refuses at the MODELS rung"
+    proven_by: rust
 
 # A field the parser accepts and the runtime never reads. G6 fires while
 # the runtime needle is absent. Tombstone with a reason and a date to

--- a/wiring.yaml
+++ b/wiring.yaml
@@ -70,7 +70,10 @@ capabilities:
   # different sizes: 38 vendor rows, 16 of which this build can seat. What
   # was missing is not the adapters — it is that no surface MARKED which,
   # including the MCP tool whose whole job is telling an agent what to
-  # pick. Each row below is DECLARED at a file:line, states whether it
+  # pick. The per-row word is `resolves` (the MODELS rung's own verb),
+  # never « wired » — that one already names the run registry, a set of
+  # a different size, one line above on the same screen.
+  # Each row below is DECLARED at a file:line, states whether it
   # ships, states how (or whether) a user reaches it, and names ONE job as
   # its judge: `rust` runs `scripts/ci/check-tests.sh`, whose
   # `catalog_family.rs` traversal walks all 38 in a single pass and, per


### PR DESCRIPTION
Closes #1184. Closes #1179.

Two counters that could not be checked against the binary, on two
first-session surfaces.

## #1184 · the catalog ships 38 vendors and this build carries 16 adapters

Nothing marked which. The human list, the `catalog_version: 1` JSON and
the MCP `nika_catalog` tool rendered a reachable and an unreachable
vendor **identically**, so the fact only arrived after the choice, at the
MODELS rung. The refusal rung was already honest; the projections were
not.

The MCP tool is the sharp end. Its own description reads *"Pick REAL
model ids from here instead of guessing"* over a list where 22 of 38 rows
cannot run. The reader there is a machine that acts on the sentence.

**Derived, never typed.** `ProviderExport` gains `resolves`, and
`CatalogExport::with_resolvable` is the only path to `true`.
`nika-catalog` is L0 and its `export` module is feature-gated *off*
inside `nika-providers`, so the fact cannot be read where the data lives
— the two L4 surfaces that serialize it state it, over
`nika_providers::CANONICAL_IDS`. A hand-maintained mirror of that list
inside the catalog data would have been the next drift.

| surface | before | after |
|---|---|---|
| human column | `azure  2 models · AZURE_OPENAI_API_KEY` | `… · catalog only — does not resolve in this build` |
| `--json` | no such field | `"resolves": true\|false` per row |
| MCP `nika_catalog` | same payload, no marker | the field **and** a description that tells the agent to filter on it |

### The word, and why it is not `wired`

The first push of this branch shipped the field as `wired`. That was
wrong, and #1184's own thread had already said so: a previous session
wrote this exact field, backed it out, and explained that stamping
`wired` from `CANONICAL_IDS` puts **16** on the rows beside a header that
says **15** — re-creating the A-06 confusion `machine_truth.rs` exists to
cure. `MachineTruth::wired` is the run registry (`mock` excluded); this
set is what the MODELS rung accepts. Two sets, one word, one screen. I
had also patched the collision with a `(+ mock, the test lane)` clause in
the renderer, which the same comment ruled out ahead of time (*"if a
fourth word is ever needed, `machine_truth.rs` is where it belongs — not
in a renderer"*). That clause is gone and the header is untouched at 15.

The word is now the refusal rung's own — `check` says *"provider `x` does
not resolve in THIS binary"* — so a user who meets the refusal and then
greps the catalog reads one verb, not two.

The separation is guarded mechanically, not remembered:
`the_two_provider_words_name_two_different_sets` asserts the row count is
the adapter set, that it **differs** from the header's count, and that no
row field is spelled `wired`. Renaming either concept onto the other's
word turns it red.

**On the envelope version.** The issue suggested a `catalog_version`
bump. The module's own locked contract says evolution is ADDITIVE-ONLY
and *"new fields may appear"* within a version — adding a field is
precisely what v1 permits, and bumping would break the three consumers
that pin `== 1`. `catalog_version: 1` stands; called out because it
diverges from the issue.

## #1179 · `doctor` counted 633 pricing rules as models

`nika catalog` says *69 models* one command away. Two inventories under
one word, an order of magnitude apart, both on a first session. `p.rules`
is `all_pricing().len()` — price rows. The line now reads `633 price
rules · 10 providers priced`; several patterns can price one model, and a
pattern can price models this catalog never lists, so neither count
contains the other. The test forbids the **word** `models` in that line,
not just the old number.

## Proof

`catalog_family.rs` already held the wire table to the MODELS rung for
all 38 rows. The traversal now also holds **both shipped projections**,
per row, in the same pass — and drives the MCP tool over a real stdio
JSON-RPC round trip rather than reading the code that serves it.

That one job (`rust` → `check-tests.sh` → `cargo nextest run
--workspace`) is the `proven_by` for the 38 provider rows this PR adds to
`wiring.yaml`, and it has run here: `PASS nika-cli::catalog_family
every_cataloged_provider_either_seats_or_is_refused_by_name` ·
`the_two_provider_words_name_two_different_sets` · `the_mcp_catalog_tool
_marks_every_row_and_teaches_the_filter`. Each row carries a real
`declared_at` file:line and states whether it ships and how it is
reached; `unreachable by design` is a legitimate state, and the
traversal's `UNWIRED` list is where a change to that set has to be
decided out loud.

```
wiring-g3-unprobed   78 findings  →  40
                     (38 provider closed · 0 ghost-job · 0 no-proven-by)
```

The residue is 25 verbs (`nika-cli/src/main.rs`, the W1/W3 contact point)
and 14 templates (`nika-pack`) — other territories, deliberately untouched.

**Seven mutations, each proven red, each restored green** — the first
five were re-run after the rename rather than inheriting the old proof:

| mutation | goes red |
|---|---|
| drop the chain in `catalog.rs` | 2 unit tests + the traversal |
| drop the chain in `nika-mcp` | payload test + the stdio round trip |
| restore `"{} models"` in the doctor | the pricing pin |
| drop the row suffix | the traversal's human-column leg |
| re-open `native`'s call to action | `a_non_resolving_row_says_so_and_offers_no_verb` |
| spell the row field `wired` again | `the_two_provider_words_name_two_different_sets` |
| point `proven_by` at a job no workflow defines | 38 `ghost-job` findings |

## Gates

6535 lib tests · `catalog_family` 5/5 · `machine_truth_surfaces` 3/3 ·
11/11 ratchets · fmt · `clippy --workspace --all-targets` clean.

`crates/nika-catalog/public-api.txt` is regenerated (3 additive lines, 0
removed) with the pinned `cargo-public-api 0.51.0`; the local run
reproduced the committed baseline byte-for-byte apart from those lines.
`nika-cli-host`'s baseline is deliberately **not** regenerated — its
public API is unchanged here, and a mac run drops 6 `zvariant` impls the
Linux runner sees.

Two hard caps were breached by these additions and repaired by
extraction, never exemption: `doctor/tests.rs` sat at 1499/1500 (the
pricing pins descend into a `pricing_tests` sibling module) and
`human_listing` crossed the 100-line function cap (the header block
becomes `listing_header`).

Both issue bodies carry `proven_by: rust`, so `issue-proof` fires and
holds on close instead of skipping.

## Not closed here

- `check`'s *"16 runnable — `nika doctor` names them"* is true only under
  `--verbose`; plain `doctor` names 9. That copy lives in W4's territory.
- Whether the 22 should be wired or moved behind their own section is the
  product call the issue defers. Either way the projection now carries
  the fact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)