### PR TITLE
fix(lsp): watch the host the server was told to watch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4685,6 +4685,7 @@ dependencies = [
  "nika-schema",
  "nika-types",
  "nika-vocab",
+ "nix 0.31.3",
  "proptest",
  "serde",
  "serde_json",

--- a/changelog.d/1181.fixed.md
+++ b/changelog.d/1181.fixed.md
@@ -1,0 +1,8 @@
+- **`nika lsp` watches the host it was told to watch.** `--clientProcessId`
+  was accepted by clap and discarded at the call site, and the `initialize`
+  request's own `processId` was never read either, so a client that died
+  **without** closing the pipe left the language server running forever — the
+  ordinary path hid it, because a clean shutdown closes stdin and the server
+  exits on EOF. Both channels now feed one watchdog (argv wins, the payload
+  covers hosts that send only that), and the server exits when its declared
+  parent goes, per LSP `initialize` §processId.

--- a/crates/nika-cli/src/main.rs
+++ b/crates/nika-cli/src/main.rs
@@ -323,7 +323,10 @@ enum Command {
         #[arg(long, hide = true)]
         stdio: bool,
         /// Same convention family: hosts pass their own PID so a server
-        /// can watchdog its parent. Accepted, currently unread.
+        /// can watchdog its parent — and this one does. A host that
+        /// closes the pipe ends the session by EOF; a host that CRASHES
+        /// does not, and the server would outlive it forever (#1181).
+        /// Hidden: no human types it, the editor does.
         #[arg(long = "clientProcessId", hide = true)]
         client_process_id: Option<u32>,
     },
@@ -883,7 +886,9 @@ fn dispatch_verb(
         // `exit` without a prior `shutdown`) — the server-process
         // convention, NOT the verb FILE/WORKFLOW/ENV taxonomy.
         Command::Dap => nika_dap::run_stdio(),
-        Command::Lsp { .. } => match nika_lsp::run_stdio() {
+        Command::Lsp {
+            client_process_id, ..
+        } => match nika_lsp::run_stdio_watching(client_process_id) {
             Ok(()) => verbs::exit::OK,
             Err(err) => {
                 eprintln!("nika lsp: {err}");

--- a/crates/nika-cli/tests/lsp_parent_watchdog.rs
+++ b/crates/nika-cli/tests/lsp_parent_watchdog.rs
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! #1181 leg B — `nika lsp --clientProcessId` must outlive nothing.
+//!
+//! The unit tests in `nika-lsp::watchdog` prove the PREDICATE (a reaped
+//! child is not alive). They cannot prove the predicate is WIRED: a
+//! `process_is_alive` stubbed to `false` would still pass them, and so
+//! would a `main.rs` that went back to dropping the flag. This file is
+//! the witness for the wiring, and it runs the real binary.
+//!
+//! Leg A (a clean shutdown closes stdin, the server sees EOF and exits) is
+//! why this defect stayed invisible for so long, so it is pinned here too:
+//! a watchdog that killed the ordinary path would be a worse bug than the
+//! one it fixes.
+//!
+//! Held open, never closed: the test owns the write end of the server's
+//! stdin for the whole of `parent_death_ends_the_server`. That is the
+//! condition the flag exists for — EOF never arrives — and without it the
+//! server would exit for the ordinary reason and prove nothing.
+
+#![cfg(unix)]
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+// The point of this file is to run the SHIPPED binary as a user's editor
+// would. A `ShellExecutor` seam would prove the seam, not the wiring.
+#![allow(clippy::disallowed_types)]
+
+use std::io::Write;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+/// Generous: the watchdog polls on a 2s tick, CI runners stall, and a
+/// flaky-red here would teach the next reader to distrust the gate.
+const DEADLINE: Duration = Duration::from_secs(30);
+
+fn nika() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_nika-cli"))
+}
+
+/// A process that will sit still until somebody kills it — the stand-in
+/// for the editor that spawned us.
+fn spawn_parent() -> Child {
+    Command::new("sleep")
+        .arg("600")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn the stand-in parent")
+}
+
+/// Wait for `child` to exit, or return `None` at the deadline.
+fn wait_for_exit(child: &mut Child, deadline: Duration) -> Option<std::process::ExitStatus> {
+    let start = Instant::now();
+    while start.elapsed() < deadline {
+        match child.try_wait().expect("poll the server") {
+            Some(status) => return Some(status),
+            None => std::thread::sleep(Duration::from_millis(100)),
+        }
+    }
+    None
+}
+
+#[test]
+fn parent_death_ends_the_server() {
+    let mut parent = spawn_parent();
+    let parent_pid = parent.id();
+
+    let mut server = nika()
+        .args(["lsp", "--stdio"])
+        .arg(format!("--clientProcessId={parent_pid}"))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn the language server");
+
+    // The write end stays in scope for the whole test. Dropping it here
+    // would close the pipe, the server would exit on EOF, and this test
+    // would go green against a server with no watchdog at all.
+    let held_stdin = server.stdin.take().expect("the server's stdin");
+
+    // The server is now blocked in `initialize`, which never completes:
+    // no client is speaking. That is deliberate — it pins the fix for the
+    // host that dies DURING the handshake, which the first shape of this
+    // patch (watchdog spawned after `initialize`) would have missed.
+    parent.kill().expect("kill the declared parent");
+    parent.wait().expect("reap the declared parent");
+
+    let status = wait_for_exit(&mut server, DEADLINE);
+    let exited = status.is_some();
+    if !exited {
+        let _ = server.kill();
+        let _ = server.wait();
+    }
+    drop(held_stdin);
+    assert!(
+        exited,
+        "the server outlived its declared parent for {DEADLINE:?} with stdin still open \
+         — the #1181 orphan"
+    );
+    assert_eq!(
+        status.and_then(|s| s.code()),
+        Some(0),
+        "a host that is gone is a normal end of session, not a failure"
+    );
+}
+
+#[test]
+fn a_closed_pipe_still_ends_the_server() {
+    // Leg A: no flag, no parent to watch — the ordinary path must be
+    // exactly as it was. This is the mutation guard on the watchdog
+    // itself: a watchdog that fired unconditionally would still pass the
+    // test above, and would fail this one.
+    let mut server = nika()
+        .args(["lsp", "--stdio"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn the language server");
+
+    let mut stdin = server.stdin.take().expect("the server's stdin");
+    let _ = stdin.flush();
+    drop(stdin); // EOF — the clean client shutdown.
+
+    let status = wait_for_exit(&mut server, DEADLINE);
+    if status.is_none() {
+        let _ = server.kill();
+        let _ = server.wait();
+    }
+    assert!(
+        status.is_some(),
+        "a closed pipe must still end the session (leg A unchanged)"
+    );
+}
+
+#[test]
+fn a_live_parent_keeps_the_server_up() {
+    // The other side of the verdict. Without this, a watchdog that exited
+    // on its first tick regardless of the parent would pass every test
+    // above — the failure mode that turns a language server into one that
+    // dies two seconds into every session.
+    let mut parent = spawn_parent();
+
+    let mut server = nika()
+        .args(["lsp", "--stdio"])
+        .arg(format!("--clientProcessId={}", parent.id()))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn the language server");
+    let held_stdin = server.stdin.take().expect("the server's stdin");
+
+    // Several watchdog ticks with the parent alive and the pipe open.
+    std::thread::sleep(Duration::from_secs(7));
+    let early = server.try_wait().expect("poll the server");
+
+    let _ = server.kill();
+    let _ = server.wait();
+    drop(held_stdin);
+    parent.kill().expect("kill the stand-in parent");
+    parent.wait().expect("reap the stand-in parent");
+
+    assert!(
+        early.is_none(),
+        "the server exited while its declared parent was alive: {early:?}"
+    );
+}

--- a/crates/nika-lsp/Cargo.toml
+++ b/crates/nika-lsp/Cargo.toml
@@ -23,6 +23,9 @@ serde       = { workspace = true }                             # DeserializeOwne
 serde_json  = { workspace = true }                             # request/notification param (de)serialization
 thiserror   = { workspace = true }                             # LspError (transport/protocol) enum
 
+[target.'cfg(unix)'.dependencies]
+nix = { workspace = true }   # kill(pid, 0) — the safe parent-existence probe behind the `initialize` §processId watchdog (encapsulates the signal FFI → crate stays unsafe_code = forbid)
+
 [dev-dependencies]
 proptest = { workspace = true }   # Gate 6 — position round-trip + apply_change ≡ full replace
 tempfile = { workspace = true }   # skills lane — workspace-walk fixtures on a real tempdir

--- a/crates/nika-lsp/public-api.txt
+++ b/crates/nika-lsp/public-api.txt
@@ -220,3 +220,4 @@ pub fn nika_lsp::error::LspError::from(t: T) -> T
 impl<T> nika_error::traits::AsAny for nika_lsp::error::LspError where T: 'static
 pub fn nika_lsp::error::LspError::as_any(&self) -> &(dyn core::any::Any + 'static)
 pub fn nika_lsp::run_stdio() -> core::result::Result<(), nika_lsp::error::LspError>
+pub fn nika_lsp::run_stdio_watching(client_process_id: core::option::Option<u32>) -> core::result::Result<(), nika_lsp::error::LspError>

--- a/crates/nika-lsp/src/lib.rs
+++ b/crates/nika-lsp/src/lib.rs
@@ -51,6 +51,7 @@ pub mod analysis;
 pub mod capabilities;
 pub mod error;
 mod server;
+mod watchdog;
 
 /// Run the language server over stdio until the client disconnects.
 ///
@@ -65,5 +66,25 @@ mod server;
 /// Returns an [`error::LspError`] when the transport fails, the protocol
 /// handshake is violated, or a payload cannot be (de)serialized.
 pub fn run_stdio() -> Result<(), error::LspError> {
-    server::run_stdio()
+    server::run_stdio(None)
+}
+
+/// Run the language server over stdio, watching the host process.
+///
+/// Same lifecycle as [`run_stdio`], plus the LSP `initialize` §`processId`
+/// contract: *"If the parent process is not alive then the server should
+/// exit its process."* `client_process_id` is the host's
+/// `--clientProcessId` argv value; when it is absent the `processId` of
+/// the `initialize` params is used instead. When neither names a live
+/// parent, nothing is watched and this behaves exactly like [`run_stdio`].
+///
+/// This matters only for a host that dies **without** closing stdio. A
+/// client that closes the pipe already ends the session by EOF; a client
+/// that crashes does not, and before this the server ran forever (#1181).
+///
+/// # Errors
+///
+/// Returns an [`error::LspError`] on the same conditions as [`run_stdio`].
+pub fn run_stdio_watching(client_process_id: Option<u32>) -> Result<(), error::LspError> {
+    server::run_stdio(client_process_id)
 }

--- a/crates/nika-lsp/src/server.rs
+++ b/crates/nika-lsp/src/server.rs
@@ -54,6 +54,7 @@ use crate::analysis::{
 };
 use crate::capabilities::server_capabilities;
 use crate::error::LspError;
+use crate::watchdog;
 
 /// The open-document map: URI string → its buffer + line index.
 type Docs = BTreeMap<String, Document>;
@@ -173,12 +174,34 @@ fn await_exit(connection: &Connection, mut batch: VecDeque<Message>) -> Result<(
 }
 
 /// Run the full stdio lifecycle: connect, initialize, serve, join threads.
-pub(crate) fn run_stdio() -> Result<(), LspError> {
+///
+/// `client_process_id` is the host's `--clientProcessId` argv value, when
+/// it passed one. The `initialize` params carry the same fact for hosts
+/// that use only the protocol channel, so both are offered to
+/// [`watchdog::declared_parent`] and the winner is watched for the rest of
+/// the session (#1181 — before this, the flag was accepted and dropped and
+/// the `initialize` `processId` was never read at all).
+pub(crate) fn run_stdio(client_process_id: Option<u32>) -> Result<(), LspError> {
     let (connection, io_threads) = Connection::stdio();
+    // argv names the parent BEFORE the handshake, so watch it from here:
+    // `initialize` blocks until the client speaks, and a host that dies
+    // during that window would otherwise strand the server exactly as
+    // #1181 describes — with the watchdog it was given never started.
+    let argv_parent = client_process_id.filter(|pid| *pid != 0);
+    if let Some(pid) = argv_parent {
+        watchdog::spawn(pid, watchdog::POLL_INTERVAL);
+    }
     let caps = serde_json::to_value(server_capabilities()).map_err(LspError::Serde)?;
-    connection
+    let init_params = connection
         .initialize(caps)
         .map_err(|e| LspError::Protocol(e.to_string()))?;
+    // The payload channel only becomes readable here. It covers the hosts
+    // that send `processId` and no flag; argv already won if it was given.
+    if argv_parent.is_none()
+        && let Some(pid) = watchdog::declared_parent(None, &init_params)
+    {
+        watchdog::spawn(pid, watchdog::POLL_INTERVAL);
+    }
     let result = serve(&connection);
     // Drop the connection BEFORE joining: it owns the sender whose channel
     // feeds the writer IO thread. While the connection lives the writer

--- a/crates/nika-lsp/src/watchdog.rs
+++ b/crates/nika-lsp/src/watchdog.rs
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The parent watchdog — LSP `initialize` §`processId`.
+//!
+//! > *"If the parent process is not alive then the server should exit its
+//! > process."*
+//!
+//! Hosts declare their PID two ways: on argv (`--clientProcessId`, the
+//! vscode-languageclient / nvim / helix convention) and in the
+//! `initialize` params. Both were accepted and neither was read (#1181):
+//! `Command::Lsp { .. }` discarded the flag and `run_stdio()` took no
+//! argument.
+//!
+//! The ordinary shutdown does not need this. A client that closes the
+//! pipe sends EOF and the transport ends the loop — which is why the
+//! gap stayed invisible. The case the flag exists for is the client that
+//! dies **without** closing stdio (a crash, a `SIGKILL`): EOF never
+//! arrives and the server outlives its host forever.
+//!
+//! ## Why this exits the process rather than unwinding
+//!
+//! Returning cleanly from the message loop cannot work here. The reader
+//! IO thread is parked on a `read()` that will never return — that is
+//! the defining condition of this failure — so `io_threads.join()` would
+//! block exactly as [`crate::server::run_stdio`] documents. Exiting the
+//! process is both the only thing that ends a blocked read and the
+//! literal instruction of the specification.
+
+use std::time::Duration;
+
+/// How often the parent is polled. Small enough that an editor restart
+/// does not leave a stale server holding a workspace, large enough to be
+/// free: one syscall per tick.
+pub(crate) const POLL_INTERVAL: Duration = Duration::from_secs(2);
+
+/// Is `pid` still a live process?
+///
+/// Unix: `kill(pid, 0)` — the existence probe, no signal delivered.
+/// `EPERM` counts as **alive**: the process exists, it is merely owned by
+/// somebody else. Only `ESRCH` (no such process) means gone.
+///
+/// Non-unix targets have no portable equivalent here, so the parent is
+/// reported alive and the watchdog never fires. Every shipped target is
+/// unix (`release.yml` builds macOS + Linux only); this arm exists so the
+/// crate still compiles for `wasm32`.
+#[must_use]
+pub(crate) fn process_is_alive(pid: u32) -> bool {
+    #[cfg(unix)]
+    {
+        let Ok(raw) = i32::try_from(pid) else {
+            // Not a PID this platform can express — nothing to watch.
+            return true;
+        };
+        !matches!(
+            nix::sys::signal::kill(nix::unistd::Pid::from_raw(raw), None),
+            Err(nix::errno::Errno::ESRCH)
+        )
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = pid;
+        true
+    }
+}
+
+/// Watch `pid` on a detached thread and end this process when it dies.
+///
+/// A PID of 0 is ignored: it is the "no parent" value hosts send when
+/// they do not want to be watched, and on unix `kill(0, …)` addresses the
+/// caller's own process group — the one probe that must never be made.
+pub(crate) fn spawn(pid: u32, interval: Duration) {
+    if pid == 0 {
+        return;
+    }
+    // Detached on purpose: the thread must outlive nothing and be joined
+    // by nobody — the server's lifetime is the process's lifetime.
+    //
+    // `tokio::spawn` is the workspace default and cannot apply here: this
+    // crate is deliberately sync (`server.rs` — "No async, no tokio").
+    // Pulling a runtime in to own one sleeping poll loop would be a far
+    // larger change than the defect it serves.
+    #[allow(clippy::disallowed_methods)] // sync crate by design · no tokio runtime to spawn onto
+    std::thread::spawn(move || {
+        while process_is_alive(pid) {
+            std::thread::sleep(interval);
+        }
+        // A host that is gone is a normal end of session, not a failure.
+        std::process::exit(0);
+    });
+}
+
+/// The PID this server should watch, given the flag and the `initialize`
+/// params, in that order of precedence.
+///
+/// argv wins because a host that bothered to pass `--clientProcessId`
+/// named the process it wants watched; `processId` in the payload is the
+/// protocol's own channel and covers every host that sends only that.
+/// `processId: null` is the spec's "no parent" and yields `None`.
+#[must_use]
+pub(crate) fn declared_parent(flag: Option<u32>, init_params: &serde_json::Value) -> Option<u32> {
+    flag.or_else(|| {
+        init_params
+            .get("processId")
+            .and_then(serde_json::Value::as_u64)
+            .and_then(|n| u32::try_from(n).ok())
+    })
+    .filter(|pid| *pid != 0)
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::disallowed_types)] // a real child process is the only honest fixture for a liveness probe
+
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn this_process_is_alive() {
+        assert!(process_is_alive(std::process::id()));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_reaped_child_is_not_alive() {
+        // Spawn, kill, WAIT — the wait is what makes this deterministic:
+        // an unreaped child is a zombie and a zombie still answers
+        // `kill(pid, 0)`. Without the reap this test would flake green
+        // against a broken predicate.
+        let mut child = std::process::Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .expect("spawn a child to kill");
+        let pid = child.id();
+        assert!(process_is_alive(pid), "alive before the kill");
+        child.kill().expect("kill the child");
+        child.wait().expect("reap the child");
+        assert!(!process_is_alive(pid), "dead and reaped after the kill");
+    }
+
+    #[test]
+    fn pid_zero_is_never_watched() {
+        assert_eq!(declared_parent(Some(0), &json!({})), None);
+        assert_eq!(declared_parent(None, &json!({ "processId": 0 })), None);
+    }
+
+    #[test]
+    fn the_flag_wins_over_the_payload() {
+        let params = json!({ "processId": 222 });
+        assert_eq!(declared_parent(Some(111), &params), Some(111));
+    }
+
+    #[test]
+    fn the_payload_covers_a_host_that_sends_no_flag() {
+        let params = json!({ "processId": 222 });
+        assert_eq!(declared_parent(None, &params), Some(222));
+    }
+
+    #[test]
+    fn a_null_process_id_is_no_parent() {
+        assert_eq!(declared_parent(None, &json!({ "processId": null })), None);
+        assert_eq!(declared_parent(None, &json!({})), None);
+    }
+}

--- a/wiring.yaml
+++ b/wiring.yaml
@@ -29,6 +29,13 @@ quarantine:
     proven_by: acp-quarantine
 
 capabilities:
+  - id: lsp.parent-watchdog
+    kind: cli-flag
+    declared_at: crates/nika-cli/src/main.rs:331
+    shipped_when: "default"
+    reachable_by: "nika lsp --stdio --clientProcessId=<pid>"
+    proven_by: rust
+    issue: 1181
   - id: access.harness
     kind: cargo-feature
     declared_at: crates/nika-cli/Cargo.toml:72

--- a/wiring.yaml
+++ b/wiring.yaml
@@ -87,9 +87,9 @@ silent_drops:
     runtime_file: crates/nika-runtime/src/dispatch.rs
     runtime_needle: "action.thinking"
     issue: 1180
-  - id: lsp.client-process-id
-    parsed_file: crates/nika-cli/src/main.rs
-    parsed_needle: "client_process_id: Option"
-    runtime_file: crates/nika-cli/src/main.rs
-    runtime_needle: "client_process_id)"
-    issue: 1181
+  # lsp.client-process-id — REMOVED 2026-08-24. The flag is read at
+  # main.rs and drives the `initialize` §processId watchdog; the field is
+  # no longer silent, so the watch would now be the lie in the other
+  # direction. Proven by `parent_death_ends_the_server`
+  # (crates/nika-cli/tests/lsp_parent_watchdog.rs), which runs under the
+  # named `rust (tests)` CI job.


### PR DESCRIPTION
## Why

`nika lsp --clientProcessId=<pid>` was accepted by clap and discarded at the one place it could have been used:

```rust
Command::Lsp { .. } => match nika_lsp::run_stdio() {   // both fields dropped
```

`run_stdio()` took no argument, and `crates/nika-lsp/` contained no occurrence of `processId` at all — so the `initialize` request's own `processId` was ignored on the same grounds. Both channels a host has to declare its PID reached nothing. The flag's doc-comment said *"Accepted, currently unread"*, which is honest and also the problem: a doc-comment is a claim nobody runs.

**Why it stayed invisible.** A client that closes the pipe sends EOF and the server exits — that is every clean shutdown, and it works. The case the flag exists for is the client that dies **without** closing stdio (a crash, a `SIGKILL`): EOF never arrives, and the server outlives its editor forever.

This is the G6 silent-drop family (#1135, #1180) on the LSP surface instead of the workflow surface.

## What changed

- `crates/nika-lsp/src/watchdog.rs` — `kill(pid, 0)` through `nix` (the safe wrapper, so the crate keeps `unsafe_code = forbid`). `EPERM` counts as **alive** (the process exists, it is just somebody else's); only `ESRCH` means gone.
- Both channels feed one watchdog. argv wins when given; the `initialize` payload covers hosts that send only that; `processId: null` and `0` mean *no parent*.
- **The argv PID is watched from before the handshake.** `initialize` blocks until the client speaks, so a host that dies inside that window would otherwise strand the server with the very watchdog it supplied never started. The first shape of this patch had that bug; the e2e test below is what found it.
- Exit code 0 — a host that is gone is a normal end of session, not a failure.
- `run_stdio_watching` is **additive**; `run_stdio()` delegates to it, so no semver break. `public-api.txt` regenerated with `cargo-public-api 0.51.0` (the pinned version) — diff is exactly one added line.
- `nix` is a `cfg(unix)` dependency, so the non-unix arm of `process_is_alive` stays real code rather than dead code.

### Why it exits the process rather than unwinding

Returning cleanly from the message loop cannot work here. The reader IO thread is parked on a `read()` that will never return — that is the defining condition of this failure — so `io_threads.join()` would block exactly as `server.rs` already documents. Exiting is both the only thing that ends a blocked read and the literal instruction of LSP `initialize` §processId.

## Proof, and its scope

The unit tests prove the **predicate** (a reaped child is not alive — and the reap is what makes it deterministic, since a zombie still answers `kill(pid, 0)`). They cannot prove the predicate is **wired**.

`crates/nika-cli/tests/lsp_parent_watchdog.rs` runs the real binary and **holds the write end of its stdin for the whole test**, so EOF never arrives. That is leg B. Mutation-proven in both directions, both actually run:

| mutant | test that goes red |
|---|---|
| restore the drop (`server::run_stdio(None)`) | `parent_death_ends_the_server` — *"the server outlived its declared parent for 30s with stdin still open"* |
| `process_is_alive` stubbed to `false` | `a_live_parent_keeps_the_server_up` — *"the server exited while its declared parent was alive"* |

The third test (`a_closed_pipe_still_ends_the_server`) pins leg A: a watchdog that broke the ordinary path would be a worse bug than the one this fixes.

**No workflow file was touched.** `scripts/ci/check-tests.sh` runs `cargo nextest run --workspace` when `$CI` is set — the full battery, lib **and** `tests/` — so the named job `rust (tests)` already executes this file.

## Ledger

- `wiring.yaml` `silent_drops:` — the `lsp.client-process-id` watch is **removed**, with the reason and the date. The field is no longer silent, so keeping the watch would be the lie in the other direction. (`wiring-g6-silent-drop` confirms: that `watch-drop` finding is gone on this branch.)
- `capabilities:` — a row with `proven_by: rust` + `issue: 1181`. `issue-proof.sh` was run both ways: `HOLD rc=0` with the real job, `FAIL rc=1 "the judge does not exist"` with a bogus one (exercised against a bogus `GH_REPO` so the refusal could not touch the real issue).

## Not fixed here

A clean stdin EOF still exits **rc=1** with `language-server protocol violation: disconnected channel`. A client closing the pipe is the normal end of a session, not a violation, and hosts that log server stderr show a red line on every clean exit. #1181 mentions it as a rider; it is a separate defect on a separate line and wants its own change rather than a quiet ride on this one.

Closes #1181
