### PR TITLE
fix(cli,check): one next step, and a scaffold that can refuse

### DIFF
--- a/changelog.d/1066.changed.md
+++ b/changelog.d/1066.changed.md
@@ -1,0 +1,14 @@
+- **An unfilled scaffold refuses at `check`, before the spend.** `nika
+  new chain` laid its `SLOT` markers as YAML **comments**, which the
+  parser drops by construction — so `check` mentioned none of them, the
+  run exited 0, and `output.md` was left holding the scaffold's own
+  prompt echoed back by a mock: a file that outlives the terminal line
+  explaining it. A comment cannot refuse, so the marker descends into
+  the VALUE (`<SLOT: what should the model do with the gathered text?>`)
+  where the parser sees it. Seven shipped skeletons now carry one, and
+  `check` names each unfilled slot with its line and closes on one
+  pasteable command. The refusal is worded as a step, not a fault —
+  `not a workflow yet — 1 slot to fill, then it audits` — because
+  someone who just typed `nika new` did nothing wrong. Fill it and the
+  same file audits clean and runs; that second half is pinned too, so
+  the refusal can never widen into a wall.

--- a/changelog.d/1187.changed.md
+++ b/changelog.d/1187.changed.md
@@ -1,0 +1,10 @@
+- **`nika --json` answers the same next step as the terminal.** The
+  screen's one next step is now computed once and rendered by every
+  projection: the `Next:` block, the new top-level `next` field,
+  `start` (a one-element array where it used to carry the pre-cascade
+  triple `nika try 01-hello` · `nika init` · `nika new`), and every
+  `inference_choice.rungs[].next`. Those rungs hardcoded `nika new
+  hello`, so a harness reading them in a directory that already held
+  the file was told to run a command that refuses on `--force`. The one
+  derivation carries the audited laws too — a red sole file yields
+  `nika check <file>`, a priced one yields the `--max-cost-usd` cap.

--- a/changelog.d/1196.changed.md
+++ b/changelog.d/1196.changed.md
@@ -1,0 +1,9 @@
+- **The first-contact screen promises one first command.** `nika` and
+  `nika welcome` used to print the cascade's single `Next:` step and,
+  eleven lines below it, the `start here` menu that step had replaced —
+  two different doors for a stranger to choose between, and `nika init`
+  offered twice. The menu is gone; the body keeps `this machine`, `this
+  binary`, the sample block and the `learn:` line. The cascade's
+  hardware row now reads `this hardware · N GB` and the local rung no
+  longer repeats the RAM, so the words `this machine` name one thing on
+  the screen instead of three. 43 lines down to 38.

--- a/crates/nika-check/public-api.txt
+++ b/crates/nika-check/public-api.txt
@@ -60,6 +60,56 @@ pub fn nika_check::permits_fit::CapabilityEscape::as_any(&self) -> &(dyn core::a
 pub fn nika_check::permits_fit::scan_escapes(wf: &nika_schema::raw::workflow::RawWorkflow) -> alloc::vec::Vec<nika_check::permits_fit::CapabilityEscape>
 pub mod nika_check::plan
 pub fn nika_check::plan::payload(file: &str, wf: &nika_schema::raw::workflow::RawWorkflow, report: &nika_check::CheckReport) -> serde_json::value::Value
+pub mod nika_check::slots
+#[non_exhaustive] pub struct nika_check::slots::SlotFinding
+pub nika_check::slots::SlotFinding::hint: alloc::string::String
+pub nika_check::slots::SlotFinding::path: alloc::string::String
+pub nika_check::slots::SlotFinding::span: nika_check::ByteSpan
+impl nika_check::slots::SlotFinding
+pub fn nika_check::slots::SlotFinding::new(path: alloc::string::String, hint: alloc::string::String, span: nika_check::ByteSpan) -> Self
+impl core::clone::Clone for nika_check::slots::SlotFinding
+pub fn nika_check::slots::SlotFinding::clone(&self) -> nika_check::slots::SlotFinding
+impl core::cmp::Eq for nika_check::slots::SlotFinding
+impl core::cmp::PartialEq for nika_check::slots::SlotFinding
+pub fn nika_check::slots::SlotFinding::eq(&self, other: &nika_check::slots::SlotFinding) -> bool
+impl core::fmt::Debug for nika_check::slots::SlotFinding
+pub fn nika_check::slots::SlotFinding::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for nika_check::slots::SlotFinding
+impl serde_core::ser::Serialize for nika_check::slots::SlotFinding
+pub fn nika_check::slots::SlotFinding::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<D> owo_colors::OwoColorize for nika_check::slots::SlotFinding
+impl<Q, K> equivalent::Equivalent<K> for nika_check::slots::SlotFinding where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn nika_check::slots::SlotFinding::equivalent(&self, key: &K) -> bool
+impl<Q, K> hashbrown::Equivalent<K> for nika_check::slots::SlotFinding where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn nika_check::slots::SlotFinding::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for nika_check::slots::SlotFinding where U: core::convert::From<T>
+pub fn nika_check::slots::SlotFinding::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_check::slots::SlotFinding where U: core::convert::Into<T>
+pub type nika_check::slots::SlotFinding::Error = core::convert::Infallible
+pub fn nika_check::slots::SlotFinding::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_check::slots::SlotFinding where U: core::convert::TryFrom<T>
+pub type nika_check::slots::SlotFinding::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_check::slots::SlotFinding::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_check::slots::SlotFinding where T: core::clone::Clone
+pub type nika_check::slots::SlotFinding::Owned = T
+pub fn nika_check::slots::SlotFinding::clone_into(&self, target: &mut T)
+pub fn nika_check::slots::SlotFinding::to_owned(&self) -> T
+impl<T> core::any::Any for nika_check::slots::SlotFinding where T: 'static + ?core::marker::Sized
+pub fn nika_check::slots::SlotFinding::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_check::slots::SlotFinding where T: ?core::marker::Sized
+pub fn nika_check::slots::SlotFinding::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_check::slots::SlotFinding where T: ?core::marker::Sized
+pub fn nika_check::slots::SlotFinding::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_check::slots::SlotFinding where T: core::clone::Clone
+pub unsafe fn nika_check::slots::SlotFinding::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_check::slots::SlotFinding
+pub fn nika_check::slots::SlotFinding::from(t: T) -> T
+impl<T> dyn_clone::DynClone for nika_check::slots::SlotFinding where T: core::clone::Clone
+pub fn nika_check::slots::SlotFinding::__clone_box(&self, _: dyn_clone::sealed::Private) -> *mut ()
+impl<T> nika_error::traits::AsAny for nika_check::slots::SlotFinding where T: 'static
+pub fn nika_check::slots::SlotFinding::as_any(&self) -> &(dyn core::any::Any + 'static)
+pub const nika_check::slots::MARKER_OPEN: &str
+pub fn nika_check::slots::scan(wf: &nika_schema::raw::workflow::RawWorkflow) -> alloc::vec::Vec<nika_check::slots::SlotFinding>
 pub mod nika_check::trifecta
 pub fn nika_check::trifecta::scan_trifecta(wf: &nika_schema::raw::workflow::RawWorkflow, edges: &[nika_check_analyzer::edges::Edge], topo_waves: &[alloc::vec::Vec<usize>]) -> nika_cap::trifecta::TrifectaVerdict
 #[non_exhaustive] pub enum nika_check::DataClassification
@@ -730,6 +780,7 @@ pub nika_check::CheckReport::schema_lints: alloc::vec::Vec<nika_check::SchemaLin
 pub nika_check::CheckReport::secret_egresses: alloc::vec::Vec<nika_check::SecretEgress>
 pub nika_check::CheckReport::secret_leaks: alloc::vec::Vec<nika_check::SecretLeak>
 pub nika_check::CheckReport::sink_findings: alloc::vec::Vec<nika_check::SinkFinding>
+pub nika_check::CheckReport::slot_findings: alloc::vec::Vec<nika_check::slots::SlotFinding>
 pub nika_check::CheckReport::trifecta_findings: alloc::vec::Vec<nika_cap::trifecta::TrifectaViolation>
 pub nika_check::CheckReport::trifecta_mitigations: alloc::vec::Vec<nika_cap::trifecta::TrifectaMitigation>
 pub nika_check::CheckReport::unknown_args: alloc::vec::Vec<nika_check::UnknownArg>
@@ -2384,6 +2435,53 @@ impl<T> dyn_clone::DynClone for nika_check::SinkFinding where T: core::clone::Cl
 pub fn nika_check::SinkFinding::__clone_box(&self, _: dyn_clone::sealed::Private) -> *mut ()
 impl<T> nika_error::traits::AsAny for nika_check::SinkFinding where T: 'static
 pub fn nika_check::SinkFinding::as_any(&self) -> &(dyn core::any::Any + 'static)
+#[non_exhaustive] pub struct nika_check::SlotFinding
+pub nika_check::SlotFinding::hint: alloc::string::String
+pub nika_check::SlotFinding::path: alloc::string::String
+pub nika_check::SlotFinding::span: nika_check::ByteSpan
+impl nika_check::slots::SlotFinding
+pub fn nika_check::slots::SlotFinding::new(path: alloc::string::String, hint: alloc::string::String, span: nika_check::ByteSpan) -> Self
+impl core::clone::Clone for nika_check::slots::SlotFinding
+pub fn nika_check::slots::SlotFinding::clone(&self) -> nika_check::slots::SlotFinding
+impl core::cmp::Eq for nika_check::slots::SlotFinding
+impl core::cmp::PartialEq for nika_check::slots::SlotFinding
+pub fn nika_check::slots::SlotFinding::eq(&self, other: &nika_check::slots::SlotFinding) -> bool
+impl core::fmt::Debug for nika_check::slots::SlotFinding
+pub fn nika_check::slots::SlotFinding::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for nika_check::slots::SlotFinding
+impl serde_core::ser::Serialize for nika_check::slots::SlotFinding
+pub fn nika_check::slots::SlotFinding::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<D> owo_colors::OwoColorize for nika_check::slots::SlotFinding
+impl<Q, K> equivalent::Equivalent<K> for nika_check::slots::SlotFinding where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn nika_check::slots::SlotFinding::equivalent(&self, key: &K) -> bool
+impl<Q, K> hashbrown::Equivalent<K> for nika_check::slots::SlotFinding where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn nika_check::slots::SlotFinding::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for nika_check::slots::SlotFinding where U: core::convert::From<T>
+pub fn nika_check::slots::SlotFinding::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_check::slots::SlotFinding where U: core::convert::Into<T>
+pub type nika_check::slots::SlotFinding::Error = core::convert::Infallible
+pub fn nika_check::slots::SlotFinding::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_check::slots::SlotFinding where U: core::convert::TryFrom<T>
+pub type nika_check::slots::SlotFinding::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_check::slots::SlotFinding::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_check::slots::SlotFinding where T: core::clone::Clone
+pub type nika_check::slots::SlotFinding::Owned = T
+pub fn nika_check::slots::SlotFinding::clone_into(&self, target: &mut T)
+pub fn nika_check::slots::SlotFinding::to_owned(&self) -> T
+impl<T> core::any::Any for nika_check::slots::SlotFinding where T: 'static + ?core::marker::Sized
+pub fn nika_check::slots::SlotFinding::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_check::slots::SlotFinding where T: ?core::marker::Sized
+pub fn nika_check::slots::SlotFinding::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_check::slots::SlotFinding where T: ?core::marker::Sized
+pub fn nika_check::slots::SlotFinding::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_check::slots::SlotFinding where T: core::clone::Clone
+pub unsafe fn nika_check::slots::SlotFinding::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_check::slots::SlotFinding
+pub fn nika_check::slots::SlotFinding::from(t: T) -> T
+impl<T> dyn_clone::DynClone for nika_check::slots::SlotFinding where T: core::clone::Clone
+pub fn nika_check::slots::SlotFinding::__clone_box(&self, _: dyn_clone::sealed::Private) -> *mut ()
+impl<T> nika_error::traits::AsAny for nika_check::slots::SlotFinding where T: 'static
+pub fn nika_check::slots::SlotFinding::as_any(&self) -> &(dyn core::any::Any + 'static)
 #[non_exhaustive] pub struct nika_check::TaintTrace
 pub nika_check::TaintTrace::secret: alloc::string::String
 impl nika_check::TaintTrace
@@ -2736,6 +2834,7 @@ impl<T> dyn_clone::DynClone for nika_check::WriteConflict where T: core::clone::
 pub fn nika_check::WriteConflict::__clone_box(&self, _: dyn_clone::sealed::Private) -> *mut ()
 impl<T> nika_error::traits::AsAny for nika_check::WriteConflict where T: 'static
 pub fn nika_check::WriteConflict::as_any(&self) -> &(dyn core::any::Any + 'static)
+pub const nika_check::MARKER_OPEN: &str
 pub const nika_check::PAID_RUN_KINDS: &[&str]
 pub const nika_check::REPORT_VERSION: u32
 pub const nika_check::STATUS_VOCAB: [&str; 4]

--- a/crates/nika-check/src/findings.rs
+++ b/crates/nika-check/src/findings.rs
@@ -273,6 +273,7 @@ pub(super) fn collect(report: &CheckReport) -> Vec<UnifiedFinding> {
     fold_write_conflicts(report, &mut out);
     fold_composition(report, &mut out);
     fold_tools(report, &mut out);
+    fold_slots(report, &mut out);
     for l in &report.schema_lints {
         let mut f = UnifiedFinding::new(
             "schema_lint",
@@ -413,6 +414,23 @@ fn fold_run_decl(report: &CheckReport, out: &mut Vec<UnifiedFinding>) {
         f.code = Some(code.to_owned());
         f.docs_url = Some(format!("{}/{code}", super::ERROR_DOCS_BASE));
         f.task = Some(r.task.clone());
+        out.push(f);
+    }
+}
+
+/// The unfilled-scaffold class (#1066) — report-only by design: no spec
+/// code exists for « you have not written this yet », and a conjured one
+/// would 404. The message names the path, and the render names the line
+/// beside it; the WORDING is the whole point of the class, so it stays
+/// an instruction rather than an accusation.
+fn fold_slots(report: &CheckReport, out: &mut Vec<UnifiedFinding>) {
+    for s in &report.slot_findings {
+        let mut f = UnifiedFinding::new(
+            "slot",
+            "SLOTS",
+            format!("`{}` is still the scaffold's — {}", s.path, s.hint),
+        );
+        f.span = Some(s.span);
         out.push(f);
     }
 }

--- a/crates/nika-check/src/lib.rs
+++ b/crates/nika-check/src/lib.rs
@@ -150,6 +150,7 @@ mod run_decl;
 mod schema_lint;
 mod schema_typing;
 mod secrets;
+pub mod slots;
 mod tools;
 pub mod trifecta;
 mod walk;
@@ -188,6 +189,7 @@ pub use run_decl::RunDeclFinding;
 pub use schema_lint::SchemaLintFinding;
 pub use schema_typing::{SchemaTypeFinding, UnverifiableOutputRef};
 pub use secrets::{SecretEgress, SecretLeak};
+pub use slots::{MARKER_OPEN, SlotFinding};
 pub use tools::{MissingArg, UnknownArg, UnknownTool};
 pub use walk::{static_literal_of, static_read_paths};
 
@@ -467,6 +469,13 @@ pub struct CheckReport {
     /// conditional contracts (`nika:wait`, `nika:fetch`) stay in
     /// `conformance` (the `builtin_shape` ladder) — no double report.
     pub missing_args: Vec<MissingArg>,
+    /// Every value a `nika new` scaffold still expects its author to
+    /// fill (#1066). The marker is a VALUE (`<SLOT: … >`), never a
+    /// comment — the parser drops comments, which is exactly how a
+    /// scaffold used to run green and leave an `output.md` holding its
+    /// own prompt echoed back. A run-blocker, but never worded as a
+    /// fault: the person typed `nika new` and did nothing wrong.
+    pub slot_findings: Vec<SlotFinding>,
     /// Every authored `schema:` defect that makes structured output
     /// unsatisfiable or un-compilable (required∉properties · bad `type`
     /// name · empty `enum`) — the static half of « structured output
@@ -533,6 +542,7 @@ impl CheckReport {
             && self.unknown_args.is_empty()
             && self.missing_args.is_empty()
             && self.schema_lints.is_empty()
+            && self.slot_findings.is_empty()
             && self.gate_findings.is_empty()
             && self.run_decl_findings.is_empty()
             && self.write_conflicts.is_empty()
@@ -779,6 +789,8 @@ pub fn check(wf: &RawWorkflow) -> CheckReport {
         unknown_args: tools::scan_unknown_args(wf),
         missing_args: tools::scan_missing_args(wf),
         schema_lints: schema_lint::scan_schemas(wf),
+        // #1066 — an unfilled scaffold is not yet a workflow.
+        slot_findings: slots::scan(wf),
         // gate reachability shares the IFC gating: a valid wave order or
         // nothing (skipped, never wrong)
         gate_findings: reach::scan_gates(wf, &topo_waves, &edges),

--- a/crates/nika-check/src/slots.rs
+++ b/crates/nika-check/src/slots.rs
@@ -1,0 +1,268 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The unfilled-scaffold class — a skeleton is not yet a workflow.
+//!
+//! `nika new chain` laid ten `# SLOT:` **comments**. The parser drops
+//! comments by construction, so `check` mentioned none of them, the run
+//! exited 0, and `output.md` was left holding the scaffold's own prompt
+//! echoed back by a mock — a file that outlives the terminal line which
+//! explained it (#1066).
+//!
+//! **A comment cannot refuse.** That is the whole finding: the marker
+//! had to descend into the VALUE, where the parser sees it. The form is
+//!
+//! ```yaml
+//! prompt: |
+//!   <SLOT: what should the model do with the gathered text?>
+//! ```
+//!
+//! and the judgment is two-ended by construction — an unfilled scaffold
+//! refuses, a filled file must never trip. A marker is a plain scalar
+//! whose trimmed line opens with `<SLOT:` and closes with `>`; it is
+//! matched per LINE, because a half-filled block scalar that still holds
+//! one marker line would send that line to the model verbatim.
+//!
+//! **Scope, stated rather than implied.** This reads the value surfaces
+//! a scaffold leaves for its author to fill: `model:`, every
+//! `const:`/`inputs:` literal, and every `infer:`/`agent:` `prompt:` and
+//! `system:`. A marker anywhere else is invisible here — which is why
+//! the pack's own family traversal walks every shipped skeleton and
+//! asserts the judge sees every marker they carry, rather than trusting
+//! this list to have stayed wide enough.
+
+use nika_schema::raw::{RawAction, RawWorkflow};
+use nika_schema::types::VarDecl;
+
+use crate::ByteSpan;
+
+/// The opening token of a slot marker. A value, never a comment — the
+/// one non-negotiable of the form (a comment cannot refuse).
+pub const MARKER_OPEN: &str = "<SLOT:";
+
+/// One value a scaffold left for its author.
+///
+/// Not an error in the usual sense: the person typed `nika new` and did
+/// nothing wrong. The render says so — the wording is « ready to be
+/// filled », never « broken » — but it IS a refusal, because a run over
+/// an unfilled scaffold spends money to produce a lie.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+#[non_exhaustive]
+pub struct SlotFinding {
+    /// The dotted path to the value (`tasks.think.infer.prompt`).
+    pub path: String,
+    /// What the scaffold asked for — the marker's own words, so the
+    /// message teaches instead of just pointing.
+    pub hint: String,
+    /// The source range, so the render can name the line.
+    pub span: ByteSpan,
+}
+
+impl SlotFinding {
+    /// Create a slot finding (invariant #19).
+    #[must_use]
+    pub fn new(path: String, hint: String, span: ByteSpan) -> Self {
+        Self { path, hint, span }
+    }
+}
+
+/// The marker's own words when this line is one, `None` otherwise.
+///
+/// Deliberately exact at both ends: `<SLOT:` must OPEN the trimmed line
+/// and `>` must close it. A prompt that merely discusses the convention
+/// (« write `<SLOT: …>` where you want a hole ») is prose, not a hole.
+fn marker_hint(line: &str) -> Option<&str> {
+    let trimmed = line.trim();
+    let inner = trimmed.strip_prefix(MARKER_OPEN)?.strip_suffix('>')?;
+    Some(inner.trim())
+}
+
+/// The first unfilled line of a scalar, if it has one.
+fn unfilled(value: &str) -> Option<&str> {
+    value.lines().find_map(marker_hint)
+}
+
+/// A JSON literal is unfilled when it is a string carrying a marker.
+/// Numbers, bools and structures cannot hold one.
+fn unfilled_json(value: &serde_json::Value) -> Option<&str> {
+    unfilled(value.as_str()?)
+}
+
+fn push(out: &mut Vec<SlotFinding>, path: String, hint: &str, span: nika_schema::Span) {
+    out.push(SlotFinding::new(
+        path,
+        hint.to_owned(),
+        ByteSpan::new(span.start.0, span.end.0),
+    ));
+}
+
+/// The `const:` and `inputs:` literals — where most skeletons put the
+/// author's own subject (`brief` · `query` · `subject` · `goal`).
+fn scan_values(
+    out: &mut Vec<SlotFinding>,
+    block: &str,
+    entries: &[(nika_schema::Spanned<String>, VarDecl)],
+) {
+    for (key, decl) in entries {
+        let literal = match decl {
+            VarDecl::Untyped(v) => Some(v),
+            VarDecl::Typed { default, .. } => default.as_ref(),
+        };
+        if let Some(hint) = literal.and_then(unfilled_json) {
+            push(out, format!("{block}.{}", key.value), hint, key.span);
+        }
+    }
+}
+
+/// The model job — the value whose echo was the artifact in #1066.
+fn scan_action(out: &mut Vec<SlotFinding>, task: &str, action: &RawAction) {
+    let verb = action.verb();
+    let (prompt, system) = match action {
+        RawAction::Infer(a) => (Some(&a.prompt), a.system.as_ref()),
+        RawAction::Agent(a) => (Some(&a.prompt), a.system.as_ref()),
+        // `exec:`/`invoke:` carry argv and tool args, not a model job —
+        // and `RawAction` is `#[non_exhaustive]`, so a fifth verb lands
+        // here silently rather than failing the build. The family
+        // traversal is what would catch a marker this arm cannot see.
+        _ => (None, None),
+    };
+    for (field, scalar) in [("prompt", prompt), ("system", system)] {
+        let Some(scalar) = scalar else { continue };
+        if let Some(hint) = unfilled(&scalar.value) {
+            push(
+                out,
+                format!("tasks.{task}.{verb}.{field}"),
+                hint,
+                scalar.span,
+            );
+        }
+    }
+}
+
+/// Every value this scaffold still expects its author to fill, in source
+/// order — the order the message lists them in, because a person reads
+/// a file top to bottom.
+#[must_use]
+pub fn scan(wf: &RawWorkflow) -> Vec<SlotFinding> {
+    let mut out = Vec::new();
+    if let Some((model, hint)) = wf
+        .model
+        .as_ref()
+        .and_then(|m| Some((m, unfilled(&m.value)?)))
+    {
+        push(&mut out, "model".to_owned(), hint, model.span);
+    }
+    scan_values(&mut out, "inputs", &wf.inputs);
+    scan_values(&mut out, "const", &wf.consts);
+    for task in &wf.tasks {
+        scan_action(&mut out, &task.value.id.value, &task.value.action);
+    }
+    out.sort_by_key(|f| f.span.start);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn slots(yaml: &str) -> Vec<SlotFinding> {
+        let wf = nika_schema::parse(
+            yaml,
+            nika_schema::FileId::new(0),
+            nika_schema::ParseMode::Strict,
+        )
+        .expect("fixture parses");
+        scan(&wf)
+    }
+
+    /// The scaffold's own shape: a marker in the prompt, a marker in a
+    /// const. Both are VALUES — the parser kept them, so the judge sees
+    /// them. This is the half a `# SLOT:` comment could never reach.
+    #[test]
+    fn a_marker_in_a_value_is_found_with_its_path_and_words() {
+        let found = slots(concat!(
+            "nika: draft\n",
+            "model: mock/echo\n",
+            "const:\n",
+            "  brief: \"<SLOT: what should this produce?>\"\n",
+            "tasks:\n",
+            "  think:\n",
+            "    infer:\n",
+            "      prompt: |\n",
+            "        <SLOT: the one model job>\n",
+            "      max_tokens: 10\n",
+        ));
+        let paths: Vec<&str> = found.iter().map(|f| f.path.as_str()).collect();
+        assert_eq!(
+            paths,
+            ["const.brief", "tasks.think.infer.prompt"],
+            "{found:#?}"
+        );
+        assert_eq!(found[0].hint, "what should this produce?");
+        assert_eq!(found[1].hint, "the one model job");
+        // The parser hands these nodes a POSITION, not a range (start ==
+        // end) — enough to name a line, which is what the message owes
+        // its reader. Asserted so the day it widens is a decision.
+        assert_eq!(found[0].span.start, 38, "the `brief` key: {found:#?}");
+        assert_eq!(found[1].span.start, 132, "the `prompt` key: {found:#?}");
+    }
+
+    /// The other end, and the one that matters more: a FILLED file must
+    /// never trip. Proving only the refusal would prove a judge that
+    /// refuses everything.
+    #[test]
+    fn a_filled_file_carries_no_slot() {
+        let found = slots(concat!(
+            "nika: draft\n",
+            "model: mock/echo\n",
+            "const:\n",
+            "  brief: \"summarise the release notes\"\n",
+            "tasks:\n",
+            "  think:\n",
+            "    infer:\n",
+            "      prompt: |\n",
+            "        Summarise this: ${{ const.brief }}\n",
+            "      max_tokens: 10\n",
+        ));
+        assert!(found.is_empty(), "{found:#?}");
+    }
+
+    /// A marker is a whole line, not a substring. A prompt that TEACHES
+    /// the convention is prose — refusing it would make the docs
+    /// unwritable, and « the explanation reproduces the token » is a
+    /// drift class this house has already been bitten by.
+    #[test]
+    fn prose_about_the_marker_is_not_a_marker() {
+        let found = slots(concat!(
+            "nika: doc\n",
+            "model: mock/echo\n",
+            "tasks:\n",
+            "  t:\n",
+            "    infer:\n",
+            "      prompt: |\n",
+            "        Explain that a hole is written <SLOT: like this> inline.\n",
+            "      max_tokens: 10\n",
+        ));
+        assert!(found.is_empty(), "{found:#?}");
+    }
+
+    /// A half-filled block scalar still refuses: the leftover line would
+    /// be sent to the model verbatim, which is the exact hazard the
+    /// chain template's own comment warns about.
+    #[test]
+    fn one_leftover_line_in_a_block_scalar_still_refuses() {
+        let found = slots(concat!(
+            "nika: half\n",
+            "model: mock/echo\n",
+            "tasks:\n",
+            "  t:\n",
+            "    infer:\n",
+            "      prompt: |\n",
+            "        Summarise the document below.\n",
+            "        <SLOT: say how long the summary should be>\n",
+            "      max_tokens: 10\n",
+        ));
+        assert_eq!(found.len(), 1, "{found:#?}");
+        assert_eq!(found[0].hint, "say how long the summary should be");
+    }
+}

--- a/crates/nika-cli-host/src/choice/mod.rs
+++ b/crates/nika-cli-host/src/choice/mod.rs
@@ -20,6 +20,12 @@ const ALIAS: &str = "nika/gear-one";
 const SLOGAN: &str = "Local first. Cloud when you want it.";
 
 /// One barreau of the scale (D-cand-1).
+///
+/// No `next` here. Every rung used to carry its own copy of the same
+/// string, and the JSON mirror served those copies while the TTY
+/// derived a fresh one from the directory — so `rungs[].next` kept
+/// saying `nika new hello` in a folder that already held the file
+/// (#1187). The next step belongs to the SCREEN, not to a rung.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub(crate) struct Rung {
     pub id: String,
@@ -27,7 +33,6 @@ pub(crate) struct Rung {
     pub available: bool,
     pub ready: bool,
     pub reason: String,
-    pub next: String,
 }
 
 /// The cascade — persisté, source unique.
@@ -170,10 +175,6 @@ fn collect_from(machine: &Machine) -> InferenceChoice {
         available: true,
         ready: local_ready,
         reason: local_reason(local_ready, ram, &download),
-        // First door is always the file that runs. Pull is on the rung
-        // reason — putting it in Next made an empty machine download 7 GB
-        // before seeing anything work (gulf of execution).
-        next: "nika new hello".to_owned(),
     };
 
     let cloud = Rung {
@@ -182,7 +183,6 @@ fn collect_from(machine: &Machine) -> InferenceChoice {
         available: false,
         ready: false,
         reason: "our models, our tools, your workflows online".to_owned(),
-        next: String::new(),
     };
 
     // A seat is READY only if a session can actually start on it: the app
@@ -282,7 +282,6 @@ fn harness_rung(seats: &[Seat], ready_seat: Option<&Seat>, in_binary: bool) -> R
             ),
             _ => "Claude Code · Codex · Kimi · Gemini · already on this computer".to_owned(),
         },
-        next: "nika new hello".to_owned(),
     }
 }
 
@@ -306,17 +305,20 @@ fn key_rung(key_row: Option<&KeyRow>) -> Rung {
         ready: key_row.is_some(),
         reason: match key_row {
             Some(k) => format!("{} is set · ready now · billed per run", k.env),
-            None => "a vendor key already on this machine".to_owned(),
+            None => "a vendor key on this computer".to_owned(),
         },
-        next: "nika new hello".to_owned(),
     }
 }
 
+/// Why the local rung reads the way it does.
+///
+/// The RAM used to be repeated here (« this machine has 18 GB ») two
+/// lines under the hardware row that already states it — the same two
+/// words naming three different things on one screen (#1196). The row
+/// above owns the hardware facet; this reason owns the price.
 fn local_reason(ready: bool, ram: Option<u32>, download: &str) -> String {
     match (ready, ram) {
-        (false, Some(gb)) => {
-            format!("ours · free · {download} to pull · this machine has {gb} GB")
-        }
+        (false, Some(_)) => format!("ours · free · {download} to pull"),
         (true, _) | (false, None) => {
             format!("ours · free · runs on this computer · {download}")
         }
@@ -565,16 +567,22 @@ fn on_path(name: &str) -> bool {
 }
 
 impl InferenceChoice {
-    /// Human projection — TTY and pipe render this same product.
+    /// The cascade rendered against the bare directory door — the
+    /// choice-only seam (`Next:` keys on the files in `cwd`, never on
+    /// the crate that compiled the binary · gauntlet P15). The screen
+    /// itself renders through [`Self::render_human_next`]: `welcome`
+    /// knows the sole file's VERDICT, and a verdict outranks a listing.
     #[must_use]
-    pub(crate) fn render_human(&self, theme: Theme) -> String {
-        self.render_human_at(theme, std::env::current_dir().ok().as_deref())
+    #[cfg(test)]
+    pub(crate) fn render_human_at(&self, theme: Theme, cwd: Option<&Path>) -> String {
+        self.render_human_next(theme, &front_door_next(cwd))
     }
 
-    /// Test seam — `Next:` keys on the files in `cwd`, never the crate
-    /// that compiled the binary (gauntlet P15).
+    /// Human projection — TTY and pipe render this same product, and
+    /// so does `--json`: `next` is computed ONCE by the caller and
+    /// handed to every projection (#1187).
     #[must_use]
-    pub(crate) fn render_human_at(&self, theme: Theme, cwd: Option<&Path>) -> String {
+    pub(crate) fn render_human_next(&self, theme: Theme, next: &str) -> String {
         let mut s = String::new();
         let _ = writeln!(s, "{}", theme.paint(Role::Strong, &self.slogan));
         let _ = writeln!(s);
@@ -583,10 +591,15 @@ impl InferenceChoice {
             let _ = writeln!(
                 s,
                 "{}",
+                // « this hardware », not « this machine » — the body's
+                // `this machine` section is the ENVIRONMENT one
+                // (editors · providers · workspace). One name, one
+                // referent: the same two words stood for three things
+                // on this screen (#1196 · the A-06 class in prose).
                 theme.paint(
                     Role::Dim,
                     &format!(
-                        "this machine · {gb} GB · Gear One {} ({})",
+                        "this hardware · {gb} GB · Gear One {} ({})",
                         self.local_tier, self.local_download_gb
                     )
                 )
@@ -609,9 +622,8 @@ impl InferenceChoice {
             let _ = writeln!(s, "{arrow}{name:<22} {}", rung.reason);
         }
         let _ = writeln!(s);
-        let next = front_door_next(cwd);
         let _ = writeln!(s, "Next:");
-        let _ = writeln!(s, "  {}", theme.paint(Role::Strong, &next));
+        let _ = writeln!(s, "  {}", theme.paint(Role::Strong, next));
         let _ = writeln!(s);
         let _ = writeln!(
             s,
@@ -641,14 +653,34 @@ impl InferenceChoice {
     }
 
     /// Versioned welcome envelope fragment.
+    ///
+    /// `next` is the screen's ONE next step, passed in rather than
+    /// derived: an agent reading `rungs[].next` and a human reading
+    /// the `Next:` block must be told the same thing (#1187). Cloud is
+    /// the one rung with no door — it does not ship yet.
     #[must_use]
-    pub(crate) fn welcome_json(&self) -> serde_json::Value {
+    pub(crate) fn welcome_json(&self, next: &str) -> serde_json::Value {
+        let rungs: Vec<serde_json::Value> = self
+            .rungs
+            .iter()
+            .map(|r| {
+                serde_json::json!({
+                    "id": r.id,
+                    "name": r.name,
+                    "available": r.available,
+                    "ready": r.ready,
+                    "reason": r.reason,
+                    "next": if r.id == "cloud" { "" } else { next },
+                })
+            })
+            .collect();
         serde_json::json!({
             "arrow": self.arrow,
+            "next": next,
             "chosen_model": self.chosen_model,
             "chosen_access": self.chosen_access,
             "slogan": self.slogan,
-            "rungs": self.rungs,
+            "rungs": rungs,
         })
     }
 }
@@ -792,10 +824,18 @@ fn first_wow_next(dest: &Path) -> String {
     format!("nika run {}", dest.display())
 }
 
+/// Every shape [`front_door_next`] can return, in the placeholder form
+/// the concierge's parse ratchet replays against the live clap tree.
+///
+/// A hand-written mirror of a function is a lie waiting to happen, so
+/// `door_shapes_mirror_the_real_door` runs the real function against
+/// real directories and proves this list is its exact image.
+pub(crate) const DOOR_SHAPES: [&str; 3] = ["nika new hello", "nika run <file>", "nika run"];
+
 /// `Next:` after the user already has a file. Teaching `nika new hello`
 /// again is a dead end (`exists — pass --force`) — gulf of execution,
 /// and the tool's own advice caused it (gauntlet P15).
-fn front_door_next(cwd: Option<&Path>) -> String {
+pub(crate) fn front_door_next(cwd: Option<&Path>) -> String {
     let Some(dir) = cwd else {
         return "nika new hello".to_owned();
     };

--- a/crates/nika-cli-host/src/choice/tests.rs
+++ b/crates/nika-cli-host/src/choice/tests.rs
@@ -559,7 +559,41 @@ fn next_for_a_ready_harness_is_new_hello() {
     let dir = tempfile::tempdir().expect("tmp");
     let human = choice.render_human_at(Theme::new(false, false, false), Some(dir.path()));
     assert!(human.contains("nika new hello"), "{human}");
-    assert!(human.contains("this machine · 18 GB"), "{human}");
+    // « this hardware », not « this machine »: the mirror body's
+    // `this machine` section is the environment one, and the same two
+    // words named three things on one screen (#1196).
+    assert!(human.contains("this hardware · 18 GB"), "{human}");
+    assert!(!human.contains("this machine"), "{human}");
+}
+
+/// [`DOOR_SHAPES`] is a hand-written mirror of [`front_door_next`], and
+/// a hand-written mirror is a lie waiting to happen — the concierge's
+/// parse ratchet replays it against the live clap tree, so it has to be
+/// the function's exact image. Run the real thing on real directories.
+#[test]
+fn door_shapes_mirror_the_real_door() {
+    let placeholder = |door: String| door.replace("hello.nika.yaml", "<file>");
+    let dir = tempfile::tempdir().expect("tmp");
+    let empty = placeholder(front_door_next(Some(dir.path())));
+    std::fs::write(dir.path().join("hello.nika.yaml"), "nika: hello\n").expect("hello");
+    let one = placeholder(front_door_next(Some(dir.path())));
+    std::fs::write(dir.path().join("a.nika.yaml"), "nika: a\n").expect("a");
+    std::fs::remove_file(dir.path().join("hello.nika.yaml")).expect("drop hello");
+    std::fs::write(dir.path().join("b.nika.yaml"), "nika: b\n").expect("b");
+    let many = placeholder(front_door_next(Some(dir.path())));
+    let measured = [empty, one, many];
+    for shape in DOOR_SHAPES {
+        assert!(
+            measured.iter().any(|m| m == shape),
+            "DOOR_SHAPES claims `{shape}`, the door never says it: {measured:?}"
+        );
+    }
+    for m in &measured {
+        assert!(
+            DOOR_SHAPES.contains(&m.as_str()),
+            "the door says `{m}`, DOOR_SHAPES never lists it"
+        );
+    }
 }
 
 #[test]

--- a/crates/nika-cli-host/src/welcome.rs
+++ b/crates/nika-cli-host/src/welcome.rs
@@ -35,98 +35,39 @@ use crate::door::DoorId;
 use crate::probe::Probe;
 use crate::{output::VerbOutput, probe};
 
-/// The next moves, keyed on where this workspace actually IS — the
-/// concierge hands over ONE key, not the keyring (row 0 carries the
-/// weight; the others stay dim context). Presence-only inputs — EXCEPT
-/// the 1-workflow case, where `gate` carries the exact file's audit
-/// verdict (P0-3): a `run` line is only ever printed for a file the
-/// ladder just saw clean, and a priced model always carries LOI-3's
-/// cap. The multi-workflow case stays generic BY DESIGN — no N-file
-/// audit on a greeting (`welcome --deep` owns the full truth).
-/// Comments stay ≤26 chars: the widest command pads to 45 and the
-/// whole row must live inside 80 columns.
-fn start_moves(glance: Glance, gate: Option<&RunGate>) -> [(String, &'static str); 3] {
-    match (glance.workflows, glance.agents_md) {
-        // P0-4: a TRUNCATED scan that saw zero is unknown, never the
-        // stranger's zero — the concierge leads with the full truth, not
-        // with founding CTAs that presume an empty workspace.
-        (0, _) if !glance.complete => [
-            ("nika welcome --deep".to_owned(), "scan partial · the truth"),
-            ("nika init".to_owned(), "found this repo (wizard)"),
-            DoorId::Discover.row(),
-        ],
-        // The stranger's moment: nothing here yet — see one run, then found.
-        // Only ever reached behind a COMPLETE scan (the arm above).
-        (0, _) => [
-            ("nika try 01-hello".to_owned(), "offline proof · zero keys"),
-            ("nika init".to_owned(), "found this repo (wizard)"),
-            ("nika new".to_owned(), "guided first workflow"),
-        ],
-        // Workflows live here but the agents were never briefed — the
-        // founding wizard skips existing files, so it only ADDS. With
-        // exactly ONE file the dim run line obeys the same P0-3 gate as
-        // the head (the audit is already paid for); with several it
-        // stays generic (no N-file audit on a greeting).
-        (_, false) => [
-            ("nika init".to_owned(), "brief agents · adds only"),
-            // A comment is a promise: `nika run` bare resolves the ONE
-            // workflow, so « your workflow, found » is only true when
-            // there IS one. With several, the bare form exits 3 asking
-            // which — the row says so up front (gauntlet 08-01).
-            gate.map_or_else(
-                || {
-                    if glance.workflows > 1 {
-                        ("nika run <file>".to_owned(), "pick one · check twin")
-                    } else {
-                        ("nika run".to_owned(), "your workflow, found")
-                    }
-                },
-                run_line,
-            ),
-            DoorId::Discover.row(),
-        ],
-        // One workflow, fully founded AND clean: run it (bare — the
-        // lazy door resolves the only workflow and says so).
-        (1, true) => match gate {
-            Some(g) if g.proposable => [
-                run_line(g),
-                ("nika check".to_owned(), "audit before running"),
-                DoorId::Discover.row(),
-            ],
-            // Red — or no verdict at all: the exact file is audited
-            // FIRST (a run CTA here is precisely what P0-3 forbids).
-            _ => [
-                gate.map_or_else(
-                    || ("nika check".to_owned(), "audit before running"),
-                    run_line,
-                ),
-                DoorId::Discover.row(),
-                ("nika welcome --deep".to_owned(), "the workspace truth"),
-            ],
-        },
-        // Several workflows, founded: the whole-workspace lens first.
-        (_, true) => [
-            ("nika welcome --deep".to_owned(), "the workspace truth"),
-            ("nika run <file>".to_owned(), "pick one · check twin"),
-            DoorId::Discover.row(),
-        ],
+/// The ONE next command the first-contact screen promises.
+///
+/// Derived HERE and nowhere else. The screen used to answer twice —
+/// the cascade's `Next:` block keyed on the directory listing, a
+/// `start here` menu eleven lines below keyed on the audited state —
+/// so a stranger was handed two different first steps (#1196), and
+/// `--json` served a third that had never met either fix (#1187).
+///
+/// `door` is the directory's own answer ([`crate::choice::front_door_next`] ·
+/// the cwd key that stopped `nika new hello` being taught into
+/// `--force`, gauntlet P15). Everything below it is a VERDICT
+/// overruling a listing, in the order the old menu ranked them:
+/// P0-3 (a file the ladder has not seen clean is audited, never run),
+/// LOI-3 (a priced run always bears its cap), P0-4 (a truncated walk
+/// may not presume an empty workspace).
+fn next_command(mode: ContextMode, glance: Glance, gate: Option<&RunGate>, door: &str) -> String {
+    if mode == ContextMode::ChatOnly {
+        // No folder to stand in, so no file claim is honest. The
+        // isolated example is the one real answer reachable from here
+        // — and it runs exactly what the sample block just showed.
+        return format!("{} 01-hello", DoorId::Discover.command());
     }
-}
-
-/// The exact-file run line (P0-3 + LOI-3): a red file gets
-/// `check <path>`; a clean priced file gets the cap placeholder on the
-/// command, always; a clean unpriced file gets the bare lazy-door run
-/// (unpriced is UNKNOWN, never worded « free »).
-fn run_line(g: &RunGate) -> (String, &'static str) {
-    if !g.proposable {
-        (format!("nika check {}", g.path), "red · audit before run")
-    } else if g.priced {
-        (
-            "nika run --max-cost-usd <usd>".to_owned(),
-            "priced model · cap it",
-        )
-    } else {
-        ("nika run".to_owned(), "your workflow, found")
+    match gate {
+        // P0-3 — the sole file is red: audit it, never run it.
+        Some(g) if !g.proposable => format!("nika check {}", g.path),
+        // LOI-3 — a priced run suggestion carries the cap, always.
+        Some(g) if g.priced && door.starts_with("nika run") => {
+            format!("{door} --max-cost-usd <usd>")
+        }
+        // P0-4 — a walk that died before it finished cannot hand out a
+        // founding CTA that presumes an empty workspace.
+        _ if !glance.complete && door.starts_with("nika new") => "nika welcome --deep".to_owned(),
+        _ => door.to_owned(),
     }
 }
 
@@ -279,151 +220,143 @@ pub fn first_wow_dest(dest: Option<&str>) -> &str {
 
 #[must_use]
 pub fn run(json: bool, theme: Theme) -> VerbOutput {
-    let choice = crate::choice::collect();
     let candidate = std::env::current_dir().ok();
     if json {
-        let out = run_in(true, theme, candidate.as_deref());
-        return merge_choice_json(out, &choice);
+        return VerbOutput::ok(front_door_json(candidate.as_deref()));
     }
-    let facts = EnvFacts {
-        evidence: candidate
-            .as_deref()
-            .map_or(EvidenceSource::None, |_| EvidenceSource::ExplicitCwd),
-        ..EnvFacts::detect()
-    };
-    let envelope = context_envelope::resolve(candidate.as_deref(), &facts);
-    crate::metrics::record_if_enabled(
-        crate::metrics::EventKind::ContextResolved,
-        crate::metrics::Facts {
-            session: Some(match envelope.mode {
-                ContextMode::ChatOnly => crate::metrics::Session::ChatOnly,
-                ContextMode::Workspace => crate::metrics::Session::Workspace,
-            }),
-            ..crate::metrics::Facts::none()
-        },
-    );
-    crate::metrics::record_if_enabled(
-        crate::metrics::EventKind::CtaImpression,
-        crate::metrics::Facts {
-            cta: Some(crate::metrics::Cta::Create),
-            ..crate::metrics::Facts::none()
-        },
-    );
-    // The seat cascade is the screen's HEAD — which model this machine can
-    // reach, and the one next command. The mirror body still follows it: a
-    // stranger has to SEE what a workflow looks like, and the sample block
-    // is the only place that shows it. Rendering the cascade alone made
-    // `render_with_context` unreachable and silently dropped that block
-    // (#1195) — the envelope was resolved and the metrics recorded, then
-    // the body was thrown away.
-    let body = run_in(false, theme, candidate.as_deref());
     VerbOutput::ok(crate::display::vocab::sober(
         theme,
-        &format!("{}\n{}", choice.render_human(theme), body.text),
+        &screen(candidate.as_deref(), theme),
     ))
 }
 
-fn merge_choice_json(mut out: VerbOutput, choice: &crate::choice::InferenceChoice) -> VerbOutput {
-    if let Ok(mut v) = serde_json::from_str::<serde_json::Value>(&out.text) {
-        v["inference_choice"] = choice.welcome_json();
-        out.text = v.to_string();
-    }
-    out
+/// The composed first-contact screen — the seat cascade (identity ·
+/// the rungs · the ONE `Next:`), then the mirror body (this machine ·
+/// this binary · the sample). Rendering the cascade alone made
+/// `render_with_context` unreachable and silently dropped the sample
+/// block (#1195); rendering the body's old `start here` menu after it
+/// put the fork back (#1196). The head promises; the body informs.
+fn screen(candidate: Option<&Path>, theme: Theme) -> String {
+    let choice = crate::choice::collect();
+    let mirror = Mirror::collect(candidate);
+    let next = mirror.next(candidate);
+    mirror.record_session();
+    record_impression(&next);
+    format!(
+        "{}\n{}",
+        choice.render_human_next(theme, &next),
+        mirror.render_body(theme)
+    )
 }
 
-/// The envelope-first verb body (P0-14 binary-side): resolve the session
-/// context from the candidate the surface named, then branch — chat-only
-/// renders the truth and the spec's two doors, workspace renders the
-/// mirror rooted at the RESOLVED folder. The process cwd is never
-/// consulted here: `None` in, chat-only out.
-fn run_in(json: bool, theme: Theme, candidate: Option<&Path>) -> VerbOutput {
-    let facts = EnvFacts {
-        evidence: candidate.map_or(EvidenceSource::None, |_| EvidenceSource::ExplicitCwd),
-        ..EnvFacts::detect()
-    };
-    let envelope = context_envelope::resolve(candidate, &facts);
-    let probe = probe::collect(false);
-    let counts = EngineCounts {
-        builtins: nika_builtin::tool_defs().len(),
-        locals: probe.providers.iter().filter(|p| !p.requires_key).count(),
-        clouds: probe.providers.iter().filter(|p| p.requires_key).count(),
-        examples: nika_pack::example_slugs().len(),
-        templates: nika_pack::template_names().len(),
-    };
-    if envelope.mode == ContextMode::ChatOnly {
-        // No reliable folder evidence: NO walk, NO gate, NO workspace
-        // claim — the mirror says « chat only » and routes to the two
-        // doors the spec allows (an isolated example · a chosen project).
-        let ctx = ContextView {
-            mode: ContextMode::ChatOnly,
-            ..ContextView::legacy()
+/// The machine front door — the same screen, the same ONE next step.
+fn front_door_json(candidate: Option<&Path>) -> String {
+    let choice = crate::choice::collect();
+    let mirror = Mirror::collect(candidate);
+    let next = mirror.next(candidate);
+    let mut v = mirror.render_json(&next);
+    v["inference_choice"] = choice.welcome_json(&next);
+    v.to_string()
+}
+
+/// Everything the mirror knows about this session, collected ONCE.
+///
+/// The envelope-first order (P0-14 binary-side): resolve the session
+/// context from the candidate the surface named, then walk and audit
+/// the RESOLVED folder. The process cwd is never consulted here:
+/// `None` in, chat-only out — no walk, no gate, no workspace claim.
+struct Mirror {
+    probe: Probe,
+    envelope: ContextEnvelope,
+    counts: EngineCounts,
+    glance: Glance,
+    /// P0-3: the ONE file's verdict, audited before any run line may
+    /// name it. Only ever `Some` behind a complete walk that saw
+    /// exactly one workflow.
+    gate: Option<RunGate>,
+    ctx: ContextView,
+}
+
+impl Mirror {
+    fn collect(candidate: Option<&Path>) -> Self {
+        let facts = EnvFacts {
+            evidence: candidate.map_or(EvidenceSource::None, |_| EvidenceSource::ExplicitCwd),
+            ..EnvFacts::detect()
         };
-        if json {
-            let experience = experience_block(&probe, &envelope, CHAT_ONLY_GLANCE, None);
-            return VerbOutput::ok(render_chat_only_json(&probe, counts, experience));
+        let envelope = context_envelope::resolve(candidate, &facts);
+        let probe = probe::collect(false);
+        let counts = EngineCounts {
+            builtins: nika_builtin::tool_defs().len(),
+            locals: probe.providers.iter().filter(|p| !p.requires_key).count(),
+            clouds: probe.providers.iter().filter(|p| p.requires_key).count(),
+            examples: nika_pack::example_slugs().len(),
+            templates: nika_pack::template_names().len(),
+        };
+        if envelope.mode == ContextMode::ChatOnly {
+            return Self {
+                probe,
+                envelope,
+                counts,
+                glance: CHAT_ONLY_GLANCE,
+                gate: None,
+                ctx: ContextView {
+                    mode: ContextMode::ChatOnly,
+                    ..ContextView::legacy()
+                },
+            };
         }
+        let root = envelope.project_root.clone();
+        let (glance, sole) = glance(&root, 4000);
+        let gate = sole.as_deref().map(|rel| run_gate(&root, rel));
+        let ctx = ContextView {
+            mode: ContextMode::Workspace,
+            root: root_label(&envelope),
+            expanded_from: envelope.evidence.expanded_from.clone(),
+        };
+        Self {
+            probe,
+            envelope,
+            counts,
+            glance,
+            gate,
+            ctx,
+        }
+    }
+
+    /// The screen's ONE next step — the directory's own door, overruled
+    /// by whatever verdict this mirror already paid for.
+    fn next(&self, candidate: Option<&Path>) -> String {
+        let door = crate::choice::front_door_next(candidate);
+        next_command(self.ctx.mode, self.glance, self.gate.as_ref(), &door)
+    }
+
+    fn render_body(&self, theme: Theme) -> String {
+        render_with_context(&self.probe, self.glance, self.counts, &self.ctx, theme)
+    }
+
+    fn render_json(&self, next: &str) -> serde_json::Value {
+        let experience =
+            experience_block(&self.probe, &self.envelope, self.glance, self.gate.as_ref());
+        if self.ctx.mode == ContextMode::ChatOnly {
+            return render_chat_only_json(&self.probe, self.counts, experience, next);
+        }
+        render_json(&self.probe, self.glance, self.counts, experience, next)
+    }
+
+    fn record_session(&self) {
         crate::metrics::record_if_enabled(
             crate::metrics::EventKind::ContextResolved,
             crate::metrics::Facts {
-                session: Some(crate::metrics::Session::ChatOnly),
-                ..crate::metrics::Facts::none()
-            },
-        );
-        let cmds: [String; 3] = chat_only_moves().map(|(cmd, _)| cmd);
-        record_impressions(&cmds);
-        return VerbOutput::ok(crate::display::vocab::sober(
-            theme,
-            &render_with_context(&probe, CHAT_ONLY_GLANCE, None, counts, &ctx, theme),
-        ));
-    }
-    // Workspace: the walk + the gate run on the VALIDATED candidate (the
-    // envelope's project root), never on a process-cwd guess.
-    let root = envelope.project_root.clone();
-    let (glance, sole) = glance(&root, 4000);
-    // P0-3: the ONE file is audited before any run line may name it.
-    let gate = sole.as_deref().map(|rel| run_gate(&root, rel));
-    let ctx = ContextView {
-        mode: ContextMode::Workspace,
-        root: root_label(&envelope),
-        expanded_from: envelope.evidence.expanded_from.clone(),
-    };
-    if json {
-        let experience = experience_block(&probe, &envelope, glance, gate.as_ref());
-        return VerbOutput::ok(render_json(
-            &probe,
-            glance,
-            gate.as_ref(),
-            counts,
-            experience,
-        ));
-    }
-    crate::metrics::record_if_enabled(
-        crate::metrics::EventKind::ContextResolved,
-        crate::metrics::Facts {
-            session: Some(crate::metrics::Session::Workspace),
-            flag: Some(envelope.evidence.expanded_from.is_some()),
-            ..crate::metrics::Facts::none()
-        },
-    );
-    let moves = start_moves(glance, gate.as_ref());
-    let cmds: [String; 3] = [0, 1, 2].map(|i| moves[i].0.clone());
-    record_impressions(&cmds);
-    // The hand-off the audit measures: the concierge LEADS with a run
-    // line (only ever on an audited-clean file — P0-3) → the run is
-    // back in human hands.
-    if cmds.first().is_some_and(|cmd| cmd.starts_with("nika run")) {
-        crate::metrics::record_if_enabled(
-            crate::metrics::EventKind::HumanRunHandoff,
-            crate::metrics::Facts {
-                handoff: Some(crate::metrics::Handoff::WelcomeCta),
+                session: Some(match self.ctx.mode {
+                    ContextMode::ChatOnly => crate::metrics::Session::ChatOnly,
+                    ContextMode::Workspace => crate::metrics::Session::Workspace,
+                }),
+                flag: (self.ctx.mode == ContextMode::Workspace)
+                    .then(|| self.envelope.evidence.expanded_from.is_some()),
                 ..crate::metrics::Facts::none()
             },
         );
     }
-    VerbOutput::ok(crate::display::vocab::sober(
-        theme,
-        &render_with_context(&probe, glance, gate.as_ref(), counts, &ctx, theme),
-    ))
 }
 
 /// The concierge's CTA classes (W8 metrics): found (`init` · `new`) ·
@@ -438,14 +371,27 @@ fn cta_class(cmd: &str) -> crate::metrics::Cta {
     }
 }
 
-/// One `cta_impression` per move the mirror shows — the content-free
-/// half of the click-through the W8 audit wants measured.
-fn record_impressions<S: AsRef<str>>(moves: &[S]) {
-    for cmd in moves {
+/// The `cta_impression` for the ONE move the mirror shows — the
+/// content-free half of the click-through the W8 audit wants measured.
+/// It used to fire three times because the screen offered three
+/// commands; a metric that counts more CTAs than the screen carries is
+/// a metric about a screen nobody sees.
+fn record_impression(next: &str) {
+    crate::metrics::record_if_enabled(
+        crate::metrics::EventKind::CtaImpression,
+        crate::metrics::Facts {
+            cta: Some(cta_class(next)),
+            ..crate::metrics::Facts::none()
+        },
+    );
+    // The hand-off the audit measures: the concierge points at a run
+    // (only ever on an audited-clean file — P0-3) → the run is back in
+    // human hands.
+    if next.starts_with("nika run") {
         crate::metrics::record_if_enabled(
-            crate::metrics::EventKind::CtaImpression,
+            crate::metrics::EventKind::HumanRunHandoff,
             crate::metrics::Facts {
-                cta: Some(cta_class(cmd.as_ref())),
+                handoff: Some(crate::metrics::Handoff::WelcomeCta),
                 ..crate::metrics::Facts::none()
             },
         );
@@ -543,26 +489,19 @@ tasks:
     infer: { prompt: "say hello to the operator", max_tokens: 50 }"#;
 
 /// The human mirror — sections: identity · this machine · this binary ·
-/// (the language, first time only) · start here · learn. This legacy
-/// entry is the TEST seam: it carries NO envelope view (an empty root),
-/// so the pre-envelope render tests stay byte-identical; `run_in`
+/// (the language, first time only) · learn. This legacy entry is the
+/// TEST seam: it carries NO envelope view (an empty root), so the
+/// pre-envelope render tests stay byte-identical; [`Mirror::render_body`]
 /// renders through [`render_with_context`] with the resolved envelope.
 #[cfg(test)]
-fn render_human(
-    probe: &Probe,
-    glance: Glance,
-    gate: Option<&RunGate>,
-    counts: EngineCounts,
-    theme: Theme,
-) -> String {
-    render_with_context(probe, glance, gate, counts, &ContextView::legacy(), theme)
+fn render_human(probe: &Probe, glance: Glance, counts: EngineCounts, theme: Theme) -> String {
+    render_with_context(probe, glance, counts, &ContextView::legacy(), theme)
 }
 
 /// The envelope-aware mirror — the one `run_in` renders with.
 fn render_with_context(
     probe: &Probe,
     glance: Glance,
-    gate: Option<&RunGate>,
     counts: EngineCounts,
     ctx: &ContextView,
     theme: Theme,
@@ -571,7 +510,7 @@ fn render_with_context(
     identity_section(&mut s, probe, theme);
     machine_section(&mut s, probe, glance, ctx, theme);
     binary_section(&mut s, counts, glance, ctx, theme);
-    start_section(&mut s, theme, glance, gate, ctx);
+    learn_line(&mut s, theme);
     s
 }
 
@@ -803,8 +742,10 @@ fn sovereign_and_keys_lines(
             ),
         );
     }
+    // `session_row` closes the section with its own blank line — a
+    // second one here rendered two, and the screen is meant to be the
+    // short one (#1196).
     session_row(s, glance, ctx, theme);
-    let _ = writeln!(s);
 }
 
 /// The P0-14 row closing the machine section: chat-only SAYS « chat
@@ -920,127 +861,77 @@ fn binary_section(
     }
 }
 
-/// The chat-only doors (the spec's two: an isolated example · choosing a
-/// project) plus the corpus — ONE source: the render and the W8
-/// impression journal read the same moves (a drift between what is shown
-/// and what is measured would make the metric a lie).
-fn chat_only_moves() -> [(String, &'static str); 3] {
-    [
-        ("nika try 01-hello".to_owned(), "isolated · zero keys"),
-        (
-            "cd <project> && nika welcome".to_owned(),
-            "choose a project first",
-        ),
-        DoorId::Discover.row(),
-    ]
-}
-
-/// Every command the concierge can ever teach, across every workspace
-/// state — the parse-ratchet surface. The `nika-cli` unit replays each
-/// one against the live clap tree, so a door rename (the 0.107
-/// `examples` → `try` move that welcome kept teaching) breaks a test
-/// before it can break a paste. Placeholders (`<file>` · `<usd>` ·
-/// `<project>`) are the operator's slots; the ratchet fills them.
+/// Every command the concierge can ever teach — the parse-ratchet
+/// surface. The `nika-cli` unit replays each one against the live clap
+/// tree, so a door rename (the 0.107 `examples` → `try` move that
+/// welcome kept teaching) breaks a test before it can break a paste.
+/// Placeholders (`<file>` · `<usd>`) are the operator's slots; the
+/// ratchet fills them.
+///
+/// Two families, and both are DERIVED, never listed: the ONE next step
+/// over every state that can produce a different one, and the dim
+/// routes the mirror body hangs off its own facts.
 #[must_use]
 pub fn taught_start_commands() -> Vec<String> {
     let gates = [
         None,
         Some(RunGate {
-            path: "wf.nika.yaml".to_owned(),
+            path: "<file>".to_owned(),
             proposable: false,
             priced: false,
         }),
         Some(RunGate {
-            path: "wf.nika.yaml".to_owned(),
+            path: "<file>".to_owned(),
             proposable: true,
             priced: false,
         }),
         Some(RunGate {
-            path: "wf.nika.yaml".to_owned(),
+            path: "<file>".to_owned(),
             proposable: true,
             priced: true,
         }),
     ];
     let mut commands: Vec<String> = Vec::new();
-    for workflows in [0usize, 1, 3] {
-        for agents_md in [false, true] {
-            for complete in [false, true] {
-                let glance = Glance {
-                    git: true,
-                    workflows,
-                    agents_md,
-                    complete,
-                };
-                for gate in &gates {
-                    for (command, _) in start_moves(glance, gate.as_ref()) {
-                        if !commands.contains(&command) {
-                            commands.push(command);
-                        }
-                    }
+    let mut push = |command: String| {
+        if !commands.contains(&command) {
+            commands.push(command);
+        }
+    };
+    for mode in [ContextMode::ChatOnly, ContextMode::Workspace] {
+        for complete in [false, true] {
+            let glance = Glance {
+                complete,
+                ..CHAT_ONLY_GLANCE
+            };
+            for gate in &gates {
+                for door in crate::choice::DOOR_SHAPES {
+                    push(next_command(mode, glance, gate.as_ref(), door));
                 }
             }
         }
     }
-    for (command, _) in chat_only_moves() {
-        if !commands.contains(&command) {
-            commands.push(command);
-        }
-    }
-    for command in [
-        "nika new",
-        "nika new hello",
-        "nika run",
-        "nika check",
+    // The routes that hang off a named gap in the body — each one
+    // repairs the fact it sits beside, and each one is a paste.
+    for route in [
+        "nika init",
+        "nika wire cursor",
+        "nika model list",
         "nika doctor",
+        "nika doctor --ping",
+        "nika try 01-hello",
     ] {
-        if !commands.iter().any(|c| c == command) {
-            commands.push((*command).to_owned());
-        }
+        push(route.to_owned());
     }
     commands
 }
 
-/// The hand-off — the state's own three moves, then where to learn more.
-/// Chat-only keys on no workspace at all: the two doors the spec allows
-/// (an isolated example · choosing a project) plus the corpus.
-fn start_section(
-    s: &mut String,
-    theme: Theme,
-    glance: Glance,
-    gate: Option<&RunGate>,
-    ctx: &ContextView,
-) {
-    let _ = writeln!(
-        s,
-        "{}",
-        theme.paint(Role::Strong, "start here (offline · zero keys)")
-    );
-    let moves = if ctx.mode == ContextMode::ChatOnly {
-        chat_only_moves()
-    } else {
-        start_moves(glance, gate)
-    };
-    let width = moves
-        .iter()
-        .map(|(cmd, _)| cmd.chars().count())
-        .max()
-        .unwrap_or(0);
-    // The gh/bun law (2026 survey): exactly ONE next command carries the
-    // maximum visual weight — the first row is the thing to run NOW, the
-    // other two stay plain (a journey, not a menu of equals).
-    for (i, (cmd, why)) in moves.iter().enumerate() {
-        let painted = if i == 0 {
-            theme.paint(Role::Strong, &format!("{cmd:<width$}"))
-        } else {
-            format!("{cmd:<width$}")
-        };
-        let _ = writeln!(
-            s,
-            "  {painted}   {}",
-            theme.paint(Role::Dim, &format!("# {why}"))
-        );
-    }
-    let _ = writeln!(s);
+/// Where to learn more — the tail of the body.
+///
+/// This used to sit under a `start here` menu of three commands. The
+/// cascade above already carries the ONE next step, and that menu was
+/// precisely what the first-wow cascade replaced: keeping both put the
+/// fork back in front of a stranger (#1196).
+fn learn_line(s: &mut String, theme: Theme) {
     let _ = writeln!(
         s,
         "{}",
@@ -1174,12 +1065,10 @@ fn experience_block(
 fn render_json(
     probe: &Probe,
     glance: Glance,
-    gate: Option<&RunGate>,
     counts: EngineCounts,
     experience: serde_json::Value,
-) -> String {
-    let moves = start_moves(glance, gate);
-    let start: Vec<&str> = moves.iter().map(|(cmd, _)| cmd.as_str()).collect();
+    next: &str,
+) -> serde_json::Value {
     let mut machine = probe::environment_json(probe);
     machine["config"] = serde_json::json!(probe.config_path);
     let mut v = serde_json::json!({
@@ -1200,10 +1089,16 @@ fn render_json(
             "examples": counts.examples,
             "templates": counts.templates,
         },
-        "start": start,
+        // ONE next step, the same string the `Next:` block prints. It
+        // was a three-command array that had met neither the cascade
+        // nor the cwd key — an agent reading `start[0]` on 0.115 was
+        // handed the retired door (#1187). `start` stays an array so a
+        // consumer indexing it still works; it just tells the truth now.
+        "next": next,
+        "start": [next],
     });
     v["experience"] = experience;
-    v.to_string()
+    v
 }
 
 /// The chat-only machine mirror — the SAME versioned envelope, minus
@@ -1214,7 +1109,8 @@ fn render_chat_only_json(
     probe: &Probe,
     counts: EngineCounts,
     experience: serde_json::Value,
-) -> String {
+    next: &str,
+) -> serde_json::Value {
     let mut machine = probe::environment_json(probe);
     machine["config"] = serde_json::json!(probe.config_path);
     let mut v = serde_json::json!({
@@ -1230,16 +1126,14 @@ fn render_chat_only_json(
             "examples": counts.examples,
             "templates": counts.templates,
         },
-        // ONE source with the rendered text (the W8 law): the JSON
-        // mirror derives from `chat_only_moves()`, never a hand-kept
-        // twin array — two lists of the same moves drift.
-        "start": chat_only_moves()
-            .iter()
-            .map(|(cmd, _)| cmd.clone())
-            .collect::<Vec<String>>(),
+        // ONE source with the rendered text (the W8 law): the machine
+        // mirror is handed the same string the `Next:` block prints,
+        // never a hand-kept twin — two lists of the same moves drift.
+        "next": next,
+        "start": [next],
     });
     v["experience"] = experience;
-    v.to_string()
+    v
 }
 
 #[cfg(test)]

--- a/crates/nika-cli-host/src/welcome/tests.rs
+++ b/crates/nika-cli-host/src/welcome/tests.rs
@@ -102,32 +102,161 @@ fn plain() -> Theme {
     Theme::new(false, false, false)
 }
 
-/// The concierge hands over ONE key per state — the four states each
-/// lead with their own move. The 1-workflow-founded state is keyed on
-/// the file's VERDICT too (P0-3): the clean gate below is what keeps
-/// `run` eligible at all.
+/// The concierge hands over ONE key — and a VERDICT outranks the
+/// directory listing that produced the door. The four arms of
+/// [`next_command`], each keyed on the fact that earns it.
 #[test]
-fn start_moves_key_on_the_workspace_state() {
-    let g = |workflows, agents_md| Glance {
+fn the_one_next_lets_a_verdict_overrule_the_listing() {
+    let complete = Glance {
         git: true,
-        workflows,
-        agents_md,
+        workflows: 1,
+        agents_md: true,
         complete: true,
     };
-    let clean = RunGate {
-        path: "a.nika.yaml".to_owned(),
-        proposable: true,
-        priced: false,
+    let partial = Glance {
+        complete: false,
+        ..complete
     };
-    assert!(start_moves(g(0, false), None)[0].0.contains("try 01-hello"));
-    assert_eq!(start_moves(g(2, false), None)[0].0, "nika init");
-    // FLIP (P0-3 · audit UX 2026-07-30): this line pinned « 1 workflow
-    // + AGENTS.md → nika run head » with NO verdict — the finding's
-    // exact reproduction. `run` now leads ONLY behind a clean gate;
-    // the red and priced arms are pinned by the scratch-dir tests
-    // (one_red_workflow_gets_check_never_run · the LOI-3 twins).
-    assert_eq!(start_moves(g(1, true), Some(&clean))[0].0, "nika run");
-    assert_eq!(start_moves(g(5, true), None)[0].0, "nika welcome --deep");
+    let gate = |proposable, priced| RunGate {
+        path: "a.nika.yaml".to_owned(),
+        proposable,
+        priced,
+    };
+    let ws = ContextMode::Workspace;
+    // No verdict to overrule it: the door stands as the listing wrote it.
+    assert_eq!(
+        next_command(ws, complete, None, "nika run a.nika.yaml"),
+        "nika run a.nika.yaml"
+    );
+    // P0-3 — red outranks everything, and names the exact file.
+    assert_eq!(
+        next_command(
+            ws,
+            complete,
+            Some(&gate(false, false)),
+            "nika run a.nika.yaml"
+        ),
+        "nika check a.nika.yaml"
+    );
+    // LOI-3 — a clean PRICED file still runs, capped.
+    assert_eq!(
+        next_command(
+            ws,
+            complete,
+            Some(&gate(true, true)),
+            "nika run a.nika.yaml"
+        ),
+        "nika run a.nika.yaml --max-cost-usd <usd>"
+    );
+    // …and an unpriced one carries no placeholder to fill.
+    assert_eq!(
+        next_command(
+            ws,
+            complete,
+            Some(&gate(true, false)),
+            "nika run a.nika.yaml"
+        ),
+        "nika run a.nika.yaml"
+    );
+    // P0-4 — a walk that died may not hand out a founding CTA.
+    assert_eq!(
+        next_command(ws, partial, None, "nika new hello"),
+        "nika welcome --deep"
+    );
+    // …but it may still point at a file it can SEE in this directory.
+    assert_eq!(
+        next_command(ws, partial, None, "nika run a.nika.yaml"),
+        "nika run a.nika.yaml"
+    );
+    // Chat-only claims no folder at all: the isolated example is the
+    // one real answer reachable without one.
+    assert_eq!(
+        next_command(
+            ContextMode::ChatOnly,
+            complete,
+            None,
+            "nika run a.nika.yaml"
+        ),
+        "nika try 01-hello"
+    );
+}
+
+/// The law the whole screen exists to obey (#1196): a stranger is
+/// offered ONE first command, never a fork. Dim routes that repair a
+/// NAMED gap (`… → nika init`) sit inside their own fact and are not
+/// first commands; the sample's `nika: hello` is a workflow id.
+#[test]
+fn the_first_contact_screen_promises_exactly_one_first_command() {
+    let dir = tempfile::tempdir().expect("scratch");
+    let text = screen(Some(dir.path()), plain());
+    let offers: Vec<&str> = text.lines().filter(|l| offers_a_command(l)).collect();
+    assert_eq!(
+        offers.len(),
+        1,
+        "the screen promises exactly one first command, got {offers:?}:\n{text}"
+    );
+    assert_eq!(offers[0].trim(), "nika new hello", "{text}");
+    assert!(
+        !text.contains("start here"),
+        "the menu the cascade replaced is gone:\n{text}"
+    );
+    // The same two words named three things on this screen — the
+    // hardware row, a rung's reason, and a section heading.
+    assert_eq!(
+        text.matches("this machine").count(),
+        1,
+        "one name, one referent:\n{text}"
+    );
+    // The hardware row only renders where the RAM could be measured;
+    // where it does, it names its own facet instead of borrowing the
+    // section's two words.
+    if let Some(row) = text.lines().find(|l| l.contains("Gear One ")) {
+        assert!(row.contains("this hardware ·"), "{row}");
+    }
+}
+
+/// An indented line whose FIRST token is the command — the shape of an
+/// offer. `→ nika wire cursor` hangs off a fact; `nika: hello` is YAML.
+fn offers_a_command(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    trimmed.len() < line.len() && trimmed.starts_with("nika ")
+}
+
+/// #1187 — the two renderers of one screen. An agent reads `--json`, a
+/// human reads the block; they must be told the same thing, in an
+/// empty directory AND in one that already holds the file.
+#[test]
+fn the_json_front_door_answers_the_same_next_as_the_screen() {
+    let dir = tempfile::tempdir().expect("scratch");
+    let read_next = |raw: &str| -> serde_json::Value {
+        serde_json::from_str::<serde_json::Value>(raw).expect("json")
+    };
+    for expected in ["nika new hello", "nika run hello.nika.yaml"] {
+        let text = screen(Some(dir.path()), plain());
+        let block = text.split("Next:").nth(1).expect("a Next: block");
+        assert!(
+            block.lines().any(|l| l.trim() == expected),
+            "the human block says `{expected}`:\n{text}"
+        );
+        let v = read_next(&front_door_json(Some(dir.path())));
+        assert_eq!(v["next"], expected, "{v}");
+        assert_eq!(v["start"][0], expected, "{v}");
+        assert_eq!(v["start"].as_array().map(Vec::len), Some(1), "{v}");
+        for rung in v["inference_choice"]["rungs"]
+            .as_array()
+            .expect("rungs")
+            .iter()
+            .filter(|r| r["id"] != "cloud")
+        {
+            assert_eq!(
+                rung["next"], expected,
+                "a rung must not teach a door the screen retired: {rung}"
+            );
+        }
+        // …now write the file the first door told us to, and go round
+        // again: a second `nika new hello` dies on `--force` (P15).
+        std::fs::write(dir.path().join("hello.nika.yaml"), CLEAN_WORKFLOW).expect("seed");
+    }
 }
 
 /// A scratch workspace on disk (auto-cleaned) — the run-CTA tests
@@ -144,11 +273,15 @@ fn scratch(files: &[(&str, &str)]) -> tempfile::TempDir {
 /// conformance finding — the file parses, the ladder refuses it.
 const RED_WORKFLOW: &str = "nika: bad\ntasks:\n  a:\n    exec: { command: [\"echo\", \"x\"] }\n  b:\n    after:\n      a: success\n    when: maybe\n    exec: { command: [\"echo\", \"y\"] }\n";
 
-/// P0-3 (audit UX 2026-07-30) — one RED workflow, agents briefed:
-/// the concierge must NEVER carry a `nika run` CTA (head or dim)
-/// for a file the ladder has not seen clean; the head is
-/// `nika check <the exact file>`. Human and JSON both eat from
-/// `start_moves`, and the JSON projection is asserted too.
+/// A file the ladder sees clean, on a model that costs nothing.
+const CLEAN_WORKFLOW: &str =
+    "nika: hello\nmodel: mock/echo\ntasks:\n  a:\n    infer: { prompt: \"x\", max_tokens: 10 }\n";
+
+/// P0-3 (audit UX 2026-07-30) — one RED workflow, agents briefed: the
+/// concierge must NEVER carry a `nika run` CTA for a file the ladder
+/// has not seen clean; the ONE next step is `nika check <the exact
+/// file>`. The screen and the machine mirror are asserted together —
+/// that they could disagree at all was #1187.
 #[test]
 fn one_red_workflow_gets_check_never_run() {
     let dir = scratch(&[("AGENTS.md", "x"), ("bad.nika.yaml", RED_WORKFLOW)]);
@@ -160,25 +293,18 @@ fn one_red_workflow_gets_check_never_run() {
         !gate.as_ref().expect("a gate for the sole file").proposable,
         "the `when: maybe` fixture is RED for real"
     );
-    let moves = start_moves(g, gate.as_ref());
-    assert_eq!(
-        moves[0].0, "nika check bad.nika.yaml",
-        "a red file is audited, never run: {moves:?}"
+    let text = screen(Some(dir.path()), plain());
+    assert!(
+        text.contains("nika check bad.nika.yaml"),
+        "a red file is audited, never run:\n{text}"
     );
-    for (cmd, _) in &moves {
-        assert!(
-            !cmd.starts_with("nika run"),
-            "no run CTA while the exact file is red: {moves:?}"
-        );
-    }
-    let raw = render_json(
-        &synthetic_probe(),
-        g,
-        gate.as_ref(),
-        counts(),
-        serde_json::Value::Null,
+    assert!(
+        !text.contains("nika run"),
+        "no run CTA while the exact file is red:\n{text}"
     );
+    let raw = front_door_json(Some(dir.path()));
     let v: serde_json::Value = serde_json::from_str(&raw).expect("json");
+    assert_eq!(v["next"], "nika check bad.nika.yaml", "{raw}");
     assert_eq!(v["start"][0], "nika check bad.nika.yaml", "{raw}");
     assert!(
         !raw.contains("nika run"),
@@ -187,18 +313,12 @@ fn one_red_workflow_gets_check_never_run() {
 }
 
 /// The twin that must NOT regress: one CLEAN unpriced workflow
-/// (mock/echo) keeps the bare `nika run` head — and the wording
-/// never calls an unpriced model « free » (LOI-3: unknown stays
-/// unknown, it is merely uncapped by law's absence of a price).
+/// (mock/echo) keeps the `nika run` next step — and the wording never
+/// calls an unpriced model « free » (LOI-3: unknown stays unknown, it
+/// is merely uncapped by the absence of a price).
 #[test]
 fn one_clean_mock_workflow_keeps_the_run_cta_uncapped() {
-    let dir = scratch(&[
-        ("AGENTS.md", "x"),
-        (
-            "good.nika.yaml",
-            "nika: good\nmodel: mock/echo\ntasks:\n  a:\n    infer: { prompt: \"x\", max_tokens: 10 }\n",
-        ),
-    ]);
+    let dir = scratch(&[("AGENTS.md", "x"), ("good.nika.yaml", CLEAN_WORKFLOW)]);
     let (g, sole) = glance(dir.path(), 4000);
     assert_eq!(g.workflows, 1);
     let gate = sole.as_deref().map(|rel| run_gate(dir.path(), rel));
@@ -207,21 +327,19 @@ fn one_clean_mock_workflow_keeps_the_run_cta_uncapped() {
         gate.proposable && !gate.priced,
         "mock/echo: clean, unpriced"
     );
-    let moves = start_moves(g, Some(&gate));
-    assert_eq!(
-        moves[0].0, "nika run",
-        "clean + unpriced → run leads: {moves:?}"
-    );
-    for (cmd, _) in &moves {
-        assert!(
-            !cmd.contains("--max-cost-usd"),
-            "an unpriced model carries no cap placeholder: {moves:?}"
-        );
-    }
-    let text = render_human(&synthetic_probe(), g, Some(&gate), counts(), plain());
+    let text = screen(Some(dir.path()), plain());
     assert!(
-        !text.contains("free"),
-        "unpriced is never « free »:\n{text}"
+        text.contains("nika run good.nika.yaml"),
+        "clean + unpriced → the file runs:\n{text}"
+    );
+    assert!(
+        !text.contains("--max-cost-usd"),
+        "an unpriced model carries no cap placeholder:\n{text}"
+    );
+    let body = render_human(&synthetic_probe(), g, counts(), plain());
+    assert!(
+        !body.contains("free"),
+        "unpriced is never « free »:\n{body}"
     );
 }
 
@@ -242,14 +360,16 @@ fn one_clean_priced_workflow_carries_the_loi3_cap() {
     let gate = sole.as_deref().map(|rel| run_gate(dir.path(), rel));
     let gate = gate.expect("a gate for the sole file");
     assert!(gate.proposable && gate.priced, "openai/*: clean, priced");
-    let moves = start_moves(g, Some(&gate));
+    let raw = front_door_json(Some(dir.path()));
+    let v: serde_json::Value = serde_json::from_str(&raw).expect("json");
+    let next = v["next"].as_str().unwrap_or_default();
     assert!(
-        moves[0].0.starts_with("nika run"),
-        "a clean priced file still runs head-first: {moves:?}"
+        next.starts_with("nika run"),
+        "a clean priced file still runs: {raw}"
     );
     assert!(
-        moves[0].0.contains("--max-cost-usd"),
-        "LOI-3: a priced run CTA carries the cap: {moves:?}"
+        next.contains("--max-cost-usd"),
+        "LOI-3: a priced run CTA carries the cap: {raw}"
     );
 }
 
@@ -265,7 +385,7 @@ fn mirror_shows_pulled_models_and_stays_silent_at_zero() {
         agents_md: false,
         complete: true,
     };
-    let silent = render_human(&synthetic_probe(), glance, None, counts(), plain());
+    let silent = render_human(&synthetic_probe(), glance, counts(), plain());
     assert!(
         !silent.contains("  models"),
         "zero models = zero line:\n{silent}"
@@ -274,7 +394,7 @@ fn mirror_shows_pulled_models_and_stays_silent_at_zero() {
     let mut probe = synthetic_probe();
     probe.models.count = 2;
     probe.models.bytes = 211 * 1024 * 1024;
-    let shown = render_human(&probe, glance, None, counts(), plain());
+    let shown = render_human(&probe, glance, counts(), plain());
     assert!(
         shown.contains("models     2 pulled · 211.0 MiB on disk"),
         "the sovereign lane is in the mirror:\n{shown}"
@@ -295,7 +415,7 @@ fn mirror_names_an_endpoint_override_and_stays_silent_on_loopback() {
         agents_md: false,
         complete: true,
     };
-    let silent = render_human(&synthetic_probe(), glance, None, counts(), plain());
+    let silent = render_human(&synthetic_probe(), glance, counts(), plain());
     assert!(
         !silent.contains("  endpoint"),
         "loopback = no endpoint line:\n{silent}"
@@ -304,7 +424,7 @@ fn mirror_names_an_endpoint_override_and_stays_silent_on_loopback() {
     let mut probe = synthetic_probe();
     probe.providers[0].endpoint = "http://gpu.lan:11434".to_owned();
     probe.providers[0].readiness.execution_locus = ExecutionLocus::Lan;
-    let shown = render_human(&probe, glance, None, counts(), plain());
+    let shown = render_human(&probe, glance, counts(), plain());
     assert!(
         shown.contains("ollama → http://gpu.lan:11434 (lan)"),
         "the override is NAMED next to the local row:\n{shown}"
@@ -332,7 +452,7 @@ fn mirror_names_kit_drift_and_stays_silent_when_aligned() {
         agents_md: false,
         complete: true,
     };
-    let silent = render_human(&synthetic_probe(), glance, None, counts(), plain());
+    let silent = render_human(&synthetic_probe(), glance, counts(), plain());
     assert!(!silent.contains("  kits"), "no kits = no line:\n{silent}");
 
     let mut probe = synthetic_probe();
@@ -346,7 +466,7 @@ fn mirror_names_kit_drift_and_stays_silent_when_aligned() {
             version: "0.105.0".to_owned(), // another train — drift
         },
     ];
-    let shown = render_human(&probe, glance, None, counts(), plain());
+    let shown = render_human(&probe, glance, counts(), plain());
     // The verdict moved to the hanging line when the drifted list grew
     // past the right edge (three kits + the version + the handle
     // measured 100 columns), so the two halves are asserted apart.
@@ -374,7 +494,7 @@ fn the_mirror_greets_each_adoption_rung_with_its_own_cta() {
         complete: true,
     };
     // KeyPresent — the stock synthetic machine (anthropic keyed).
-    let keyed = render_human(&synthetic_probe(), glance, None, counts(), plain());
+    let keyed = render_human(&synthetic_probe(), glance, counts(), plain());
     assert!(
         keyed.contains("state      key present · 1 of 2 clouds configured — ready for a real run"),
         "KeyPresent renders its own line:\n{keyed}"
@@ -386,7 +506,7 @@ fn the_mirror_greets_each_adoption_rung_with_its_own_cta() {
     let mut bare = synthetic_probe();
     bare.providers[2].key_present = false;
     bare.providers[2].readiness.configured = false;
-    let installed = render_human(&bare, glance, None, counts(), plain());
+    let installed = render_human(&bare, glance, counts(), plain());
     assert!(
         installed.contains("state      installed · no inference path — proof → nika try 01-hello"),
         "Installed routes to the offline proof:\n{installed}"
@@ -396,7 +516,7 @@ fn the_mirror_greets_each_adoption_rung_with_its_own_cta() {
     let mut lan = bare.clone();
     lan.providers[0].endpoint = "http://gpu.lan:11434".to_owned();
     lan.providers[0].readiness.execution_locus = ExecutionLocus::Lan;
-    let detected = render_human(&lan, glance, None, counts(), plain());
+    let detected = render_human(&lan, glance, counts(), plain());
     assert!(
         detected
             .contains("state      ollama detected · unproven — start it, then nika doctor --ping"),
@@ -410,7 +530,7 @@ fn the_mirror_greets_each_adoption_rung_with_its_own_cta() {
         "127.0.0.1:11434".to_owned(),
         PingState::Reachable(3),
     )];
-    let reachable = render_human(&pinged, glance, None, counts(), plain());
+    let reachable = render_human(&pinged, glance, counts(), plain());
     assert!(
         reachable.contains("state      local reachable · ollama (3ms) — point a run at it"),
         "LocalReachable carries the measured round-trip:\n{reachable}"
@@ -420,7 +540,7 @@ fn the_mirror_greets_each_adoption_rung_with_its_own_cta() {
     // « path configured »: the journal proves runs, never the model.
     let mut real = synthetic_probe();
     real.recorded_runs = 2;
-    let ready = render_human(&real, glance, None, counts(), plain());
+    let ready = render_human(&real, glance, counts(), plain());
     assert!(
         ready.contains("state      real-ready · 2 runs on record · path configured — nika run"),
         "RealReady claims the record, never « a real model answered »:\n{ready}"
@@ -448,7 +568,6 @@ fn human_mirror_carries_the_four_sections_and_no_key_names() {
             agents_md: false,
             complete: true,
         },
-        None,
         counts(),
         plain(),
     );
@@ -456,7 +575,6 @@ fn human_mirror_carries_the_four_sections_and_no_key_names() {
         "Intent as Code",
         "this machine",
         "this binary",
-        "start here",
         "hash-chained",
         "cursor ✓",
         "vscode ✗",
@@ -467,10 +585,6 @@ fn human_mirror_carries_the_four_sections_and_no_key_names() {
         "state      key present · 1 of 2 clouds configured",
         "ready for a real run",
         "not briefed → nika init",
-        // 2 workflows + unbriefed → the ONE key is the founding wizard
-        // (adds only); the stranger's mock/echo line belongs to the
-        // 0-workflow state (pinned in start_moves' own test below).
-        "brief agents · adds only",
         "learn: nika.sh",
         "github.com/supernovae-st/nika",
     ] {
@@ -595,7 +709,6 @@ fn the_stranger_sees_the_language_and_it_fits_eighty_columns() {
             agents_md: false,
             complete: true,
         },
-        None,
         EngineCounts {
             builtins: 25,
             locals: 5,
@@ -635,7 +748,6 @@ fn ascii_theme_swaps_every_glyph() {
             agents_md: true,
             complete: true,
         },
-        None,
         counts(),
         Theme::new(false, true, false),
     );
@@ -732,7 +844,7 @@ fn the_experience_block_routes_from_the_concierge_facts() {
 
 #[test]
 fn json_mirror_is_versioned_additive_and_value_free() {
-    let raw = render_json(
+    let v = render_json(
         &synthetic_probe(),
         Glance {
             git: false,
@@ -740,11 +852,11 @@ fn json_mirror_is_versioned_additive_and_value_free() {
             agents_md: true,
             complete: true,
         },
-        None,
         counts(),
         serde_json::Value::Null,
+        "nika new hello",
     );
-    let v: serde_json::Value = serde_json::from_str(&raw).expect("welcome --json parses");
+    let raw = v.to_string();
     assert_eq!(v["welcome_version"], 1);
     assert_eq!(v["machine"]["cloud_keys_present"], 1);
     assert_eq!(v["machine"]["cloud_keys_total"], 2);
@@ -752,7 +864,10 @@ fn json_mirror_is_versioned_additive_and_value_free() {
     assert_eq!(v["workspace"]["workflows"], 0);
     assert_eq!(v["workspace"]["inventory_complete"], true);
     assert_eq!(v["engine"]["verbs"], 4);
-    assert_eq!(v["start"].as_array().map(Vec::len), Some(3));
+    // ONE next step, and `start` is its one-element projection — the
+    // three-command array was the pre-cascade menu (#1187).
+    assert_eq!(v["next"], "nika new hello");
+    assert_eq!(v["start"].as_array().map(Vec::len), Some(1));
     assert!(
         !raw.contains("API_KEY") && !raw.contains("key_present"),
         "the JSON mirror carries counts, never per-key facts: {raw}"
@@ -771,7 +886,7 @@ fn a_partial_scan_never_renders_the_strangers_zero() {
         agents_md: false,
         complete: false,
     };
-    let text = render_human(&synthetic_probe(), g, None, counts(), plain());
+    let text = render_human(&synthetic_probe(), g, counts(), plain());
     assert!(
         !text.contains("no workflows yet"),
         "a partial scan is unknown, never « zero »:\n{text}"
@@ -784,17 +899,16 @@ fn a_partial_scan_never_renders_the_strangers_zero() {
         !text.contains("a whole workflow is one file"),
         "the sample is the COMPLETE stranger's moment only:\n{text}"
     );
-    let raw = render_json(
+    let v = render_json(
         &synthetic_probe(),
         g,
-        None,
         counts(),
         serde_json::Value::Null,
+        "nika welcome --deep",
     );
-    let v: serde_json::Value = serde_json::from_str(&raw).expect("json");
     assert_eq!(
         v["workspace"]["inventory_complete"], false,
-        "the machine mirror carries the scan's completeness: {raw}"
+        "the machine mirror carries the scan's completeness: {v}"
     );
 }
 
@@ -841,44 +955,35 @@ fn glance_counts_workflows_skips_heavy_dirs_and_sees_git() {
 
 /// P0-14 binary-side (W2): candidate `None` → chat-only. The mirror
 /// SAYS it and makes zero workspace claim — no workspace row, no
-/// inventory count, no agents line — and routes to the two doors the
-/// spec allows (an isolated example · choosing a project).
+/// inventory count, no agents line — and its one next step is the door
+/// that needs no folder (the isolated example).
 #[test]
 fn chat_only_says_so_and_claims_no_workspace() {
-    let out = run_in(false, plain(), None);
-    assert_eq!(out.code, exit::OK, "{}", out.text);
+    let mirror = Mirror::collect(None);
+    let body = mirror.render_body(plain());
     assert!(
-        out.text
-            .contains("chat only — no reliable project detected"),
-        "chat-only says so:\n{}",
-        out.text
+        body.contains("chat only — no reliable project detected"),
+        "chat-only says so:\n{body}"
     );
     assert!(
-        !out.text.contains("  workspace"),
-        "no workspace row in chat-only:\n{}",
-        out.text
+        !body.contains("  workspace"),
+        "no workspace row in chat-only:\n{body}"
     );
     assert!(
-        !out.text.contains("workflows") && !out.text.contains("agents"),
-        "no workspace inventory claim in chat-only:\n{}",
-        out.text
+        !body.contains("workflows") && !body.contains("agents"),
+        "no workspace inventory claim in chat-only:\n{body}"
     );
-    assert!(
-        out.text.contains("isolated") && out.text.contains("choose a project"),
-        "the two chat-only doors are named:\n{}",
-        out.text
+    let next = mirror.next(None);
+    assert_eq!(
+        next, "nika try 01-hello",
+        "the one door that needs no folder"
     );
-    let json = run_in(true, plain(), None);
-    assert_eq!(json.code, exit::OK, "{}", json.text);
+    let json = mirror.render_json(&next);
+    assert_eq!(json["context"]["mode"], "chat_only", "{json}");
+    assert_eq!(json["next"], next, "{json}");
     assert!(
-        json.text.contains("\"chat_only\""),
-        "the machine mirror carries the mode: {}",
-        json.text
-    );
-    assert!(
-        !json.text.contains("\"workspace\""),
-        "no workspace projection in chat-only: {}",
-        json.text
+        !json.to_string().contains("\"workspace\""),
+        "no workspace projection in chat-only: {json}"
     );
 }
 
@@ -891,12 +996,10 @@ fn workspace_names_the_root_and_traces_the_subdir_expansion() {
     std::fs::create_dir(dir.path().join(".git")).expect("mkdir .git");
     let deep = dir.path().join("crates").join("nika-cli");
     std::fs::create_dir_all(&deep).expect("mkdir deep");
-    let out = run_in(false, plain(), Some(&deep));
-    assert_eq!(out.code, exit::OK, "{}", out.text);
+    let body = Mirror::collect(Some(&deep)).render_body(plain());
     let root = dir.path().canonicalize().expect("canon root");
     let deep_canon = deep.canonicalize().expect("canon deep");
-    let row = out
-        .text
+    let row = body
         .lines()
         .skip_while(|l| !l.contains("  workspace"))
         .take(3)
@@ -954,7 +1057,6 @@ fn the_editor_roster_wraps_instead_of_running_off_the_terminal() {
             agents_md: false,
             complete: true,
         },
-        None,
         EngineCounts {
             builtins: 25,
             locals: 5,

--- a/crates/nika-cli/tests/pack_templates_family.rs
+++ b/crates/nika-cli/tests/pack_templates_family.rs
@@ -38,12 +38,109 @@ fn scratch_dir(tag: &str) -> std::path::PathBuf {
     dir
 }
 
-/// Lay one template down on disk, alone, the way `nika new` hands it over.
+/// Lay one template down on disk, alone, the way `nika new` hands it
+/// over — with its `<SLOT: …>` markers still in place.
+fn plant_as_shipped(dir: &std::path::Path, name: &str) -> String {
+    let body = nika_pack::template(name).unwrap_or_else(|| panic!("pack carries `{name}`"));
+    write_at(dir, name, body)
+}
+
+/// The same skeleton with its slots answered — what an author holds a
+/// minute later, and the state every claim below about auditing and
+/// running is about.
 fn plant(dir: &std::path::Path, name: &str) -> String {
     let body = nika_pack::template(name).unwrap_or_else(|| panic!("pack carries `{name}`"));
+    write_at(dir, name, &fill_slots(body))
+}
+
+fn write_at(dir: &std::path::Path, name: &str, body: &str) -> String {
     let path = dir.join(format!("{name}.nika.yaml"));
     std::fs::write(&path, body).expect("write template");
     path.to_str().expect("utf8 path").to_owned()
+}
+
+/// Answer every slot with one plain sentence.
+///
+/// Works on the SOURCE, so it has to close on the first `>` after the
+/// opener rather than on a trimmed line ending — a quoted marker
+/// (`query: "<SLOT: …>"`) closes before the quote.
+fn fill_slots(body: &str) -> String {
+    let mut out = body.to_owned();
+    while let Some(open) = out.find(nika_check::MARKER_OPEN) {
+        let Some(rel) = out[open..].find('>') else {
+            break;
+        };
+        out.replace_range(open..=open + rel, "answered by the family traversal");
+    }
+    out
+}
+
+/// Every `<SLOT:` a template carries in VALUE position — a marker
+/// inside a comment is prose about the convention, not a hole.
+fn markers_in(body: &str) -> usize {
+    body.lines()
+        .filter(
+            |line| match (line.find(nika_check::MARKER_OPEN), line.find('#')) {
+                (Some(slot), Some(hash)) => slot < hash,
+                (Some(_), None) => true,
+                (None, _) => false,
+            },
+        )
+        .count()
+}
+
+/// #1066 — an unfilled scaffold is not yet a workflow, so it refuses
+/// BEFORE the spend, and it refuses for every marker it carries.
+///
+/// The second half is the one that keeps the judge honest. `nika-check`
+/// reads a NAMED set of value surfaces (`model:`, the `const:`/`inputs:`
+/// literals, the `infer:`/`agent:` prompts) — a narrow probe returns a
+/// clean result, so nothing but a count taken from the skeletons
+/// themselves can prove the judge stayed as wide as the pack.
+#[test]
+fn an_unfilled_template_refuses_and_the_judge_sees_every_marker() {
+    let dir = scratch_dir("slots");
+    let mut marked: Vec<String> = Vec::new();
+    for name in &nika_pack::template_names() {
+        let body = nika_pack::template(name).unwrap_or_else(|| panic!("pack carries `{name}`"));
+        let laid = markers_in(body);
+        let path = plant_as_shipped(&dir, name);
+        let parsed = nika_schema::parse(
+            body,
+            nika_schema::FileId::new(0),
+            nika_schema::ParseMode::Strict,
+        )
+        .unwrap_or_else(|e| panic!("`{name}` parses as shipped: {e}"));
+        let report = nika_check::check(&parsed);
+        assert_eq!(
+            report.slot_findings.len(),
+            laid,
+            "`{name}` lays {laid} marker(s) and the judge sees {} — a marker the judge \
+             cannot reach is a hole that ships silently",
+            report.slot_findings.len()
+        );
+        if laid == 0 {
+            continue;
+        }
+        marked.push(name.clone());
+        let out = check::run(&path, false, false, None, PLAIN);
+        assert_ne!(
+            out.code,
+            exit::OK,
+            "`{name}` carries {laid} unfilled slot(s) — it must refuse before the spend:\n{}",
+            out.text
+        );
+        assert!(
+            out.text.contains("ready to be filled"),
+            "the refusal is an invitation, not an accusation (`{name}`):\n{}",
+            out.text
+        );
+    }
+    assert!(
+        !marked.is_empty(),
+        "no skeleton carries a slot — a traversal that proves nothing about \
+         the class it exists for"
+    );
 }
 
 #[test]
@@ -58,7 +155,8 @@ fn every_shipped_template_audits() {
         assert_eq!(
             out.code,
             exit::OK,
-            "`{name}` is a skeleton a stranger is handed — it audits or it does not ship:\n{}",
+            "`{name}` is a skeleton a stranger is handed — once its slots are \
+             answered it audits, or it does not ship:\n{}",
             out.text
         );
     }

--- a/crates/nika-display/src/check_render.rs
+++ b/crates/nika-display/src/check_render.rs
@@ -149,6 +149,10 @@ pub fn render(
             .map(|l| format!("task `{}` at {} — {}", l.task, l.path, l.detail))
             .collect(),
     );
+    // #1066 — an unfilled scaffold is not yet a workflow. Placed
+    // before the security rungs: what to do next outranks what a
+    // half-written file's boundary would have been.
+    slots::slots_rung(&mut out, report, source, path, t);
     section_or_skip(
         &mut out,
         report,
@@ -1462,6 +1466,7 @@ fn loopback_declassification_lines(out: &mut String, wf: &RawWorkflow, t: Theme)
 }
 mod footer;
 mod permits_glance;
+mod slots;
 use footer::hints_and_verdict;
 
 #[cfg(test)]

--- a/crates/nika-display/src/check_render/footer.rs
+++ b/crates/nika-display/src/check_render/footer.rs
@@ -82,6 +82,12 @@ pub(super) fn hints_and_verdict(
             " {}",
             audited_line(report, wf, distinct_identities.len(), hint_sites, grade, t)
         );
+    } else if unfilled_scaffold(report) {
+        // No NEXT after it: the SLOTS rung already ended on the one
+        // command, and `nika explain` has nothing to say about a value
+        // nobody wrote (the class is report-only — a code would 404).
+        scaffold_verdict(out, report, t);
+        return;
     } else {
         // Through `mark()`, not a hardcoded glyph: this line shipped a
         // literal `✖` and was the one verdict in the report that leaked
@@ -96,6 +102,37 @@ pub(super) fn hints_and_verdict(
         );
     }
     render_next(out, report, path, repair_target, hint_sites, t);
+}
+
+/// The verdict for a scaffold whose only finding is its own unfilled
+/// slots (#1066 constraint 4).
+///
+/// `✖ findings above` would tell someone who typed `nika new` thirty
+/// seconds ago that they broke a file they never wrote. The run still
+/// refuses — the exit code is untouched — only the wording matches what
+/// actually happened.
+fn scaffold_verdict(out: &mut String, report: &CheckReport, t: Theme) {
+    let n = report.slot_findings.len();
+    let slots = if n == 1 { "slot" } else { "slots" };
+    let _ = writeln!(
+        out,
+        " {} {}",
+        t.paint(Role::Warn, if t.ascii { ".." } else { "…" }),
+        t.paint(
+            Role::Warn,
+            &format!("not a workflow yet — {n} {slots} to fill, then it audits")
+        )
+    );
+}
+
+/// Whether the ONLY thing standing between this file and a green audit
+/// is its own unfilled slots.
+///
+/// Deliberately narrow: a scaffold that ALSO escapes its permits or
+/// leaks a secret gets the ordinary refusal, because those are real
+/// faults and softening them would be the lie in the other direction.
+fn unfilled_scaffold(report: &CheckReport) -> bool {
+    !report.slot_findings.is_empty() && report.findings.iter().all(|f| f.kind == "slot")
 }
 
 /// The ONE next command, when the report left anything to say.

--- a/crates/nika-display/src/check_render/slots.rs
+++ b/crates/nika-display/src/check_render/slots.rs
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The SLOTS rung — a scaffold saying which values are still its own.
+//!
+//! This rung blocks the run, and it must not read like a fault. The
+//! person typed `nika new` thirty seconds ago and did nothing wrong;
+//! the file is simply not finished. So it wears the `Warn` face rather
+//! than the `Bad` one, opens on « ready to be filled », names every slot
+//! with its LINE (« some slots are empty » would send someone hunting),
+//! and closes on one pasteable command.
+//!
+//! Silent when there is nothing to fill — a rung with no information is
+//! a lecture (the `SKILLS` precedent).
+
+use std::fmt::Write as _;
+
+use nika_check::CheckReport;
+
+use crate::theme::{Role, Theme};
+
+/// The 1-based line a byte offset falls on.
+fn line_of(source: &str, offset: u32) -> usize {
+    let cut = source.len().min(offset as usize);
+    source
+        .get(..cut)
+        .map_or(1, |head| head.matches('\n').count() + 1)
+}
+
+/// Render the rung. `path` is played back verbatim in the closing
+/// command so the line is a paste, not a template to fill in by hand.
+pub(crate) fn slots_rung(
+    out: &mut String,
+    report: &CheckReport,
+    source: &str,
+    path: &str,
+    t: Theme,
+) {
+    let slots = &report.slot_findings;
+    if slots.is_empty() {
+        return;
+    }
+    let glyph = t.paint(Role::Warn, if t.ascii { ".." } else { "…" });
+    let n = slots.len();
+    let plural = if n == 1 { "value is" } else { "values are" };
+    let _ = writeln!(
+        out,
+        " {} {} {}",
+        glyph,
+        t.paint(Role::Strong, &format!("{:<8}", "SLOTS")),
+        format_args!("your file is ready to be filled — {n} {plural} still the scaffold's")
+    );
+    for s in slots {
+        let _ = writeln!(
+            out,
+            "   {}  {} {}",
+            t.paint(
+                Role::Dim,
+                &format!("line {:>4}", line_of(source, s.span.start))
+            ),
+            s.path,
+            t.paint(Role::Dim, &format!("· {}", s.hint))
+        );
+    }
+    let _ = writeln!(
+        out,
+        "   {}",
+        t.paint(Role::Dim, &format!("fill them, then: nika check {path}"))
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PLAIN: Theme = Theme::new(false, false, false);
+
+    fn report(yaml: &str) -> CheckReport {
+        nika_check::check(
+            &nika_schema::parse(
+                yaml,
+                nika_schema::FileId::new(0),
+                nika_schema::ParseMode::Strict,
+            )
+            .expect("fixture parses"),
+        )
+    }
+
+    const SCAFFOLD: &str = concat!(
+        "nika: draft\n",
+        "model: mock/echo\n",
+        "permits: {}\n",
+        "tasks:\n",
+        "  think:\n",
+        "    infer:\n",
+        "      prompt: |\n",
+        "        <SLOT: the one model job>\n",
+        "      max_tokens: 10\n",
+    );
+
+    /// Constraint 3 of the ruling: the message names WHICH slot, on
+    /// WHICH line, and ends on one command. « some slots are empty »
+    /// would make a person hunt through their own file.
+    #[test]
+    fn the_rung_names_each_slot_its_line_and_one_command() {
+        let mut out = String::new();
+        slots_rung(
+            &mut out,
+            &report(SCAFFOLD),
+            SCAFFOLD,
+            "first.nika.yaml",
+            PLAIN,
+        );
+        assert!(out.contains("SLOTS"), "{out}");
+        assert!(
+            out.contains("line    8"),
+            "the marker sits on line 8:\n{out}"
+        );
+        assert!(out.contains("tasks.think.infer.prompt"), "{out}");
+        assert!(
+            out.contains("the one model job"),
+            "the marker teaches:\n{out}"
+        );
+        assert!(
+            out.contains("fill them, then: nika check first.nika.yaml"),
+            "one pasteable command, naming their file:\n{out}"
+        );
+    }
+
+    /// Constraint 4: it must not read as a fault. The person just typed
+    /// `nika new`. The rung blocks the run — it does not scold.
+    #[test]
+    fn the_rung_reads_as_a_step_not_a_failure() {
+        let mut out = String::new();
+        slots_rung(
+            &mut out,
+            &report(SCAFFOLD),
+            SCAFFOLD,
+            "first.nika.yaml",
+            PLAIN,
+        );
+        assert!(out.contains("ready to be filled"), "{out}");
+        for scold in ["✖", "error", "invalid", "broken", "failed"] {
+            assert!(
+                !out.to_lowercase().contains(scold),
+                "`{scold}` turns a step into a fault:\n{out}"
+            );
+        }
+    }
+
+    /// A rung with nothing to say says nothing — the SKILLS precedent.
+    #[test]
+    fn a_filled_file_gets_no_rung_at_all() {
+        let filled = SCAFFOLD.replace("<SLOT: the one model job>", "Summarise the release notes.");
+        let mut out = String::new();
+        slots_rung(
+            &mut out,
+            &report(&filled),
+            &filled,
+            "first.nika.yaml",
+            PLAIN,
+        );
+        assert!(out.is_empty(), "{out}");
+    }
+
+    /// The line arithmetic, at both ends of the file.
+    #[test]
+    fn line_of_counts_from_one() {
+        assert_eq!(line_of("a\nb\nc", 0), 1);
+        assert_eq!(line_of("a\nb\nc", 2), 2);
+        assert_eq!(line_of("a\nb\nc", 4), 3);
+        assert_eq!(line_of("a\nb\nc", 9_999), 3, "past the end clamps");
+    }
+}

--- a/crates/nika-onboard/src/guided/tests.rs
+++ b/crates/nika-onboard/src/guided/tests.rs
@@ -464,6 +464,7 @@ fn every_embedded_template_audits_clean_or_is_a_documented_gap() {
     // a genuine flow-model design gap is documented here.
     const KNOWN_GAP: &[&str] = &[];
     let mut clean = 0_usize;
+    let mut invitations = 0_usize;
     for name in nika_pack::template_names() {
         let body = nika_pack::template(&name).expect("template embedded");
         let parsed = nika_schema::parse(
@@ -474,12 +475,23 @@ fn every_embedded_template_audits_clean_or_is_a_documented_gap() {
         assert!(parsed.is_ok(), "{name}: template must parse: {parsed:?}");
         let wf = parsed.expect("asserted ok above");
         let is_gap = KNOWN_GAP.contains(&name.as_str());
-        if nika_check::check(&wf).is_clean() {
+        let report = nika_check::check(&wf);
+        // #1066 amended the own-corpus law rather than retiring it. A
+        // fresh skeleton may refuse for its OWN unfilled slots — that
+        // refusal is the invitation to fill them, and it is why a
+        // scaffold can no longer run and leave a file that reads like a
+        // result. It may refuse for nothing else: a permits escape or a
+        // dangling reference in a shipped template still fails here.
+        let invitation =
+            !report.slot_findings.is_empty() && report.findings.iter().all(|f| f.kind == "slot");
+        if report.is_clean() {
             assert!(
                 !is_gap,
                 "{name}: now audits CLEAN — remove it from KNOWN_GAP, the design gap is resolved"
             );
             clean += 1;
+        } else if invitation {
+            invitations += 1;
         } else {
             assert!(
                 is_gap,
@@ -488,7 +500,19 @@ fn every_embedded_template_audits_clean_or_is_a_documented_gap() {
             );
         }
     }
-    assert!(clean >= 8, "expected >= 8 clean templates, got {clean}");
+    // Every shipped skeleton is one of the two healthy states, and both
+    // states are populated — a floor on `clean` alone would go quietly
+    // green on a pack where every template had become a form.
+    assert_eq!(
+        clean + invitations,
+        nika_pack::template_names().len() - KNOWN_GAP.len(),
+        "clean {clean} · invitations {invitations}"
+    );
+    assert!(clean >= 5, "expected >= 5 clean templates, got {clean}");
+    assert!(
+        invitations >= 1,
+        "no skeleton invites its author to fill it"
+    );
 }
 
 #[test]

--- a/crates/nika-onboard/src/recipes.rs
+++ b/crates/nika-onboard/src/recipes.rs
@@ -326,9 +326,16 @@ mod tests {
                     nika_schema::ParseMode::Strict,
                 )
                 .expect("recipe scaffold parses");
+                // The own-corpus law as #1066 amended it: a fresh
+                // scaffold may refuse for its OWN unfilled slots (the
+                // invitation to fill them) and for nothing else.
+                let report = nika_check::check(&wf);
                 assert!(
-                    nika_check::check(&wf).is_clean(),
-                    "{path}: a fresh recipe scaffold FAILS its own audit (own-corpus law)"
+                    report.is_clean()
+                        || report.findings.iter().all(|f| f.kind == "slot")
+                            && !report.slot_findings.is_empty(),
+                    "{path}: a fresh recipe scaffold FAILS its own audit for something \
+                     other than its unfilled slots (own-corpus law)"
                 );
             }
             std::fs::remove_dir_all(&dir).ok();

--- a/crates/nika-pack/pack/templates/agent-loop.nika.yaml
+++ b/crates/nika-pack/pack/templates/agent-loop.nika.yaml
@@ -39,7 +39,7 @@ inputs:
     # A `required:` input still carries a `default:` here so the skeleton
     # RUNS the moment it is scaffolded. Replace the default with your job;
     # `--var goal=…` overrides it at any time.
-    default: "list the risks of running an agent without a turn budget"   # SLOT
+    default: "<SLOT: what the agent must accomplish>"
     description: "What the agent must accomplish"   # SLOT
 
 permits:                            # the blast radius · default-deny once present

--- a/crates/nika-pack/pack/templates/chain.nika.yaml
+++ b/crates/nika-pack/pack/templates/chain.nika.yaml
@@ -63,12 +63,12 @@ tasks:
       gather: ${{ tasks.gather.output }}
     infer:
       max_tokens: 800               # SLOT: the spend ceiling · sized for the SEAT, not the answer
-      # SLOT: the one model job. Keep slot markers OUT of the block below —
-      # everything indented under `prompt: |` is prompt TEXT, so a stray
-      # `# SLOT:` line is sent to the model verbatim (visible in the mock
-      # echo). Comments belong out here, where YAML eats them.
+      # The marker below is a VALUE, not a comment. The parser drops
+      # comments, so a `# SLOT:` line could never make `check` refuse —
+      # which is how an unfilled scaffold ran green and left a file that
+      # read like a result (#1066). Replace the line, keep the binding.
       prompt: |
-        Summarize the following in a short paragraph.
+        <SLOT: what should the model do with the gathered text?>
 
         ${{ with.gather }}
 

--- a/crates/nika-pack/pack/templates/classify-and-route.nika.yaml
+++ b/crates/nika-pack/pack/templates/classify-and-route.nika.yaml
@@ -13,7 +13,7 @@ nika: classify-and-route
 model: mock/echo                     # SLOT: replace with a local or hosted seat
 
 const:
-  request: "Production checkout is unavailable for every customer."   # SLOT
+  request: "<SLOT: the request to classify and route>"
   bundle:
     decision_bundle_format: 1
     manifest:

--- a/crates/nika-pack/pack/templates/corpus-qa.nika.yaml
+++ b/crates/nika-pack/pack/templates/corpus-qa.nika.yaml
@@ -14,7 +14,7 @@ nika: corpus-qa
 model: mock/echo                     # SLOT: replace with a local or hosted seat
 
 const:
-  query: "What is the holiday carry-over policy?"   # SLOT: the question
+  query: "<SLOT: the question to answer from the corpus>"
   documents:                         # SLOT: replace with retrieved source chunks
     - { id: handbook, text: "Support hours are 09:00 to 17:00 UTC." }
     - { id: security, text: "Security incidents are reported within one hour." }

--- a/crates/nika-pack/pack/templates/document-to-fields.nika.yaml
+++ b/crates/nika-pack/pack/templates/document-to-fields.nika.yaml
@@ -14,7 +14,13 @@ nika: document-to-fields
 model: mock/echo                     # SLOT: replace with a local or hosted seat
 
 const:
-  document: |                        # SLOT: replace with content from nika:read or nika:fetch
+  # NOT a slot, deliberately. This literal is the REHEARSAL FIXTURE the
+  # skeleton's own `nika:assert` step reads — hole it and the template
+  # stops rehearsing green, without closing anything: this workflow
+  # persists nothing, so it leaves behind no file that reads like a
+  # result (#1066's actual failure mode). Replace it with your document,
+  # or bind this const to a `nika:read` / `nika:fetch` task's output.
+  document: |
     Invoice INV-204
     Supplier: Northwind Tools
     Total: EUR 84.50

--- a/crates/nika-pack/pack/templates/evaluate-and-optimize.nika.yaml
+++ b/crates/nika-pack/pack/templates/evaluate-and-optimize.nika.yaml
@@ -14,7 +14,7 @@ nika: evaluate-and-optimize
 model: mock/echo                     # SLOT: replace with a local or hosted seat
 
 const:
-  brief: "Explain why idempotent retries matter in two sentences."   # SLOT
+  brief: "<SLOT: the deliverable to draft, critique and revise>"
 
 permits: {}
 

--- a/crates/nika-pack/pack/templates/fanout.nika.yaml
+++ b/crates/nika-pack/pack/templates/fanout.nika.yaml
@@ -103,8 +103,14 @@ tasks:
       recover: null                 # a failed item yields null at its index · the batch lives
     infer:                          # SLOT: the per-item job (any verb)
       max_tokens: 500               # SLOT: the per-ITEM ceiling · multiply by the fan width
+      # The marker below is a VALUE, not a comment. The parser drops
+      # comments, so a `# SLOT:` line could never make `check` refuse —
+      # which is how an unfilled scaffold ran green and left a file that
+      # read like a result (#1066). Replace the line, keep the binding.
       prompt: |
-        Process this item · ${{ item }}
+        <SLOT: what to do with each item>
+
+        ${{ item }}
 
   survivors:
     with:

--- a/crates/nika-pack/pack/templates/media-asset-pack.nika.yaml
+++ b/crates/nika-pack/pack/templates/media-asset-pack.nika.yaml
@@ -27,7 +27,7 @@ nika: media-asset-pack-template       # SLOT: kebab-case workflow id
 model: ollama/qwen2.5:14b
 
 const:
-  subject: "a calm cosmic landing hero"   # SLOT: what the asset is about
+  subject: "<SLOT: what the asset is about>"
   out_dir: "./out/assets"           # SLOT: where assets land
 
 permits:                            # the blast radius · default-deny once present

--- a/scripts/ci/funnel-e2e.sh
+++ b/scripts/ci/funnel-e2e.sh
@@ -75,6 +75,26 @@ printf '%s' "$OUT" | grep -q "sk-CANARY-9911" && fail "[welcome] key VALUE leake
 # 2 · scaffold → audit (the inputs trap is TAUGHT) → provision → run → story → verify
 run new-from 0 -- "$BIN" new chain first.nika.yaml
 [ -f first.nika.yaml ] || fail "[new] no file created"
+# #1066 · a scaffold whose slots are untouched is not a workflow yet, and
+# `check` refuses it BEFORE the spend. Played first, because a 0 here
+# would mean the refusal is gone — and the marker has to be a VALUE for
+# it to fire at all (a comment dies with the parse, which is how this
+# file used to run green and leave an `output.md` holding its own prompt).
+run check-unfilled 2 -- "$BIN" check first.nika.yaml
+need check-unfilled "SLOTS"
+need check-unfilled "ready to be filled"
+# It reads as a step, not a fault: the person typed `nika new` and did
+# nothing wrong.
+if printf '%s' "$OUT" | grep -qF "findings above"; then
+  fail "[check-unfilled] a scaffold is not a fault"
+fi
+# Answer the slot the way its author would, then the SAME file audits —
+# the other end of the ratchet: a refusal nobody can clear is a wall.
+sed 's|<SLOT:[^>]*>|Summarise the gathered text in one short paragraph.|' \
+  first.nika.yaml >first.filled && mv first.filled first.nika.yaml
+if grep -q '<SLOT:' first.nika.yaml; then
+  fail "[fill] a marker survived the fill"
+fi
 run check 0 -- "$BIN" check first.nika.yaml
 need check "audited"
 need check "[inputs]" # the scaffold's input trap is taught BEFORE the run


### PR DESCRIPTION
## Why

Three findings about the first minute, all measured against a built binary.

**#1196 — the first-contact screen promised two different first commands.**
The first-wow cascade replaced a menu with a single next step; #1195's repair
recomposed the whole mirror body after it and the menu came back. A stranger
read `nika new hello` at line 11 and `start here` offering `nika try 01-hello`
/ `nika init` / `nika new` at line 39. Both work — it was undecided in public,
with `nika init` offered twice. The same two words, `this machine`, named three
things on one screen.

**#1187 — `--json` answered a third way.** `start` still carried the pre-cascade
triple, and every `inference_choice.rungs[].next` hardcoded `nika new hello` —
the command that dies on `--force` in a directory that already holds the file,
the exact dead end `85dcb224d` closed for the terminal. Two renderers of one
screen, each deriving its own next step.

**#1066 — an unfilled scaffold ran green and left a file that looked like a
result.** `nika new chain` laid ten `SLOT` markers as YAML **comments**. The
parser drops comments by construction, so `check` mentioned none of them, the
run exited 0, and `output.md` held the scaffold's own prompt echoed back by a
mock — a file that outlives the terminal line explaining it.

## What

**One next step, derived once.** `start_moves` and `front_door_next` were two
derivations of the same thing, and neither could simply be dropped: the menu
carried the audited laws (P0-3 red→`check`, LOI-3 priced→cap, P0-4 partial
scan), the cascade carried the cwd key (gauntlet P15). `welcome::next_command`
is the single derivation now and carries all four. The `Next:` block, a new
top-level `next`, `start` (a one-element array where it was the menu) and every
`rungs[].next` read that one value. The cascade's hardware row reads
`this hardware · N GB`, and the local rung stopped repeating the RAM the row
above already states.

**A comment cannot refuse.** That is the whole of #1066, and it is why the FORM
mattered more than the judge: the marker descends into the VALUE, where the
parser sees it — `<SLOT: what goes here>`, matched per line so a half-filled
block scalar still holding one marker line refuses rather than sending it to the
model verbatim. Seven skeletons carry one, each on the value that stands in for
its author's subject.

Two scope rules, both stated in the code:

- **A path or host that `permits:` must mirror is never a slot.** Holing
  `const.destination` would fire `escapes the boundary` beside the invitation,
  and « ready to be filled » must not arrive next to an accusation.
- **`document-to-fields` keeps its sample invoice** for the same reason in
  reverse: that literal is the fixture its own `assert` reads, and the workflow
  persists nothing, so it leaves behind no file that reads like a result.

The refusal is worded as a step. Someone who typed `nika new` thirty seconds ago
did nothing wrong, so the rung wears the `Warn` face, names each slot with its
LINE, closes on one pasteable command, and the verdict reads `not a workflow yet
— 1 slot to fill, then it audits` instead of `findings above`. The exit code is
unchanged: it still refuses, before the spend.

```
nika new chain → check rc=2 · SLOTS  your file is ready to be filled — 1 value is still the scaffold's
                              line   71  tasks.think.infer.prompt · what should the model do…
                              fill them, then: nika check first.nika.yaml
                 run    → refuses · output.md does NOT exist
fill the slot  → check rc=0 ✔ audited · run green
```

The own-corpus law in `nika-onboard` is amended, not retired: a fresh scaffold
may refuse for its own unfilled slots and for nothing else.

## Proof

Measured on a built binary, in a fresh dir, before and after:

| | before | after |
|---|---|---|
| `nika welcome` lines | 43 | 38 |
| `this machine` occurrences | 3 | 1 |
| commands offered | 4 | 1 |

`--json` and the TTY now agree in both directions of the gauntlet-P15 flip —
empty directory (`nika new hello`), then the file it just wrote
(`nika run hello.nika.yaml`) — across `next`, `start[0]` and every
`rungs[].next`.

Ratchets, each mutation-checked:

- the screen offers exactly ONE first command (re-adding the menu makes it 4)
  and `this machine` resolves to one referent
- `DOOR_SHAPES` is a hand-written mirror of the real door, so a test runs the
  real door on real directories and proves it a fixed point
- the family traversal plants every skeleton **as shipped** and requires a
  refusal, then plants it **filled** and requires the audit AND the mock run —
  a refusal nobody can clear is a wall
- …and it compares the markers a template LAYS against the ones the judge SEES.
  The judge reads a NAMED set of value surfaces; a narrow probe returns a clean
  result, so only a count taken from the skeletons can prove it stayed as wide
  as the pack
- `funnel-e2e.sh` plays the refusal first (forcing its expected rc from 2 to 0
  turns it red), then fills and requires the green

Green locally on this branch, rebased onto `dc322f6d8`: `cargo test --workspace
--lib` · `clippy --workspace --all-targets -D warnings` · `fmt --check` ·
`funnel-e2e FAILS=0` · conformance core + deep + `decide_goldens` (154 fixtures,
run against a spec checkout) · the loc / fn-length / crate-size / unwrap /
expect / dead-code / changelog-fragment ratchets.

Pre-existing on `main`, unrelated and qualified by running them on unmodified
`dc322f6d8`: `composition_e2e::parent_timeout_bounds_the_real_child` (fails at
9.4s there, 9.9s here — a law-6 timeout not holding locally, worth its own look)
and `ask_pty` (PTY flake, passes on re-run).

## Territory

This crosses waves deliberately, with the owner's decision on record. Landing
the marker form without the judge would be worse than the defect — `nika run`
would send `<SLOT: …>` to a model — so it is one commit. `nika-check/src/slots.rs`
and `nika-display/src/check_render/slots.rs` are new files; the existing files
touched are `lib.rs` (+3 lines), `findings.rs` (+1 fold), `check_render.rs`
(+2 lines) and `footer.rs` (+1 branch).

Supersedes #1173, which implements the pre-ruling shape — scanning `# SLOT:`
comments, the thing that by construction cannot refuse.

Closes #1196.
Closes #1187.
Closes #1066.
