### PR TITLE
fix(ci): wire issue 1198 to its live proof

### DIFF
--- a/wiring.yaml
+++ b/wiring.yaml
@@ -36,6 +36,13 @@ capabilities:
     reachable_by: "nika lsp --stdio --clientProcessId=<pid>"
     proven_by: rust
     issue: 1181
+  - id: display.gate-provenance
+    kind: operator-teaching
+    declared_at: crates/nika-display/src/render.rs:416
+    shipped_when: "default"
+    reachable_by: "a task blocked by a settled upstream binding"
+    proven_by: rust
+    issue: 1198
   - id: access.harness
     kind: cargo-feature
     declared_at: crates/nika-cli/Cargo.toml:72


### PR DESCRIPTION
## Summary

- register the shipped gate-provenance teaching behavior in `wiring.yaml`
- bind issue #1198 to its executable Rust proof
- let `issue-proof.sh` derive closure from the canonical ledger

## Verification

- `bash scripts/ci/issue-proof.sh --issue 1198`
- full pre-push gate: green

Closes #1198

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>
Signed-off-by: Thibaut Melen <thibaut@supernovae.studio>