### PR TITLE
fix(catalog): the group is the marker, and the pointer names a surface that names them

### DIFF
--- a/changelog.d/catalog-sections.changed.md
+++ b/changelog.d/catalog-sections.changed.md
@@ -1,0 +1,10 @@
+- **`nika catalog` groups what runs, instead of tagging what does not.**
+  Marking each unreachable vendor was correct and unreadable: 22 of 38
+  rows repeated the same suffix, so the fact a reader wanted had to be
+  found by scanning for its ABSENCE. LOCAL and CLOUD now hold only the
+  16 providers this build resolves, in the same doctrine order; the rest
+  sit under one new head, `CATALOG ONLY (no adapter in this build · nika
+  check refuses these)`. The group is the marker, said once. `native`
+  leaves the « zero key · zero network » banner it could never honour.
+  The `--json` and MCP projections are unchanged — a machine filters on
+  `resolves`, it does not read headings.

--- a/changelog.d/models-rung-pointer.fixed.md
+++ b/changelog.d/models-rung-pointer.fixed.md
@@ -1,0 +1,12 @@
+- **The MODELS refusal points at a surface that actually names them.**
+  It said *"16 runnable — `nika doctor` names them"*. Measured on a
+  virgin machine: plain `nika doctor` names five — the local line — and
+  folds the ten cloud rows into « 10 providers unconfigured »; `mock`
+  gets no row at all. A stuck user was sent to a surface that named five
+  of the sixteen, and only `--verbose` improved on it. Both refusals now
+  point at `nika catalog`, which groups all sixteen under LOCAL and
+  CLOUD, and the unknown-provider one adds where the id they typed sits
+  (`CATALOG ONLY`). The claim is pinned per run:
+  `the_named_surface_actually_names_them` counts the rows the listing
+  renders before that head and refuses any drift from
+  `CANONICAL_IDS.len()`.

--- a/crates/nika-cli/src/verbs/catalog.rs
+++ b/crates/nika-cli/src/verbs/catalog.rs
@@ -119,10 +119,28 @@ fn human_listing(
 ) -> String {
     let models: usize = export.providers.iter().map(|p| p.models.len()).sum();
 
-    let mut local: Vec<&ProviderExport> = export.providers.iter().filter(|p| p.local).collect();
+    // Three sections, because the GROUP is the marker. A per-row
+    // « catalog only » suffix was correct and unreadable: 22 of 38 rows
+    // repeated the same 30 characters, so the fact a reader needed had
+    // to be found by scanning for its ABSENCE. LOCAL and CLOUD now hold
+    // only what this build resolves, in the doctrine order; everything
+    // the engine has no adapter for sits under its own head, where one
+    // sentence covers all of them.
+    let mut local: Vec<&ProviderExport> = export
+        .providers
+        .iter()
+        .filter(|p| p.local && p.resolves)
+        .collect();
     local.sort_by_key(|p| p.id);
-    let mut cloud: Vec<&ProviderExport> = export.providers.iter().filter(|p| !p.local).collect();
+    let mut cloud: Vec<&ProviderExport> = export
+        .providers
+        .iter()
+        .filter(|p| !p.local && p.resolves)
+        .collect();
     cloud.sort_by(|a, b| cloud_rank(a.id).cmp(&cloud_rank(b.id)));
+    let mut catalog_only: Vec<&ProviderExport> =
+        export.providers.iter().filter(|p| !p.resolves).collect();
+    catalog_only.sort_by_key(|p| p.id);
 
     let mut out = listing_header(theme, truth, models);
     out.push('\n');
@@ -177,6 +195,17 @@ fn human_listing(
     for p in cloud {
         out.push_str(&provider_line(p, theme, None));
     }
+    if !catalog_only.is_empty() {
+        out.push('\n');
+        out.push_str(&chrome::rail_head(
+            theme,
+            "CATALOG ONLY (no adapter in this build · nika check refuses these)",
+        ));
+        out.push('\n');
+        for p in catalog_only {
+            out.push_str(&provider_line(p, theme, None));
+        }
+    }
     out.push_str(
         "\nnika catalog --json → the machine projection (models · capabilities · context windows · resolves)",
     );
@@ -197,10 +226,12 @@ fn cloud_rank(id: &str) -> (u8, &str) {
 
 /// One provider line of the human listing. A local engine whose
 /// EFFECTIVE endpoint sits off-loopback (an operator override) is NAMED
-/// with endpoint + locus — the ink the honest header saved (P0-20). A
-/// row this build has no wire for says so ON THE ROW (#1184): an
-/// aggregate in the header does not survive the scan a user actually
-/// performs, which is down the column of names.
+/// with endpoint + locus — the ink the honest header saved (P0-20).
+///
+/// The row carries no resolvability marker: its SECTION does (#1184).
+/// An aggregate in the header does not survive the scan a user actually
+/// performs — but neither does the same suffix repeated on 22 of 38
+/// rows, which is what marking each one produced.
 fn provider_line(p: &ProviderExport, theme: Theme, locus: Option<&LocalLocus>) -> String {
     // B-6b (the gauntlet's Marta): `native` sits under the « zero key ·
     // zero network » banner, but in-process GGUF inference needs the
@@ -218,11 +249,6 @@ fn provider_line(p: &ProviderExport, theme: Theme, locus: Option<&LocalLocus>) -
     } else {
         "no key"
     };
-    let resolve_note = if p.resolves {
-        ""
-    } else {
-        " · catalog only — does not resolve in this build"
-    };
     let locus_note = match locus {
         Some(l) if l.locus != ExecutionLocus::Loopback => format!(
             " → {} ({})",
@@ -238,10 +264,7 @@ fn provider_line(p: &ProviderExport, theme: Theme, locus: Option<&LocalLocus>) -
             &format!(
                 " {}{}{}",
                 theme.paint(Role::Strong, &format!("{:<14}", p.id)),
-                theme.paint(
-                    Role::Dim,
-                    &format!(" {:>2} models · {key}{resolve_note}", p.models.len()),
-                ),
+                theme.paint(Role::Dim, &format!(" {:>2} models · {key}", p.models.len()),),
                 theme.paint(Role::Dim, &locus_note),
             ),
         )
@@ -309,36 +332,31 @@ mod tests {
     /// never carries a call to action (`native` invited « nika model
     /// pull » into a door that refuses at check).
     #[test]
-    fn a_non_resolving_row_says_so_and_offers_no_verb() {
+    fn a_non_resolving_row_sits_below_the_head_and_offers_no_verb() {
         let text = run(false, PLAIN).text;
         let export = resolvable_export();
-        for p in export.providers.iter().filter(|p| !p.resolves) {
-            let row = text
-                .lines()
-                .find(|l| l.contains(&format!("\u{2502}  {:<14}", p.id)))
+        let head = text
+            .find("CATALOG ONLY")
+            .expect("the listing separates what runs from what it merely knows");
+        for p in &export.providers {
+            let at = text
+                .find(&format!("\u{2502}  {:<14}", p.id))
                 .unwrap_or_else(|| panic!("provider `{}` missing from the listing", p.id));
-            assert!(
-                row.contains("catalog only"),
-                "non-resolving provider `{}` reads as runnable: {row}",
+            assert_eq!(
+                at < head,
+                p.resolves,
+                "provider `{}` sits in the wrong block (resolves={})",
                 p.id,
-            );
-            assert!(
-                !row.contains("nika model pull"),
-                "non-resolving provider `{}` still invites a verb: {row}",
-                p.id,
+                p.resolves,
             );
         }
-        for p in export.providers.iter().filter(|p| p.resolves) {
-            let row = text
-                .lines()
-                .find(|l| l.contains(&format!("\u{2502}  {:<14}", p.id)))
-                .unwrap_or_else(|| panic!("provider `{}` missing from the listing", p.id));
-            assert!(
-                !row.contains("catalog only"),
-                "resolving provider `{}` reads as unreachable: {row}",
-                p.id,
-            );
-        }
+        // An unreachable row carries no call to action: `native` invited
+        // « nika model pull » into a door that refuses at check.
+        let below = &text[head..];
+        assert!(
+            !below.contains("nika model pull"),
+            "a CATALOG ONLY row still invites a verb:\n{below}",
+        );
     }
 
     #[test]

--- a/crates/nika-cli/tests/catalog_family.rs
+++ b/crates/nika-cli/tests/catalog_family.rs
@@ -145,6 +145,9 @@ fn every_cataloged_provider_either_seats_or_is_refused_by_name() {
     // The two SHIPPED projections, rendered once and read per row below.
     let json = shipped_json();
     let human = catalog::run(false, PLAIN).text;
+    let catalog_only_at = human
+        .find("CATALOG ONLY")
+        .expect("the listing separates what runs from what the catalog merely knows");
 
     let mut seats = 0usize;
     let mut refused: Vec<&str> = Vec::new();
@@ -176,18 +179,25 @@ fn every_cataloged_provider_either_seats_or_is_refused_by_name() {
             row["resolves"],
         );
 
-        // #1184 · and the human column a user actually scans.
-        let line = human
-            .lines()
-            .find(|l| l.contains(&format!("\u{2502}  {:<14}", p.id)))
+        // #1184 · and the human listing, where the SECTION is the marker.
+        // A per-row suffix said this once per row; on 22 of 38 rows that
+        // is the same 30 characters repeated, and the fact a reader wants
+        // has to be found by scanning for its absence. The group carries
+        // it now, so membership is what gets judged.
+        let row_at = human
+            .find(&format!("\u{2502}  {:<14}", p.id))
             .unwrap_or_else(|| panic!("`{}` is missing from the human listing", p.id));
+        let runs_here = row_at < catalog_only_at;
         assert_eq!(
-            !line.contains("catalog only"),
+            runs_here,
             resolves,
-            "`{}` reads runnable={} down the column while check says resolves={resolves}. \
-             Row: {line}",
+            "`{}` sits in the {} block while check says resolves={resolves}",
             p.id,
-            !line.contains("catalog only"),
+            if runs_here {
+                "runnable"
+            } else {
+                "CATALOG ONLY"
+            },
         );
 
         if resolves {
@@ -224,6 +234,15 @@ fn the_refusal_names_the_runnable_count_and_where_to_get_the_list() {
     // The MODELS rung tells a refused user how many seats exist and who
     // names them. Both halves are load-bearing: the count is what makes the
     // refusal actionable, and the pointer is the only route to the list.
+    //
+    // The pointer used to be `nika doctor`, and it was not true. Measured
+    // on a virgin machine (env_clear · no keys): plain `doctor` names FIVE
+    // providers — the local line — and folds the ten cloud rows into « 10
+    // providers unconfigured »; `mock` gets no row at all. A refusal that
+    // says « 16 runnable, doctor names them » sent a stuck user to a
+    // surface that named five of them. `nika catalog` groups all sixteen
+    // under LOCAL and CLOUD, which is what
+    // `the_named_surface_actually_names_them` below re-proves per run.
     let unwired = UNWIRED
         .first()
         .expect("the unwired set is never empty here");
@@ -249,10 +268,70 @@ fn the_refusal_names_the_runnable_count_and_where_to_get_the_list() {
         out.text
     );
     assert!(
-        out.text.contains("nika doctor"),
+        out.text.contains("nika catalog"),
         "and points at the surface that NAMES them: {}",
         out.text
     );
+}
+
+/// A pointer is a CLAIM, and this is its proof.
+///
+/// The refusal says « N runnable — `nika catalog` names them under LOCAL
+/// and CLOUD ». That sentence is only true if the shipped listing really
+/// carries N rows outside its CATALOG ONLY block. Nothing else in the
+/// suite ties the number in the message to the surface it sends a user
+/// to; without this, the count could stay honest while the pointer
+/// rotted — which is exactly how the `nika doctor` pointer died.
+#[test]
+fn the_named_surface_actually_names_them() {
+    let human = catalog::run(false, PLAIN).text;
+    let (before, after) = human
+        .split_once("CATALOG ONLY")
+        .expect("the listing separates what runs from what the catalog merely knows");
+
+    let rows = |section: &str| {
+        section
+            .lines()
+            .filter(|l| l.trim_start().starts_with('\u{2502}'))
+            .count()
+    };
+    let named = rows(before);
+    let catalog_only = rows(after);
+
+    assert_eq!(
+        named,
+        nika_providers::CANONICAL_IDS.len(),
+        "the refusal promises {} runnable and the listing names {named} before \
+         CATALOG ONLY — the pointer is a lie the moment these differ",
+        nika_providers::CANONICAL_IDS.len(),
+    );
+    assert!(
+        catalog_only > 0,
+        "a CATALOG ONLY head with no rows under it is a section that stopped \
+         carrying its class",
+    );
+    assert_eq!(
+        named + catalog_only,
+        shipped_json()["providers"]
+            .as_array()
+            .expect("providers array")
+            .len(),
+        "every catalog row lands in exactly one section — a row in neither is \
+         a vendor the listing silently dropped",
+    );
+
+    // The sovereign path still leads, and the doctrine head order holds
+    // INSIDE the section that now excludes the unreachable vendors.
+    let local = before.find("LOCAL").expect("a LOCAL section");
+    let cloud = before.find("CLOUD").expect("a CLOUD section");
+    assert!(local < cloud, "local leads the teaching surface");
+    let pos = |id: &str| {
+        before
+            .find(&format!("\n\u{2502}  {id}"))
+            .unwrap_or_else(|| panic!("`{id}` must sit in a runnable section"))
+    };
+    assert!(pos("mistral") < pos("anthropic"), "mistral leads anthropic");
+    assert!(pos("anthropic") < pos("openai"), "anthropic leads openai");
 }
 
 /// One JSON-RPC round trip against the REAL `nika mcp` stdio server.

--- a/crates/nika-providers/src/profile.rs
+++ b/crates/nika-providers/src/profile.rs
@@ -261,8 +261,8 @@ pub fn resolve_refusal(model: &str) -> Option<ResolveRefusal> {
         None => Some(
             ResolveRefusal::new(format!(
                 "`{model}` is a bare model id — the contract is `<provider>/<model>` \
-                 (pick the provider that serves it; `nika doctor` names the \
-                 {} runnable providers)",
+                 (pick the provider that serves it; `nika catalog` names the \
+                 {} runnable providers under LOCAL and CLOUD)",
                 CANONICAL_IDS.len()
             ))
             .with_code(PREFIX_REFUSAL_CODE),
@@ -277,8 +277,9 @@ pub fn resolve_refusal(model: &str) -> Option<ResolveRefusal> {
                 .unwrap_or_default();
             let why = format!(
                 "provider `{provider}` does not resolve in THIS binary \
-                 ({} runnable — `nika doctor` names them); a cataloged \
-                 vendor is not a runnable one{guess}",
+                 ({} runnable — `nika catalog` names them under LOCAL and \
+                 CLOUD, this one under CATALOG ONLY); a cataloged vendor \
+                 is not a runnable one{guess}",
                 CANONICAL_IDS.len()
             );
             let mut refusal = ResolveRefusal::new(why);


### PR DESCRIPTION
Follow-up to #1205, closing the two things it deliberately left open.

## 1 · The marker was right and unreadable

#1205 put the resolvability fact on every row. Correct, and 22 of 38 rows
then carried the same 30-character suffix — so the fact a reader actually
wants (*which of these can I use?*) had to be found by scanning a column
for the **absence** of a string.

LOCAL and CLOUD now hold only what this build resolves, same doctrine
order. Everything else sits under one new head. The group is the marker,
said once.

```
◆ LOCAL (zero key · zero network)
│  llamacpp        1 models · no key
…
◆ CLOUD (key named by env var · the value is never read here)
│  mistral         2 models · MISTRAL_API_KEY
…
◆ CATALOG ONLY (no adapter in this build · nika check refuses these)
│  ai21            2 models · AI21_API_KEY
│  azure           2 models · AZURE_OPENAI_API_KEY
…
```

`native` leaves the « zero key · zero network » banner it could never
honour, and loses the `nika model pull` invitation to a door that
refuses at `check`.

The `--json` and MCP projections are **untouched** — an agent filters on
`resolves`, it does not read headings.

## 2 · The pointer was false, and it is the part that mattered

The MODELS rung said *"16 runnable — `nika doctor` names them"*.
Measured on a virgin machine (`env_clear`, no keys):

```
✔ local      5 providers (ollama · lmstudio · llamacpp · localai · vllm)
· advisory   … 10 providers unconfigured · nika doctor --verbose unfolds each
```

**Five named of sixteen promised.** The ten cloud rows are folded by
design (B-8b: a healthy machine reads calm), `mock` gets no row at all,
and only `--verbose` improves it — which the message never said to pass.
A user stuck at a refusal was sent to a surface that did not answer.

Both refusals now name `nika catalog`. The unknown-provider one also says
where the id they typed **did** land, so *"then what is this vendor doing
in your catalog?"* is answered on the same line as the refusal:

```
✖ MODELS  `azure/gpt-4o` (task t) — provider `azure` does not resolve in THIS
          binary (16 runnable — `nika catalog` names them under LOCAL and CLOUD,
          this one under CATALOG ONLY); a cataloged vendor is not a runnable one
```

### The pointer is a claim, so it gets a proof

`the_named_surface_actually_names_them` counts the rows the **shipped**
listing renders before the `CATALOG ONLY` head and refuses any drift from
`CANONICAL_IDS.len()`; asserts the other section is non-empty; asserts the
two partition every catalog row; and re-checks that the sovereign path
still leads inside the section that now excludes unreachable vendors.

Nothing else in the suite tied the number in the message to the surface it
sends a user to — which is exactly how the `nika doctor` pointer died: the
count stayed honest while the surface it named quietly stopped naming.

## Proof

| mutation | goes red |
|---|---|
| let an unresolvable vendor back into the CLOUD block | traversal + `the_named_surface_actually_names_them` |
| drop the `CATALOG ONLY` head | both, again |
| repoint the refusal at a surface that does not name them | `the_refusal_names_the_runnable_count_and_where_to_get_the_list` |

6594 lib tests · `catalog_family` 6/6 · `machine_truth_surfaces` 3/3 ·
11/11 ratchets · fmt · `clippy --workspace --all-targets` clean.
`nika-providers`' public-api baseline is unchanged (the messages are
internal strings, not API), verified with the pinned
`cargo-public-api 0.51.0`.

The two tests that judged the old per-row suffix now judge **section
membership** — the same fact, read the way the surface now states it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)