### PR TITLE
ci(spec-pin-heal): install the sandbox backend the run tests need

### DIFF
--- a/.github/workflows/spec-pin-heal.yml
+++ b/.github/workflows/spec-pin-heal.yml
@@ -38,6 +38,27 @@ jobs:
       - uses: taiki-e/install-action@a2a5f6e99e1a31540baa0468acfa302cff0f359f # v2
         with:
           tool: cargo-nextest
+      # This job runs the SAME suite diamond-ci's tests leg runs, so it needs
+      # the same host. Without a sandbox backend a workflow that declares
+      # `permits:` refuses with NIKA-1710 and the run verb's gate tests read
+      # rc=3 where they pin rc=0 — a green sibling and a red here on ONE sha
+      # (805640259), which is the signature of a runner gap, not a code
+      # defect. The block below is diamond-ci.yml's, minus its matrix guard.
+      # Static shell only: no github.event.* value is read here.
+      - name: Install bubblewrap (the run verb's gate tests execute a permits workflow)
+        run: |
+          # apt has no deadline of its own: a mirror stall once held every job
+          # to the 6-hour ceiling. A 30 s socket timeout + 3 retries cover the
+          # transient half; the 5-minute hard deadline turns the rest into a
+          # clean red the operator can re-run.
+          sudo timeout 300 apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 update
+          sudo timeout 300 apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 install -y --no-install-recommends bubblewrap
+          # ubuntu-24.04's AppArmor bwrap profile grants userns creation but
+          # denies CAP_NET_ADMIN inside it, so bwrap dies bringing up loopback
+          # in the unshared netns. Detach the profile and keep unprivileged
+          # userns open so bwrap behaves as on a developer machine.
+          sudo apparmor_parser -R /etc/apparmor.d/bwrap-userns-restrict 2>/dev/null || true
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
       - name: The pin follows the spec
         id: heal
         env:


### PR DESCRIPTION
## The red

`spec-pin-heal` failed on `main` at `805640259` (run 32820248541):

```
verbs::run::tests::answer_without_resume_preseeds_the_gate ... FAILED
  assertion `left == right` failed: the pre-seeded answer clears the gate on a fresh run
    left: 3
   right: 0

  stderr: nika run: environment: NIKA-1710 · this workflow declares `permits:`
  and no OS sandbox backend can confine them on this host (NIKA_SANDBOX=auto)
  — install bubblewrap (apt install bubblewrap) and re-run
```

## Why this is the host and not the test

Three witnesses, all on the same sha:

1. **`Diamond CI` passed on `805640259`.** It runs the same suite. So did
   `public-api`, `Coverage`, `estate`, `Code Quality` and `Scorecard`. This
   gate alone failed.
2. **`bubblewrap` is installed in `diamond-ci.yml` and `release.yml` only.**
   Nothing installs it here, and this job runs the full battery through
   `scripts/ci/check-tests.sh`.
3. **The refusal names its own cause.** `NIKA-1710` is the engine correctly
   refusing to run a workflow that declares a permits block on a host with no
   sandbox backend. rc=3 where the test pins rc=0.

A green sibling and a red here on one sha is the signature of a runner gap.

## The change

The `diamond-ci.yml` block, minus its matrix guard, comments kept. Both of its
parts were bought by real incidents and neither is decoration:

- the apt deadline (a mirror stall once held every job to the 6-hour ceiling)
- the AppArmor detach (ubuntu-24.04 grants userns creation but denies
  CAP_NET_ADMIN inside it, so bwrap dies bringing up loopback)

Static shell only. No `github.event` value is read, consistent with the
SECURITY note at the top of this file.

## What this PR can and cannot prove

**It cannot prove itself.** This workflow has no `pull_request` trigger — it
runs on `schedule` (06:51 daily) and `workflow_dispatch`. No check on this PR
exercises the change.

**I did not dispatch it from this branch on purpose.** On a passing battery
this job advances `SPEC_PIN` and opens a PR from the checked-out tree. A
success path that writes outward has no dry run, so proving the fix that way
would have created a spec-pin PR carrying this workflow edit.

**The proof is therefore the next run after merge** — the 06:51 cron, or a
manual dispatch on `main` once this lands. If the battery still fails there,
the diagnosis was wrong and the red is a genuine engine defect that
`diamond-ci` is somehow not reaching. That is the falsifiable half, stated in
advance.

## Not in scope

The same run also surfaced that `issue-proof` reads a *mention* of
`proven_by:` as a *declaration*, in both directions. Filed separately as
issue 1218 with a standalone reproduction; it is a different file and a
different class.
