### PR TITLE
fix(access): close P4 post-merge verification gaps

### DIFF
--- a/crates/nika-cli-host/src/doctor.rs
+++ b/crates/nika-cli-host/src/doctor.rs
@@ -144,8 +144,8 @@ pub fn diagnose(probe: &Probe) -> Vec<Finding> {
     out
 }
 
-/// `--access` vocabulary (NIKA-1802). Classes, never a harness seat id.
-/// Gauntlet P01/P05: copying `claude-agent-acp` from a doctor row dies.
+/// `--access` vocabulary (NIKA-1802). Both classes and live harness seat
+/// ids are pins; ACP wrapper executable names remain implementation detail.
 fn access_class_finding() -> Finding {
     let vocabulary = nika_types::access::AccessClass::ALL
         .map(nika_types::access::AccessClass::as_str)
@@ -153,7 +153,11 @@ fn access_class_finding() -> Finding {
     Finding {
         level: Level::Ok,
         label: "access".to_owned(),
-        detail: format!("--access classes: {vocabulary} (not a seat id)"),
+        detail: format!(
+            "--access classes: {vocabulary} · harness seats: {} \
+             (ACP wrapper ids are not pins)",
+            nika_types::access::HarnessRuntime::vocabulary()
+        ),
         fix: None,
     }
 }
@@ -1100,48 +1104,70 @@ pub(crate) fn harness_findings() -> Vec<Finding> {
         }
     };
     nika_harness::probe_adapters_sync(rows)
-        .into_iter()
-        .map(|row| {
-            let display = nika_types::access::HarnessRuntime::lookup(&row.id)
-                .map_or(row.id.as_str(), |rt| rt.display);
-            match (row.product_present, row.version, row.authenticated) {
-                (_, Some((major, minor)), Some(true)) => Finding {
-                    level: Level::Ok,
-                    label: "runtime".to_owned(),
-                    detail: format!(
-                        "{} — {display} · detected (v{major}.{minor}) · authenticated (its own login) · `--access {}`",
-                        row.id, row.id
-                    ),
-                    fix: None,
-                },
-                (_, Some((major, minor)), _) => Finding {
-                    level: Level::Warn,
-                    label: "runtime".to_owned(),
-                    detail: format!(
-                        "{} — {display} · detected (v{major}.{minor}) · not signed in · `--access {}`",
-                        row.id, row.id
-                    ),
-                    fix: Some(format!("sign in to {display} itself")),
-                },
-                (true, None, _) => Finding {
-                    level: Level::Warn,
-                    label: "runtime".to_owned(),
-                    detail: format!(
-                        "{} — {display} · installed, ACP speaker missing · `--access {}`",
-                        row.id, row.id
-                    ),
-                    fix: Some(format!("install: {}", row.package)),
-                },
-                (false, None, _) => Finding {
-                    level: Level::Warn,
-                    label: "runtime".to_owned(),
-                    detail: format!(
-                        "{} — {display} · not installed · `--access {}`",
-                        row.id, row.id
-                    ),
-                    fix: Some(format!("install: {}", row.package)),
-                },
-            }
-        })
+        .iter()
+        .map(harness_finding)
         .collect()
+}
+
+#[cfg(feature = "access-harness")]
+fn harness_finding(row: &nika_harness::AdapterProbeRow) -> Finding {
+    harness_finding_from_parts(
+        &row.id,
+        row.version,
+        row.authenticated,
+        &row.package,
+        row.product_present,
+    )
+}
+
+#[cfg(feature = "access-harness")]
+fn harness_finding_from_parts(
+    id: &str,
+    version: Option<(u32, u32)>,
+    authenticated: Option<bool>,
+    package: &str,
+    product_present: bool,
+) -> Finding {
+    let display = nika_types::access::HarnessRuntime::lookup(id).map_or(id, |rt| rt.display);
+    if id == "codex" && product_present && version.is_none() {
+        return Finding {
+            level: Level::Warn,
+            label: "runtime".to_owned(),
+            detail: format!(
+                "{id} — {display} · infer-grade direct path detected (login judged at run) · \
+                 agent ACP speaker missing · `--access {id}`"
+            ),
+            fix: Some(format!("install: {package} (only required for agent:)")),
+        };
+    }
+    match (product_present, version, authenticated) {
+        (_, Some((major, minor)), Some(true)) => Finding {
+            level: Level::Ok,
+            label: "runtime".to_owned(),
+            detail: format!(
+                "{id} — {display} · detected (v{major}.{minor}) · authenticated (its own login) · `--access {id}`"
+            ),
+            fix: None,
+        },
+        (_, Some((major, minor)), _) => Finding {
+            level: Level::Warn,
+            label: "runtime".to_owned(),
+            detail: format!(
+                "{id} — {display} · detected (v{major}.{minor}) · not signed in · `--access {id}`"
+            ),
+            fix: Some(format!("sign in to {display} itself")),
+        },
+        (true, None, _) => Finding {
+            level: Level::Warn,
+            label: "runtime".to_owned(),
+            detail: format!("{id} — {display} · installed, ACP speaker missing · `--access {id}`"),
+            fix: Some(format!("install: {package}")),
+        },
+        (false, None, _) => Finding {
+            level: Level::Warn,
+            label: "runtime".to_owned(),
+            detail: format!("{id} — {display} · not installed · `--access {id}`"),
+            fix: Some(format!("install: {package}")),
+        },
+    }
 }

--- a/crates/nika-cli-host/src/doctor/runtime_tests.rs
+++ b/crates/nika-cli-host/src/doctor/runtime_tests.rs
@@ -2,6 +2,17 @@
 // Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
+#[test]
+fn doctor_teaches_access_classes_and_live_seat_pins() {
+    let detail = &super::access_class_finding().detail;
+    assert!(detail.contains("--access classes:"), "{detail}");
+    assert!(
+        detail.contains("harness seats: claude-code · codex"),
+        "{detail}"
+    );
+    assert!(detail.contains("ACP wrapper ids are not pins"), "{detail}");
+}
+
 #[cfg(feature = "access-harness")]
 #[test]
 fn doctor_lists_every_agentic_cli_runtime() {
@@ -28,5 +39,35 @@ fn doctor_lists_every_agentic_cli_runtime() {
     assert!(
         !text.contains("Nika MCP oracle"),
         "runtime rows must not market MCP wire: {text}"
+    );
+}
+
+#[cfg(feature = "access-harness")]
+#[test]
+fn codex_without_acp_still_names_the_direct_infer_path() {
+    let finding = super::harness_finding_from_parts("codex", None, None, "codex-acp package", true);
+
+    assert!(
+        finding.detail.contains("infer-grade direct path detected"),
+        "{}",
+        finding.detail
+    );
+    assert!(
+        finding.detail.contains("login judged at run"),
+        "{}",
+        finding.detail
+    );
+    assert!(
+        finding.detail.contains("agent ACP speaker missing"),
+        "{}",
+        finding.detail
+    );
+    assert!(
+        finding
+            .fix
+            .as_deref()
+            .is_some_and(|fix| fix.contains("only required for agent:")),
+        "{:?}",
+        finding.fix
     );
 }

--- a/crates/nika-cli/src/main.rs
+++ b/crates/nika-cli/src/main.rs
@@ -441,11 +441,14 @@ struct RunArgs {
     #[arg(long, value_name = "PROVIDER/NAME")]
     model: Option<String>,
     /// Pin the ACCESS path (`model:` picks the intelligence; access
-    /// picks the path) — a class: `local` · `mock` · `harness` ·
-    /// `oauth` · `api`. A harness seat id (`claude-agent-acp`) is not a
-    /// class (NIKA-1802). A pin is a pin: unsatisfied refuses before
-    /// the prologue with a witness, never substitutes another path or
-    /// model (D-2026-08-04-N1).
+    /// picks the path) — either a class (`local` · `mock` · `harness` ·
+    /// `oauth` · `api`) or a harness seat (`claude-code` · `codex` ·
+    /// `gemini-cli` · `kimi-code` · `qwen-code`). Retired ACP wrapper
+    /// ids (`claude-agent-acp` · `codex-acp`) refuse with NIKA-1802. A
+    /// pin is a pin: unsatisfied refuses before the prologue with a
+    /// witness, never substitutes another path or model (D-2026-08-04-N1).
+    /// Example: `--model openai/gpt-5.2 --access codex` requests that
+    /// model through the user's Codex subscription seat.
     #[arg(long, value_name = "PATH")]
     access: Option<String>,
     /// Set a workflow `inputs:` value (repeatable). Overrides a declared
@@ -1371,8 +1374,12 @@ mod tests {
             "doctor listing seat ids as pins caused NIKA-1802: {help}"
         );
         assert!(
-            help.contains("claude-agent-acp") && help.contains("not a class"),
-            "the help must name the trap: {help}"
+            help.contains("claude-code") && help.contains("codex"),
+            "the live harness seat pins must be taught: {help}"
+        );
+        assert!(
+            help.contains("claude-agent-acp") && help.contains("Retired ACP wrapper"),
+            "the retired wrapper trap must stay named: {help}"
         );
         let hidden = cmd
             .get_subcommands()

--- a/crates/nika-cli/src/verbs/run/dry_run.rs
+++ b/crates/nika-cli/src/verbs/run/dry_run.rs
@@ -5,6 +5,7 @@
 
 use nika_check::CheckReport;
 use nika_schema::raw::RawWorkflow;
+use nika_types::access::{AccessClass, AccessPlan};
 
 use super::{RunVerdict, exit};
 use crate::Theme;
@@ -35,6 +36,7 @@ pub(super) fn lane(
     skills: &nika_schema::ResolvedSkills,
     repair_target: nika_display::check_render::RepairTarget,
     model_override: Option<&str>,
+    access_pin: Option<&str>,
     json: bool,
     theme: Theme,
     output_json: bool,
@@ -42,7 +44,10 @@ pub(super) fn lane(
     if let Some(model) = model_override {
         match swap(wf, model) {
             Ok((wf, report)) => {
-                return RunVerdict::bare(verdict(file, &wf, &report, json, theme));
+                if let Some(verdict) = access_refusal(&wf, &report, access_pin, output_json) {
+                    return verdict;
+                }
+                return RunVerdict::bare(verdict(file, &wf, &report, access_pin, json, theme));
             }
             Err(refused) => {
                 let (wf, report) = *refused;
@@ -61,13 +66,58 @@ pub(super) fn lane(
             }
         }
     }
-    RunVerdict::bare(verdict(file, wf, report, json, theme))
+    if let Some(verdict) = access_refusal(wf, report, access_pin, output_json) {
+        return verdict;
+    }
+    RunVerdict::bare(verdict(file, wf, report, access_pin, json, theme))
 }
 
-fn verdict(file: &str, wf: &RawWorkflow, report: &CheckReport, json: bool, theme: Theme) -> u8 {
+fn access_refusal(
+    wf: &RawWorkflow,
+    report: &CheckReport,
+    access_pin: Option<&str>,
+    output_json: bool,
+) -> Option<RunVerdict> {
+    let probes = nika_cli_host::probe::access_probes_with_harness();
+    nika_runtime::access_pin_refusal(wf, report, &probes, access_pin, None).map(|error| {
+        RunVerdict::bare(super::epilogue::env_refusal(
+            &error.to_string(),
+            output_json,
+        ))
+    })
+}
+
+fn verdict(
+    file: &str,
+    wf: &RawWorkflow,
+    report: &CheckReport,
+    access_pin: Option<&str>,
+    json: bool,
+    theme: Theme,
+) -> u8 {
+    let plans = preview_access_plans(report, access_pin);
+    let seated = plans
+        .values()
+        .any(|plan| plan.chosen == AccessClass::Harness);
     if json {
-        println!("{:#}", nika_check::plan::payload(file, wf, report));
+        let payload = project_access(
+            nika_check::plan::payload(file, wf, report),
+            access_pin,
+            &plans,
+        );
+        println!("{payload:#}");
+    } else if seated {
+        println!("{file} · subscription-seat preview");
+        for plan in plans.values() {
+            println!(
+                "  requested {} → seat {} · subscription quota",
+                plan.model, plan.access
+            );
+        }
     } else {
+        if let Some(pin) = access_pin {
+            println!("access: pinned `{pin}` · admission satisfied");
+        }
         let plan = crate::verbs::inspect::render_pair(wf, report, theme);
         if !plan.text.is_empty() {
             println!("{}", plan.text.trim_end());
@@ -75,4 +125,125 @@ fn verdict(file: &str, wf: &RawWorkflow, report: &CheckReport, json: bool, theme
         println!("\n  dry-run · plan only · no effects executed");
     }
     exit::OK
+}
+
+fn preview_access_plans(
+    report: &CheckReport,
+    access_pin: Option<&str>,
+) -> std::collections::BTreeMap<String, AccessPlan> {
+    let Some(pin) = access_pin else {
+        return std::collections::BTreeMap::new();
+    };
+    let models: Vec<String> = report
+        .requirements
+        .models
+        .iter()
+        .map(|model| model.model.clone())
+        .collect();
+    let probes = nika_cli_host::probe::access_probes_with_harness();
+    nika_providers::access_plan_map(&models, &probes, Some(pin))
+}
+
+fn project_access(
+    mut payload: serde_json::Value,
+    access_pin: Option<&str>,
+    plans: &std::collections::BTreeMap<String, AccessPlan>,
+) -> serde_json::Value {
+    let Some(pin) = access_pin else {
+        return payload;
+    };
+    let rows: Vec<serde_json::Value> = plans
+        .values()
+        .map(|plan| {
+            serde_json::json!({
+                "requested_model": plan.model,
+                "access": plan.access,
+                "class": plan.chosen.as_str(),
+                "billing": plan.billing.as_str(),
+            })
+        })
+        .collect();
+    let seated = plans
+        .values()
+        .any(|plan| plan.chosen == AccessClass::Harness);
+    payload["access"] = serde_json::json!({
+        "requested": pin,
+        "resolved": !plans.is_empty(),
+        "plans": rows,
+    });
+    if seated {
+        let tasks = payload["cost"]["tasks"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .map(|task| {
+                serde_json::json!({
+                    "task": task.get("task").cloned().unwrap_or(serde_json::Value::Null),
+                    "requested_model": task
+                        .get("model")
+                        .cloned()
+                        .unwrap_or(serde_json::Value::Null),
+                    "budget": "subscription_quota",
+                })
+            })
+            .collect::<Vec<_>>();
+        payload["cost"] = serde_json::json!({
+            "basis": "subscription_quota",
+            "tasks": tasks,
+        });
+    }
+    payload
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use nika_types::access::{AccessClass, AccessPlan, BillingClass};
+    use serde_json::json;
+
+    #[test]
+    fn subscription_preview_names_request_and_contains_no_numeric_meter() {
+        let plans = BTreeMap::from([(
+            "openai/gpt-5.2".to_owned(),
+            AccessPlan::new(
+                "openai/gpt-5.2",
+                "openai",
+                "codex",
+                AccessClass::Harness,
+                BillingClass::IncludedQuota,
+                true,
+                Vec::new(),
+            ),
+        )]);
+        let payload = json!({
+            "cost": {
+                "bounded_total_usd": 0.25,
+                "tasks": [{
+                    "task": "answer",
+                    "model": "openai/gpt-5.2",
+                    "max_tokens": 400,
+                    "usd": 0.25
+                }]
+            }
+        });
+
+        let projected = super::project_access(payload, Some("codex"), &plans);
+        let wire = projected.to_string();
+        assert_eq!(projected["access"]["requested"], "codex");
+        assert_eq!(
+            projected["access"]["plans"][0]["requested_model"],
+            "openai/gpt-5.2"
+        );
+        assert_eq!(projected["access"]["plans"][0]["access"], "codex");
+        assert_eq!(projected["cost"]["basis"], "subscription_quota");
+        for forbidden in ["usd", "max_tokens", "responding_model"] {
+            assert!(!wire.contains(forbidden), "{forbidden} leaked: {wire}");
+        }
+        assert!(
+            projected["cost"]["tasks"][0]["budget"]
+                .as_str()
+                .is_some_and(|budget| budget == "subscription_quota")
+        );
+    }
 }

--- a/crates/nika-cli/src/verbs/run/execution_adapter.rs
+++ b/crates/nika-cli/src/verbs/run/execution_adapter.rs
@@ -189,6 +189,7 @@ fn run_admitted_context(
             world.driver.skills(),
             request.repair_target,
             request.model_override,
+            request.access_pin,
             request.json,
             request.theme,
             request.output_json,

--- a/crates/nika-cli/src/verbs/run/tests.rs
+++ b/crates/nika-cli/src/verbs/run/tests.rs
@@ -617,3 +617,62 @@ fn dry_run_without_the_flag_keeps_the_files_model() {
     let p = nika_check::plan::payload("hello-ai.nika.yaml", &wf, &report);
     assert_eq!(p["cost"]["tasks"][0]["model"], "ollama/llama3.2:3b");
 }
+
+#[test]
+fn dry_run_refuses_an_unknown_access_pin() {
+    let wf = stage(
+        "dry-run-unknown-access.nika.yaml",
+        "nika: dry-run-access\nmodel: mock/echo\npermits: {}\ntasks:\n  ask:\n    infer: { prompt: \"hello\" }\n",
+    );
+    let code = run(
+        &wf.to_string_lossy(),
+        false,
+        None,
+        plain_theme(),
+        RenderMode::Plain,
+        true,
+        None,
+        Some("nonsense-seat"),
+        &[],
+        None,
+        true,
+        None,
+        false,
+        None,
+        true,
+        false,
+    );
+    assert_eq!(code, exit::ENV, "dry-run must enforce the NIKA-1802 gate");
+}
+
+#[cfg(feature = "access-harness")]
+#[test]
+fn mock_model_with_harness_pin_refuses_before_a_live_seat() {
+    let wf = stage(
+        "mock-never-harness.nika.yaml",
+        "nika: mock-never-harness\nmodel: mock/echo\npermits: {}\ntasks:\n  ask:\n    infer: { prompt: \"hello\" }\n",
+    );
+    let code = run(
+        &wf.to_string_lossy(),
+        false,
+        None,
+        plain_theme(),
+        RenderMode::Plain,
+        false,
+        None,
+        Some("harness"),
+        &[],
+        None,
+        true,
+        None,
+        false,
+        None,
+        true,
+        false,
+    );
+    assert_eq!(
+        code,
+        exit::ENV,
+        "mock/echo must refuse before any harness backend can be seated"
+    );
+}

--- a/crates/nika-providers/src/resolve_access.rs
+++ b/crates/nika-providers/src/resolve_access.rs
@@ -353,15 +353,26 @@ pub fn refuse_pin_for_verbs<'m>(
     has_infer: bool,
     has_agent: bool,
 ) -> Option<PinRefusal> {
+    let models: Vec<&str> = models.into_iter().collect();
     let infer_only = has_infer && !has_agent;
     let named = HarnessRuntime::lookup(pin);
+    if (named.is_some() || pin == AccessClass::Harness.as_str())
+        && models.iter().any(|model| provider_of(model) == "mock")
+    {
+        return Some(PinRefusal::PinUnsatisfied {
+            message: String::from(
+                "model `mock/echo` is the isolated rehearsal backend and cannot run through a \
+                 harness seat — use `--access mock` (refusal, never a live substitute)",
+            ),
+        });
+    }
     let direct = named.is_some_and(|rt| infer_only && named_infer_grade_ready(rt, probes));
     let generic = pin == AccessClass::Harness.as_str()
         && infer_only
         && first_ready_infer_harness(probes).is_some();
     if !direct
         && !generic
-        && let Some(refusal) = refuse_pin(models, probes, pin)
+        && let Some(refusal) = refuse_pin(models.iter().copied(), probes, pin)
     {
         return Some(refusal);
     }
@@ -644,6 +655,14 @@ pub fn access_plan_map(
     // An explicit ready harness pin is the infer/agent path for EVERY
     // static model (the envelope `model:` is a hint, not a serves-filter).
     if let Some(pin) = pin {
+        let requests_mock = models
+            .iter()
+            .any(|model| !model.contains("${{") && provider_of(model) == "mock");
+        if requests_mock
+            && (HarnessRuntime::lookup(pin).is_some() || pin == AccessClass::Harness.as_str())
+        {
+            return std::collections::BTreeMap::new();
+        }
         if let Some(rt) = HarnessRuntime::lookup(pin) {
             let infer_grade_ready = named_infer_grade_ready(rt, probes);
             if infer_grade_ready || refuse_named_runtime(rt, probes).is_none() {

--- a/crates/nika-runtime/src/admit.rs
+++ b/crates/nika-runtime/src/admit.rs
@@ -841,6 +841,30 @@ mod tests {
         assert!(access_pin_refusal(&wf, &report, probes, pin, None).is_none());
     }
 
+    #[cfg(feature = "access-harness")]
+    #[test]
+    fn a_mock_model_refuses_a_harness_pin_before_any_live_seat() {
+        let wf =
+            parse("nika: t\ntasks:\n  s:\n    infer: { prompt: \"x\", model: \"mock/echo\" }\n");
+        let report = nika_check::check(&wf);
+        let probe = access_probe(
+            "codex",
+            false,
+            true,
+            nika_types::access::AccessClass::Harness,
+        );
+        let err = access_pin_refusal(&wf, &report, &[probe], Some("harness"), None)
+            .expect("mock must never substitute a live harness");
+        assert!(
+            matches!(err, RuntimeError::AccessPinUnsatisfied { .. }),
+            "{err:?}"
+        );
+        let witness = err.to_string();
+        assert!(witness.contains("mock/echo"), "{witness}");
+        assert!(witness.contains("--access mock"), "{witness}");
+        assert!(witness.contains("never a live substitute"), "{witness}");
+    }
+
     #[test]
     fn the_model_override_is_what_the_pin_judges() {
         // The ENVELOPE model is mistral (api) — the override sends the

--- a/crates/nika-runtime/src/tests.rs
+++ b/crates/nika-runtime/src/tests.rs
@@ -10,6 +10,8 @@
 
 use super::*;
 
+mod seated_receipt;
+
 /// The F-O1 integrity label for the pre-existing frame tests below —
 /// they exercise the frame surface, not the label: a trusted settle
 /// emits NO `integrity` field (the additive law: absent = trusted).

--- a/crates/nika-runtime/src/tests/seated_receipt.rs
+++ b/crates/nika-runtime/src/tests/seated_receipt.rs
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! Subscription-seat terminal receipt regressions.
+
+use super::*;
+
+/// A subscription seat is quota-backed, not free. Its terminal receipt
+/// identifies the seat and requested model without inventing metered spend,
+/// token usage, or the identity of the model that actually answered.
+#[test]
+fn seated_infer_receipt_exposes_no_numeric_or_responder_identity() {
+    const NOTE: &str = "infer · seat codex · requested anthropic/claude-sonnet-4-6";
+    let ran = task::RanTask {
+        decisions: Vec::new(),
+        note: NOTE.to_owned(),
+        retries: Vec::new(),
+        agent_events: Vec::new(),
+        evidence: None,
+        duration_ms: 0,
+        result: task::RunResult::Success {
+            value: Value::String("hi".to_owned()),
+            tokens: None,
+            recovered_from: None,
+            warning: None,
+            child: None,
+            cost_usd: None,
+            cost_unpriced: Some(nika_types::cost::UnpricedReason::SubscriptionQuota),
+            model: None,
+        },
+    };
+    let mut ok = true;
+    let mut stamper = DeterministicStamper::new();
+    let mut sink = VecSink::new();
+    settle::settle_ran(
+        "ask",
+        ran,
+        None,
+        &TRUSTED,
+        &[],
+        None,
+        &mut ok,
+        &mut stamper,
+        &mut sink,
+    );
+    let completed = sink
+        .events()
+        .iter()
+        .find(|event| event.kind == EventKind::TaskCompleted)
+        .expect("a TaskCompleted frame");
+    let sfield = |key: &str| {
+        completed
+            .fields
+            .iter()
+            .find(|field| field.key == key)
+            .and_then(|field| match &field.value {
+                FieldValue::String(value) => Some(value.as_str()),
+                _ => None,
+            })
+    };
+
+    assert_eq!(sfield("note"), Some(NOTE));
+    assert_eq!(sfield("access"), Some("harness"));
+    assert_eq!(sfield("billing"), Some("unknown"));
+    assert_eq!(sfield("cost_unpriced"), Some("subscription_quota"));
+    for forbidden in ["tokens", "cost_usd", "model", "provider"] {
+        assert!(
+            !completed.fields.iter().any(|field| field.key == forbidden),
+            "subscription receipts must omit {forbidden}"
+        );
+    }
+}


### PR DESCRIPTION
## Outcome

Closes the P4 post-merge evidence gaps found by the eight-persona gauntlet and the independent verification swarm.

- makes dry-run use the same access-pin meet as live execution
- keeps `mock/echo` isolated from live harness seats
- renders seated infer previews as subscription quota, with no numeric USD or token budget
- exposes requested model, seat and access class without claiming the responding model
- aligns public help and doctor with the live seat vocabulary
- adds the missing terminal `task_completed` absence witness

## Verification

- full pre-push gate: green twice (11 CI ratchets + workspace lib tests + hygiene)
- touched-crate clippy: green
- 8/8 exogenous gauntlet personas completed
- mock+harness and invalid dry-run pins refuse before backend dispatch
- seated preview contains `subscription_quota` and no numeric USD/token/model-response meter

Signed-off-by: Thibaut Melen <20891897+ThibautMelen@users.noreply.github.com>

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>