### PR TITLE
fix(runtime): expand portable home grants at dispatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4449,6 +4449,7 @@ dependencies = [
 name = "nika-exec-runner"
 version = "0.114.0"
 dependencies = [
+ "nika-cap",
  "nika-check",
  "nika-kernel",
  "nika-sandbox-seatbelt",

--- a/changelog.d/1025.changed.md
+++ b/changelog.d/1025.changed.md
@@ -1,0 +1,7 @@
+- **`permits.fs` `~/` and `$HOME/` grants expand at run.** A confined
+  `exec` can name `~/.gitconfig` instead of one laptop's `/Users/…`
+  path, so the grant that makes `git` (or `python3`, or any tool that
+  reads its own installed state) work is one a shared workflow can
+  commit. Expansion uses the operator `HOME`; `~user` and another
+  tree stay out, and `permits.exec: ["git"]` still does not grant the
+  homedir — the author names `~/.gitconfig`.

--- a/crates/nika-acp/Cargo.lock
+++ b/crates/nika-acp/Cargo.lock
@@ -2151,6 +2151,7 @@ dependencies = [
 name = "nika-exec-runner"
 version = "0.114.0"
 dependencies = [
+ "nika-cap",
  "nika-kernel",
  "nika-schema",
  "nika-types",

--- a/crates/nika-cap/public-api.txt
+++ b/crates/nika-cap/public-api.txt
@@ -459,7 +459,9 @@ pub fn nika_cap::Permits::new() -> Self
 impl nika_cap::Permits
 pub fn nika_cap::Permits::allows_host(&self, host: &str) -> bool
 pub fn nika_cap::Permits::allows_path(&self, path: &str, write: bool) -> bool
+pub fn nika_cap::Permits::allows_path_in(&self, path: &str, write: bool, home: core::option::Option<&str>) -> bool
 pub fn nika_cap::Permits::jail_admits_read(&self, path: &str) -> bool
+pub fn nika_cap::Permits::jail_admits_read_in(&self, path: &str, home: core::option::Option<&str>) -> bool
 impl nika_cap::Permits
 pub fn nika_cap::Permits::intersect(&self, other: &Self) -> Self
 pub fn nika_cap::Permits::union(&self, other: &Self) -> Self
@@ -735,6 +737,7 @@ pub fn nika_cap::builtin_shape_findings(tool: &str, args: core::option::Option<&
 pub fn nika_cap::chart_vl_sibling(tool: &str, args: core::option::Option<&serde_json::value::Value>) -> core::option::Option<alloc::string::String>
 pub fn nika_cap::code_bearing_path_class(path: &str) -> core::option::Option<(&'static str, &'static str)>
 pub fn nika_cap::compose_child_env(lookup: impl core::ops::function::Fn(&str) -> core::option::Option<alloc::string::String>, passthrough: &[alloc::string::String], authored: &alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>) -> alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+pub fn nika_cap::expand_home_grant(glob: &str, home: &str) -> alloc::string::String
 pub fn nika_cap::glob_admits(glob: &str, path: &str) -> bool
 pub fn nika_cap::glob_matches(glob: &str, value: &str) -> bool
 pub fn nika_cap::glob_walk_root(pattern: &str) -> alloc::string::String

--- a/crates/nika-cap/src/fit.rs
+++ b/crates/nika-cap/src/fit.rs
@@ -11,6 +11,10 @@
 //! glob's literal prefix no longer string-matches it. Symlink escapes still
 //! need the runtime canonicalize-then-confine check (`NIKA-SEC-004`) — a
 //! static pass cannot resolve a link.
+//!
+//! Home-anchored grants (`~/` · `$HOME/` · `${HOME}/`) stay authored as-is
+//! so a tracked workflow is portable. [`expand_home_grant`] rewrites them
+//! against the operator home at match time; `~user` is left intact.
 
 use crate::Permits;
 
@@ -30,11 +34,25 @@ impl Permits {
     /// Whether `path` matches the declared `permits.fs` allowlist for the
     /// direction (`write` selects `fs.write`, else `fs.read`). Default-deny:
     /// an omitted `fs` block forbids all paths. Traversal-safe (see module doc).
+    ///
+    /// Home-anchored grants stay literal here — the check has no operator
+    /// `HOME`. The run-time twin is [`Self::allows_path_in`].
     #[must_use]
     pub fn allows_path(&self, path: &str, write: bool) -> bool {
+        self.allows_path_in(path, write, None)
+    }
+
+    /// [`Self::allows_path`], expanding `~/` and `$HOME/` grants against
+    /// `home` first (the operator home at run). A missing or non-absolute
+    /// home leaves those grants inert — they do not become `/**`.
+    #[must_use]
+    pub fn allows_path_in(&self, path: &str, write: bool, home: Option<&str>) -> bool {
         self.fs.as_ref().is_some_and(|fs| {
             let globs = if write { &fs.write } else { &fs.read };
-            globs.iter().any(|g| path_glob_matches(g, path))
+            globs.iter().any(|g| match home {
+                Some(h) => path_glob_matches(&expand_home_grant(g, h), path),
+                None => path_glob_matches(g, path),
+            })
         })
     }
 
@@ -73,9 +91,55 @@ impl Permits {
     /// this predicate exists to catch.
     #[must_use]
     pub fn jail_admits_read(&self, path: &str) -> bool {
-        self.fs
-            .as_ref()
-            .is_some_and(|fs| fs.read.iter().any(|g| bound_subtree_admits(g, path)))
+        self.jail_admits_read_in(path, None)
+    }
+
+    /// [`Self::jail_admits_read`], expanding `~/` and `$HOME/` grants
+    /// against `home` first — the same rewrite the exec jail applies
+    /// before it binds a subpath.
+    #[must_use]
+    pub fn jail_admits_read_in(&self, path: &str, home: Option<&str>) -> bool {
+        self.fs.as_ref().is_some_and(|fs| {
+            fs.read.iter().any(|g| match home {
+                Some(h) => bound_subtree_admits(&expand_home_grant(g, h), path),
+                None => bound_subtree_admits(g, path),
+            })
+        })
+    }
+}
+
+/// Expand a `~/` or `$HOME/` fs grant against the operator `home`.
+///
+/// The authored spelling stays portable (`~/.gitconfig`); this rewrite
+/// is what makes it match the live absolute path. `~user` and `$HOMEDIR`
+/// are left intact — they are not this operator's home. An empty or
+/// non-absolute `home` is a no-op (the grant stays inert rather than
+/// becoming `/…` or `/**`).
+#[must_use]
+pub fn expand_home_grant(glob: &str, home: &str) -> String {
+    let home = home.trim_end_matches('/');
+    if home.is_empty() || !home.starts_with('/') {
+        return glob.to_owned();
+    }
+    let rest = if let Some(rest) = glob.strip_prefix("~/") {
+        Some(rest)
+    } else if glob == "~" {
+        Some("")
+    } else if let Some(rest) = glob.strip_prefix("$HOME/") {
+        Some(rest)
+    } else if glob == "$HOME" {
+        Some("")
+    } else if let Some(rest) = glob.strip_prefix("${HOME}/") {
+        Some(rest)
+    } else if glob == "${HOME}" {
+        Some("")
+    } else {
+        None
+    };
+    match rest {
+        None => glob.to_owned(),
+        Some("") => home.to_owned(),
+        Some(rest) => format!("{home}/{rest}"),
     }
 }
 
@@ -473,5 +537,120 @@ mod tests {
                 );
             }
         }
+    }
+
+    fn home_grant(read: &str) -> Permits {
+        let mut p = Permits::new();
+        p.fs = Some(FsPermits {
+            read: vec![read.into()],
+            write: vec![],
+        });
+        p
+    }
+
+    /// #1025 — a portable `~/` grant matches this operator's home after
+    /// expansion, not another tree, and never becomes `/**`.
+    #[test]
+    fn a_tilde_grant_matches_the_operator_home_after_expansion() {
+        let home = "/tmp/nika-op-home";
+        let p = home_grant("~/.gitconfig");
+        assert!(
+            !p.allows_path(&format!("{home}/.gitconfig"), false),
+            "without a home, ~ is a literal spelling — the bug this closes"
+        );
+        assert!(
+            p.allows_path_in(&format!("{home}/.gitconfig"), false, Some(home)),
+            "the operator home after expansion"
+        );
+        assert!(
+            p.jail_admits_read_in(&format!("{home}/.gitconfig"), Some(home)),
+            "the jail binds the expanded exact file"
+        );
+        assert!(
+            !p.allows_path_in("/tmp/evil/.gitconfig", false, Some(home)),
+            "another tree"
+        );
+        assert!(!p.allows_path_in("/Users/other/.gitconfig", false, Some(home)));
+        assert!(
+            !p.allows_path_in("/etc/passwd", false, Some(home)),
+            "~ is not /**"
+        );
+        assert!(!p.jail_admits_read_in("/etc/passwd", Some(home)));
+        assert!(
+            !p.allows_path_in(&format!("{home}/.ssh/id_rsa"), false, Some(home)),
+            "a sibling under home is not granted"
+        );
+    }
+
+    #[test]
+    fn a_dollar_home_grant_expands_the_same_way() {
+        let home = "/tmp/nika-op-home";
+        for grant in ["$HOME/.gitconfig", "${HOME}/.gitconfig"] {
+            let p = home_grant(grant);
+            assert!(p.allows_path_in(&format!("{home}/.gitconfig"), false, Some(home)));
+            assert!(!p.allows_path_in("/tmp/evil/.gitconfig", false, Some(home)));
+        }
+    }
+
+    #[test]
+    fn literal_etc_passwd_still_requires_an_absolute_grant() {
+        let home = "/tmp/nika-op-home";
+        assert!(!home_grant("~/.gitconfig").allows_path_in("/etc/passwd", false, Some(home)));
+        assert!(home_grant("/etc/passwd").allows_path("/etc/passwd", false));
+        assert!(
+            !home_grant("/etc/passwd").allows_path_in(
+                &format!("{home}/.gitconfig"),
+                false,
+                Some(home)
+            ),
+            "an absolute grant is not a home grant"
+        );
+    }
+
+    #[test]
+    fn exec_git_does_not_auto_grant_the_homedir() {
+        let mut p = Permits::new();
+        p.exec = Some(crate::ExecPermit::Programs(vec!["git".into()]));
+        assert!(p.allows_program("git"));
+        assert!(
+            !p.allows_path_in(
+                "/tmp/nika-op-home/.gitconfig",
+                false,
+                Some("/tmp/nika-op-home")
+            ),
+            "permits.exec: [git] is not a home grant — the author still names ~/.gitconfig"
+        );
+    }
+
+    #[test]
+    fn expand_home_grant_is_prefix_only() {
+        let home = "/tmp/nika-op-home";
+        assert_eq!(
+            expand_home_grant("~/.config/git/**", home),
+            "/tmp/nika-op-home/.config/git/**"
+        );
+        assert_eq!(expand_home_grant("~", home), home);
+        assert_eq!(
+            expand_home_grant("~other/.gitconfig", home),
+            "~other/.gitconfig",
+            "~user is not this operator"
+        );
+        // A longer variable name that begins with the same four letters
+        // is not the operator home variable and must stay literal.
+        assert_eq!(
+            expand_home_grant("$HOMEDIR/.gitconfig", home),
+            "$HOMEDIR/.gitconfig"
+        );
+        assert_eq!(
+            expand_home_grant("~/.gitconfig", "relative"),
+            "~/.gitconfig",
+            "a non-absolute home is a no-op"
+        );
+        assert_eq!(expand_home_grant("~/.gitconfig", ""), "~/.gitconfig");
+        assert_eq!(
+            expand_home_grant("./data/**", home),
+            "./data/**",
+            "in-tree grants are untouched"
+        );
     }
 }

--- a/crates/nika-cap/src/lib.rs
+++ b/crates/nika-cap/src/lib.rs
@@ -59,7 +59,7 @@ pub use expr::{
     WITHHELD_JQ_NATIVES, WithheldNative, is_withheld_jq_native, withheld_jq_native,
     withheld_jq_reason,
 };
-pub use fit::{glob_admits, lexically_normalize};
+pub use fit::{expand_home_grant, glob_admits, lexically_normalize};
 // P3 B5 · the harness permission-bridge judge (the pure half — the
 // wire facts' translation into the declared boundary's verdict).
 pub use harness_gate::{HarnessAskFacts, HarnessGate, judge_harness_ask};

--- a/crates/nika-cap/src/trifecta.rs
+++ b/crates/nika-cap/src/trifecta.rs
@@ -190,7 +190,13 @@ pub struct TrifectaVerdict {
 /// fit.rs doctrine: dropping it would collapse an out-of-boundary glob into
 /// an in-boundary one).
 fn write_glob_escapes(glob: &str) -> bool {
-    if glob.starts_with('/') || glob.starts_with('~') {
+    if glob.starts_with('/')
+        || glob.starts_with('~')
+        || glob == "$HOME"
+        || glob.starts_with("$HOME/")
+        || glob == "${HOME}"
+        || glob.starts_with("${HOME}/")
+    {
         return true;
     }
     lexically_normalize(glob).starts_with("..")
@@ -593,6 +599,11 @@ mod tests {
     fn write_glob_escape_variants() {
         assert!(write_glob_escapes("/etc/passwd"), "absolute escapes");
         assert!(write_glob_escapes("~/loot.txt"), "home escapes");
+        assert!(write_glob_escapes("$HOME/loot.txt"), "$HOME escapes");
+        assert!(
+            write_glob_escapes("${HOME}/loot.txt"),
+            "dollar-brace HOME escapes"
+        );
         assert!(write_glob_escapes("../outside.txt"), "climb escapes");
         assert!(write_glob_escapes("./out/../../etc/x"), "normalized climb");
         assert!(!write_glob_escapes("./out/**"), "workspace write stays");

--- a/crates/nika-exec-runner/Cargo.toml
+++ b/crates/nika-exec-runner/Cargo.toml
@@ -23,6 +23,9 @@ nika-kernel = { path = "../nika-kernel", version = "0.114.0" }
 # leaf carries the ONE argv exec-floor predicate (#605 · exec::argv_floor_refusal)
 # the blocklist wrapper and the `nika check` SEC-001 finding both judge with.
 nika-types = { path = "../nika-types", version = "0.114.0" }
+# L0 · home-grant expansion (`~/` · `$HOME/`) the spawn-side SandboxSpec
+# applies at run so a tracked workflow does not bake one machine's home.
+nika-cap = { path = "../nika-cap", version = "0.114.0" }
 # L0 · the declared `permits:` vocabulary the spawn-side SandboxSpec derives
 # from (sandbox_spec · descended from nika-runtime::dispatch at the 15k wall ·
 # ADR-110 · #889). L1 → L0, no cycle possible.

--- a/crates/nika-exec-runner/public-api.txt
+++ b/crates/nika-exec-runner/public-api.txt
@@ -26,6 +26,7 @@ pub fn nika_exec_runner::sandbox_spec::PathMismatch::from(t: T) -> T
 impl<T> nika_error::traits::AsAny for nika_exec_runner::sandbox_spec::PathMismatch where T: 'static
 pub fn nika_exec_runner::sandbox_spec::PathMismatch::as_any(&self) -> &(dyn core::any::Any + 'static)
 pub fn nika_exec_runner::sandbox_spec::spec_of(permits: &nika_cap::permits::Permits, root: &std::path::Path) -> core::result::Result<nika_kernel_core::io::process::SandboxSpec, alloc::boxed::Box<nika_exec_runner::sandbox_spec::PathMismatch>>
+pub fn nika_exec_runner::sandbox_spec::spec_of_with_home(permits: &nika_cap::permits::Permits, root: &std::path::Path, home: core::option::Option<&str>) -> core::result::Result<nika_kernel_core::io::process::SandboxSpec, alloc::boxed::Box<nika_exec_runner::sandbox_spec::PathMismatch>>
 #[non_exhaustive] pub enum nika_exec_runner::EgressEvent
 pub nika_exec_runner::EgressEvent::Closed
 pub nika_exec_runner::EgressEvent::Closed::bytes_down: u64

--- a/crates/nika-exec-runner/src/sandbox_spec.rs
+++ b/crates/nika-exec-runner/src/sandbox_spec.rs
@@ -18,6 +18,10 @@
 //!   absolute subpaths only (`grant_subpath` fail-closes on a relative
 //!   grant), so the derivation absolutizes HERE — a task-level `cwd:`
 //!   does not re-anchor the boundary, exactly like the builtin gate.
+//!   Home-anchored grants (`~/` · `$HOME/` · `${HOME}/`) expand against the operator
+//!   `HOME` at the same moment, so a tracked workflow can name
+//!   `~/.gitconfig` without baking one machine's `/Users/…` path. `~user`
+//!   is left intact and stays the launchers' fail-closed refusal.
 //! - **Network is a tri-state** ([`NetPolicy`](nika_kernel::process::NetPolicy)
 //!   · the Anthropic
 //!   sandbox-runtime model): `net.http` non-empty maps to `Allowlist`
@@ -42,6 +46,7 @@
 
 use std::path::{Component, Path, PathBuf};
 
+use nika_cap::expand_home_grant;
 use nika_kernel::process::{EgressAllowlist, NetPolicy, SandboxSpec};
 use nika_schema::types::Permits;
 
@@ -63,6 +68,8 @@ pub struct PathMismatch {
 /// NEP-0009: every fs grant's literal prefix must keep its judged identity
 /// on the live filesystem — an escape refuses the whole derivation (the
 /// task never spawns) and is never rewritten to the resolved form.
+/// Home-anchored grants need [`spec_of_with_home`]: this entry does not
+/// read `HOME`.
 ///
 /// # Errors
 ///
@@ -70,14 +77,31 @@ pub struct PathMismatch {
 /// declared set (NEP-0009 law 1+2) — the caller refuses the dispatch and
 /// attests the judged prefix + the resolved target.
 pub fn spec_of(permits: &Permits, root: &Path) -> Result<SandboxSpec, Box<PathMismatch>> {
+    spec_of_with_home(permits, root, None)
+}
+
+/// [`spec_of`] with an injected operator home so `~/` · `$HOME/` · `${HOME}/` fs
+/// grants become live absolute paths on the jail. Production dispatch
+/// reads `HOME` at the runtime seam and passes it here — this crate does
+/// not touch the environment. `None` leaves those grants unexpanded, and
+/// the launchers then fail-close on a non-absolute leftover.
+///
+/// # Errors
+///
+/// Same as [`spec_of`].
+pub fn spec_of_with_home(
+    permits: &Permits,
+    root: &Path,
+    home: Option<&str>,
+) -> Result<SandboxSpec, Box<PathMismatch>> {
     let (read, write) = permits
         .fs
         .as_ref()
         .map(|fs| (fs.read.as_slice(), fs.write.as_slice()))
         .unwrap_or_default();
     let mut spec = SandboxSpec::new();
-    spec.fs_read = read.iter().map(|g| absolutize(root, g)).collect();
-    spec.fs_write = write.iter().map(|g| absolutize(root, g)).collect();
+    spec.fs_read = read.iter().map(|g| absolutize(root, g, home)).collect();
+    spec.fs_write = write.iter().map(|g| absolutize(root, g, home)).collect();
     for (grant, access) in spec
         .fs_read
         .iter()
@@ -118,8 +142,10 @@ fn net_policy_of(permits: &Permits) -> NetPolicy {
 /// the judged path · REFUSE, never rewrite (NEP-0009 backwards-compat: the
 /// author declares the effective path). A not-yet-existing tail (the legal
 /// new-write · law 5) folds identically on both sides → admitted. Non-
-/// absolute shapes (`~` · a preserved escape) pass through untouched — the
-/// launchers' `grant_subpath` owns their fail-closed refusal, as before.
+/// absolute leftover (`~user` · a preserved escape) pass through untouched —
+/// the launchers' `grant_subpath` owns their fail-closed refusal, as before.
+/// `~/` · `$HOME/` · `${HOME}/` are expanded against the operator home before this
+/// gate sees them.
 fn judge_identity(grant: &str, access: &'static str) -> Result<(), Box<PathMismatch>> {
     if !grant.starts_with('/') {
         return Ok(());
@@ -218,12 +244,25 @@ fn fold_trailing<'a>(base: PathBuf, comps: impl Iterator<Item = &'a Component<'a
 /// `lexically_normalize` semantics the fit checker already pins, so a
 /// `data/../out/**` grant reads identically on both seams). An absolute
 /// glob passes through unchanged — including the shapes the launchers
-/// refuse (`~` · a preserved leading `..` · a bare system root): their
+/// refuse (`~user` · a preserved leading `..` · a bare system root): their
 /// fail-closed `Profile` refusal is the honest verdict, named to the
-/// operator, never a silent widening.
-fn absolutize(root: &Path, glob: &str) -> String {
-    if glob.starts_with('/') || glob.starts_with('~') {
-        return glob.to_owned();
+/// operator, never a silent widening. `~/` · `$HOME/` · `${HOME}/` expand first so
+/// the jail lists the live absolute path.
+fn absolutize(root: &Path, glob: &str, home: Option<&str>) -> String {
+    let glob = match home {
+        Some(h) => expand_home_grant(glob, h),
+        None => glob.to_owned(),
+    };
+    if glob.starts_with('/') {
+        return glob;
+    }
+    if glob.starts_with('~')
+        || glob == "$HOME"
+        || glob.starts_with("$HOME/")
+        || glob == "${HOME}"
+        || glob.starts_with("${HOME}/")
+    {
+        return glob;
     }
     lexically_normalize(&root.join(glob))
 }
@@ -353,7 +392,7 @@ mod tests {
             let spec = spec_of(&p, root).expect("no symlink on the judged prefixes");
             let mut jail = Permits::new();
             jail.fs = Some(nika_schema::types::FsPermits::new(spec.fs_read, vec![]));
-            let jail_admits = jail.jail_admits_read(&absolutize(root, script));
+            let jail_admits = jail.jail_admits_read(&absolutize(root, script, None));
             assert_eq!(
                 jail_admits, *admitted,
                 "the jail must admit exactly what the reference admits — \
@@ -542,13 +581,87 @@ mod tests {
         let _ = std::fs::remove_dir_all(&base);
     }
 
-    /// The launcher-refused shapes (`~` · relative escapes) pass through
-    /// unjudged — `grant_subpath`'s fail-closed refusal stays the honest
-    /// verdict for them, exactly as before NEP-0009.
+    /// A missing or non-absolute home leaves every portable spelling
+    /// non-absolute for the launchers' fail-closed refusal. `~user` is
+    /// likewise never expanded.
     #[test]
-    fn non_absolute_shapes_stay_the_launchers_refusal() {
-        let spec = spec_of(&permits(&["~/x/**"], &[], &[]), Path::new("/repo"))
-            .expect("the `~` shape is the launcher's refusal, not this gate's");
-        assert_eq!(spec.fs_read, vec!["~/x/**".to_owned()]);
+    fn unresolved_home_grants_stay_the_launchers_refusal() {
+        let spec = spec_of_with_home(
+            &permits(&["~other/.gitconfig"], &[], &[]),
+            Path::new("/repo"),
+            Some("/tmp/nika-op-home"),
+        )
+        .expect("`~user` is the launcher's refusal, not this gate's");
+        assert_eq!(spec.fs_read, vec!["~other/.gitconfig".to_owned()]);
+
+        let grants = [
+            "~",
+            "~/x/**",
+            "$HOME",
+            "$HOME/.gitconfig",
+            "${HOME}",
+            "${HOME}/.config/git/**",
+        ];
+        for home in [None, Some("relative/home")] {
+            let spec = spec_of_with_home(&permits(&grants, &[], &[]), Path::new("/repo"), home)
+                .expect("an unresolved home stays for the launcher's refusal");
+            assert_eq!(spec.fs_read, grants, "home = {home:?}");
+            assert!(
+                spec.fs_read.iter().all(|grant| !grant.starts_with('/')),
+                "no unresolved home grant may root-anchor: {:?}",
+                spec.fs_read
+            );
+        }
+    }
+
+    /// #1025 — a portable `~/` grant becomes this operator's absolute
+    /// path on the jail spec, not another tree, and never `/**`.
+    #[test]
+    fn a_tilde_grant_expands_to_the_operator_home_on_the_jail() {
+        let home = "/tmp/nika-op-home";
+        let spec = spec_of_with_home(
+            &permits(
+                &[
+                    "~",
+                    "~/.gitconfig",
+                    "$HOME",
+                    "$HOME/.config/git/**",
+                    "${HOME}",
+                    "${HOME}/.local/state/nika/**",
+                ],
+                &[],
+                &[],
+            ),
+            Path::new("/repo"),
+            Some(home),
+        )
+        .expect("home grants expand to absolute paths, then judge");
+        assert_eq!(
+            spec.fs_read,
+            vec![
+                home.to_owned(),
+                format!("{home}/.gitconfig"),
+                home.to_owned(),
+                format!("{home}/.config/git/**"),
+                home.to_owned(),
+                format!("{home}/.local/state/nika/**"),
+            ]
+        );
+        let mut jail = Permits::new();
+        jail.fs = Some(nika_schema::types::FsPermits::new(
+            spec.fs_read.clone(),
+            vec![],
+        ));
+        assert!(jail.jail_admits_read(&format!("{home}/.gitconfig")));
+        assert!(jail.jail_admits_read(&format!("{home}/.config/git/config")));
+        assert!(
+            !jail.jail_admits_read("/tmp/evil/.gitconfig"),
+            "another tree"
+        );
+        assert!(!jail.jail_admits_read("/Users/other/.gitconfig"));
+        assert!(
+            !jail.jail_admits_read("/etc/passwd"),
+            "~ is not /** · /etc/passwd still needs an absolute grant"
+        );
     }
 }

--- a/crates/nika-runtime/src/dispatch.rs
+++ b/crates/nika-runtime/src/dispatch.rs
@@ -540,16 +540,11 @@ where
         self.run_invoke_gated(note, input).await
     }
 
-    /// ADR-095 Layer 6 — the OS-confinement spec from the declared
-    /// boundary (the `dispatch/sandbox.rs` derivation). F-O8 « absent =
-    /// zero authority »: `None` maps to the EMPTY boundary's spec (fs
-    /// empty · net deny) — the double lock under `check_exec_permits`,
-    /// which already refuses the exec upstream. Fallible since NEP-0009
-    /// (LAW-AUTH-0330): a grant whose EFFECTIVE path identity escapes the
-    /// declared set refuses before spawn (`NIKA-SEC-004`) — witnessed on
-    /// the `fs` plane, granted and refused alike, the refusal attested as
-    /// `fs.path_mismatch` carrying the judged prefix and the resolved
-    /// target (never a silent rewrite: judged = mounted).
+    /// ADR-095 Layer 6 — derive the OS jail from the declared boundary. F-O8
+    /// maps absent permits to empty fs + denied net, under `check_exec_permits`.
+    /// Since NEP-0009 (LAW-AUTH-0330), an effective path escape refuses before
+    /// spawn as `NIKA-SEC-004`; its witness records `fs.path_mismatch`, the
+    /// judged prefix, and the resolved target. Judged = mounted, never rewritten.
     fn exec_sandbox_spec(
         &self,
         permits: Option<&nika_schema::types::Permits>,
@@ -564,7 +559,9 @@ where
             .clone()
             .or_else(|| std::env::current_dir().ok())
             .unwrap_or_default();
-        match nika_exec_runner::sandbox_spec::spec_of(permits, &root) {
+        #[allow(clippy::disallowed_methods)] // dispatch-owned absolute HOME for issue 1025
+        let home = std::env::var("HOME").ok().filter(|h| h.starts_with('/'));
+        match nika_exec_runner::sandbox_spec::spec_of_with_home(permits, &root, home.as_deref()) {
             Ok(spec) => {
                 for grant in spec.fs_read.iter().chain(spec.fs_write.iter()) {
                     witness.record(

--- a/crates/nika-runtime/src/dispatch/tests.rs
+++ b/crates/nika-runtime/src/dispatch/tests.rs
@@ -174,3 +174,86 @@ fn seated_infer_records_quota_without_any_numeric_meter_or_responder_claim() {
         Some(nika_types::cost::UnpricedReason::SubscriptionQuota)
     );
 }
+
+/// #1025 — the exec jail derives `permits.fs` through `spec_of`: a
+/// portable `~/` grant must land as this operator's absolute path, not
+/// as the literal `~` the launcher refuses, and not as another tree.
+#[test]
+fn a_tilde_fs_grant_expands_to_the_operator_home_on_the_jail() {
+    use nika_schema::types::{FsPermits, Permits};
+
+    let home = "/tmp/nika-op-home";
+    let mut permits = Permits::new();
+    permits.fs = Some(FsPermits::new(
+        vec!["~/.gitconfig".into(), "$HOME/.config/git/**".into()],
+        vec![],
+    ));
+    let spec = nika_exec_runner::sandbox_spec::spec_of_with_home(
+        &permits,
+        std::path::Path::new("/repo"),
+        Some(home),
+    )
+    .expect("home grants expand to absolute paths");
+    assert_eq!(
+        spec.fs_read,
+        vec![
+            format!("{home}/.gitconfig"),
+            format!("{home}/.config/git/**"),
+        ]
+    );
+    let mut jail = Permits::new();
+    jail.fs = Some(FsPermits::new(spec.fs_read, vec![]));
+    assert!(jail.jail_admits_read(&format!("{home}/.gitconfig")));
+    assert!(!jail.jail_admits_read("/tmp/evil/.gitconfig"));
+    assert!(!jail.jail_admits_read("/etc/passwd"));
+}
+
+/// #1025 — the production launcher receives unresolved portable home
+/// grants as non-absolute paths and refuses before spawn. Both missing
+/// and non-absolute homes cover the three spellings and their exact tokens.
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+#[test]
+fn unresolved_home_grants_fail_closed_at_the_production_launcher() {
+    use nika_kernel::command_sandbox::{CommandSandbox, CommandSandboxError};
+    use nika_kernel::process::ShellCommand;
+    use nika_schema::types::{FsPermits, Permits};
+
+    #[cfg(target_os = "linux")]
+    let sandbox = nika_sandbox_landlock::LandlockSandbox::new();
+    #[cfg(target_os = "macos")]
+    let sandbox = nika_sandbox_seatbelt::SeatbeltSandbox::new();
+
+    let grants = [
+        "~",
+        "~/.gitconfig",
+        "$HOME",
+        "$HOME/.gitconfig",
+        "${HOME}",
+        "${HOME}/.config/git/**",
+    ];
+    for home in [None, Some("relative/home")] {
+        for grant in grants {
+            let mut permits = Permits::new();
+            permits.fs = Some(FsPermits::new(vec![grant.to_owned()], vec![]));
+            let spec = nika_exec_runner::sandbox_spec::spec_of_with_home(
+                &permits,
+                std::path::Path::new("/repo"),
+                home,
+            )
+            .expect("an unresolved home reaches the launcher's refusal");
+            assert_eq!(spec.fs_read, vec![grant], "home = {home:?}");
+            assert!(!spec.fs_read[0].starts_with('/'));
+
+            let refusal = sandbox
+                .confine(&spec, ShellCommand::new("/usr/bin/true"))
+                .expect_err("an unresolved home grant must refuse before spawn");
+            assert!(
+                matches!(
+                    refusal,
+                    CommandSandboxError::Profile { .. } | CommandSandboxError::Unavailable { .. }
+                ),
+                "home = {home:?}, grant = {grant:?}: {refusal:?}"
+            );
+        }
+    }
+}

--- a/docs/crate-specs/nika-exec-runner.md
+++ b/docs/crate-specs/nika-exec-runner.md
@@ -6,7 +6,7 @@
 | Layer | L1 — effect crate · the only production site spawning PLAIN subprocesses (`tokio::process`) — one deliberate second site: `nika-mcp`’s stdio MCP client (a persistent pipe session the one-shot shell seam cannot express) |
 | Design | `TokioShell` impl of the L0.5 `nika_kernel::process` traits (`ShellRun` + `ShellCancel`) via the `*Dyn` (`Send`) companions · SECURITY-SENSITIVE (command blocklist + injection defense) |
 | LOC budget | well under the ≤1500/file + ≤15k/crate caps (enforced live by vectors 12+24) · live count · `scripts/crate-metrics.sh nika-exec-runner` |
-| LOC (live) | ~3137 LOC src (live · `scripts/crate-metrics.sh nika-exec-runner`) |
+| LOC (live) | ~3755 LOC src (live · `scripts/crate-metrics.sh nika-exec-runner`) |
 | Function cap | ≤100 lines each |
 | Crate version | tracks workspace |
 | License | `AGPL-3.0-or-later` |
@@ -150,7 +150,7 @@ AND stderr) is therefore capped at **64 MiB** (`MAX_OUTPUT_BYTES`):
 |---|---|---|
 | 1 SPEC | ✅ | this file |
 | 2 TDD | ✅ | `tests/exec_contract.rs` (14 subprocess contract) + blocklist/lib unit (25) authored first · RED → GREEN |
-| 3 IMPL | ✅ | ~1412 LOC src (live · `scripts/crate-metrics.sh`) · zero unwrap/expect in src |
+| 3 IMPL | ✅ | ~3755 LOC src (live · `scripts/crate-metrics.sh nika-exec-runner`) · zero unwrap/expect in src |
 | 4 CLIPPY 0 | ✅ | `cargo clippy --workspace --all-targets -- -D warnings` GREEN |
 | 5 MUTATION ≥90% | ✅ | `cargo mutants -p nika-exec-runner` · 28 mutants · **23 caught / 25 viable = 92%** (3 unviable). 2 documented survivors, both non-security: (a) the `basename_normalized` OR-branch — an EQUIVALENT mutant (for the current patterns `basename(s).contains(p) ⇒ lower.contains(p)`, so it never uniquely matches · pure defense-in-depth redundancy that would only bite a future mid-path pattern); (b) the `-1` exit sentinel for signal-death (`status.code()==None`) — cosmetic, no control-flow/security impact. The killers added: dequoted-sole-matcher (`/d'e'v/tcp/`) + quote-bypass-via-dequoting + basename helper + shell-expansion regression set. |
 | 6 PROPERTY | ✅ | security unit-battery: each normalization layer (NFKC/zero-width/quote/basename) blocked · shell-expansion bypasses ($IFS/$VAR/$()/backtick/fullwidth-$) refused · safe commands + plain pipes allowed |

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -2471,6 +2471,7 @@ dependencies = [
 name = "nika-exec-runner"
 version = "0.114.0"
 dependencies = [
+ "nika-cap",
  "nika-kernel",
  "nika-schema",
  "nika-types",


### PR DESCRIPTION
## Summary

- expand `~/`, `$HOME/`, and `${HOME}/` filesystem grants only against an absolute operator home at the runtime dispatch seam
- leave missing or relative homes unresolved so Seatbelt and Landlock refuse before spawn
- pin both the admitted absolute-home path and all fail-closed unresolved spellings
- preserve the integrated P4 runtime test while keeping `nika-runtime` below its 15k wall

## Verification

- `cargo test -p nika-cap -p nika-exec-runner -p nika-runtime -p nika-sandbox-landlock -p nika-sandbox-seatbelt --lib`
- `cargo clippy -p nika-cap -p nika-exec-runner -p nika-runtime -p nika-sandbox-landlock -p nika-sandbox-seatbelt --all-targets -- -D warnings`
- exact runtime admission and refusal tests
- full pre-push gate: green · 11/11 ratchets · runtime 14996/15000 LOC

Supersedes #1216.
Closes #1025.

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>
Signed-off-by: Thibaut Melen <20891897+ThibautMelen@users.noreply.github.com>