### PR TITLE
fix(ci): one rule, one reader for the test-item scope

### DIFF
--- a/scripts/ci/_lib.sh
+++ b/scripts/ci/_lib.sh
@@ -312,7 +312,27 @@ strip_test_items() {
         print ""
         next
       }
-      if ($0 ~ /^[[:space:]]*#\[cfg\(test\)\][[:space:]]*$/) {
+      # `#[cfg(test)]` and the `all`/`any` composites (#1207). The private
+      # python copies this filter replaced already knew the composite form —
+      # `#[cfg(all(test, unix))]` guards the hermetic adapter fixtures in
+      # nika-harness — while this one only knew the bare attribute. Reading
+      # through here without teaching it that would have traded one blindness
+      # for another, and reddened ten lines of real test code on main.
+      #
+      # `not` is excluded BY CONSTRUCTION rather than by a negative lookahead
+      # POSIX awk does not have: the composite arm admits the literals `all`
+      # and `any` and nothing else, so `#[cfg(not(test))]` — production code
+      # that must stay visible — matches neither arm.
+      #
+      # The trailing class admits `)` as well as space and comma. Leaving it
+      # out looked safe (it was what kept `not(test)` out) and silently
+      # dropped `#[cfg(all(test))]`, valid Rust with no second predicate —
+      # test code read as production. Two guards for one job is how the weak
+      # one goes unnoticed: the literal list is the guard, and it is the only
+      # one. Mutation-pinned in test-strip-test-items.sh from both sides.
+      if ($0 ~ /^[[:space:]]*#\[cfg\(test\)\][[:space:]]*$/ ||
+          ($0 ~ /^[[:space:]]*#\[cfg\([[:space:]]*(all|any)[[:space:]]*\([[:space:]]*test[[:space:],)]/ &&
+           $0 ~ /\][[:space:]]*$/)) {
         pending = 1; print ""; next
       }
       if ($0 ~ /^[[:space:]]*#\[test\][[:space:]]*$/) {

--- a/scripts/ci/check-expect.sh
+++ b/scripts/ci/check-expect.sh
@@ -1,126 +1,61 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC1091  # _lib.sh sourced at runtime
 # Ratchet: zero `.expect(` calls in production src/.
 #
 # "Production" = lines outside `#[cfg(test)]` / `#[test]` items, in any
 # `*/src/*.rs` file whose basename is not `tests.rs`. Mirrors clippy's
 # `expect_used` lint scoping. This script promotes the workspace-level
-# `expect_used = "warn"` to a hard block on the `nika-diamond` branch.
+# `expect_used = "warn"` to a hard block on this branch.
 #
-# Uses Python3 for context-aware detection: tracks brace depth to distinguish
-# #[cfg(test)] modules and #[test] function bodies from production code.
-# String and char literals are stripped before brace counting so braces
-# inside string content do not unbalance the depth counter.
+# ONE RULE, ONE READER (#1207). Until 2026-08-25 this gate carried a private
+# python re-implementation of the test-item scope. It read `#[cfg(test)]` as
+# an attribute waiting for a brace, so a declaration —
+#
+#     #[cfg(test)]
+#     mod tests;
+#
+# — left the flag pending and the NEXT block became the "test" region. A
+# production `.expect(` inside that block was then invisible. Verified on two
+# fixtures differing only in the module's shape: the shipped reader saw 0
+# where the shared filter saw 1. Silent direction: it does not raise a false
+# finding, it stops reporting real ones.
+#
+# The delta over the tree at the time of the change was ZERO (782 files, 0 vs
+# 0), so nothing was leaking. It was a latent hole in a load-bearing ratchet,
+# and the remedy is not a second patched copy — it is to stop having copies.
+# `_lib.sh::strip_test_items` already ends a pending item at `;` and already
+# blanks string, raw-string and char literals before counting braces, lessons
+# the private copies never inherited. `scripts/ci/check-unwrap.sh` has read
+# through it all along; this file now does the same, and its behaviour is
+# pinned by `test-strip-test-items.sh`, which the shared filter's readers run
+# before they judge anything.
+#
+# Exit codes: 0 — OK · 1 — RED (production .expect( found)
 set -euo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source-path=SCRIPTDIR
 # shellcheck source=./_lib.sh
 . "$HERE/_lib.sh"
 
-# Load allowlist (P1-2 Batch H+: pre-existing violations surfaced by errexit fix)
+# Pre-existing violations (Batch H+ 2026-04-15). Each entry names a file the
+# ratchet skips until it is fixed; the reasons live beside the entries. Note
+# that several exist because `strip_test_items` cannot parse
+# `#[cfg(all(test, ...))]` — a documented limitation of the shared filter, so
+# reading through it does not change what those entries are for.
 ALLOWLIST_FILE="$HERE/allowlist-expect.conf"
 _allowed_files=""
-if [[ -f "$ALLOWLIST_FILE" ]]; then
+if [ -f "$ALLOWLIST_FILE" ]; then
   _allowed_files="$(grep -v '^#' "$ALLOWLIST_FILE" | grep -v '^$' || true)"
 fi
-
-# Python helper written to a temp script so it can be called per-file without
-# bash here-doc-in-subshell limitations.
-# No suffix after the Xs: BSD/macOS mktemp only randomizes TRAILING Xs, so
-# `…_XXXXXX.py` degraded to a LITERAL name — two concurrent pre-push hooks
-# (parallel worktree pushes) collided on it with `mkstemp failed: File
-# exists`, blocking whichever push ran second (observed 2026-07-10). Python
-# runs any filename; portability beats the extension.
-_PY_CHECKER="$(mktemp /tmp/check_expect_XXXXXX)"
-trap 'rm -f "$_PY_CHECKER"' EXIT
-
-cat >"$_PY_CHECKER" <<'PYEOF'
-import re, sys
-
-def strip_str_lits(line):
-    """Strip string/char literal CONTENTS for brace counting.
-    Handles "...", b"...", r"...", br"..." and char literals b?'.'.
-    Order matters: raw strings first (no backslash escaping, simpler pattern),
-    then char literals (so a '"' char literal cannot start a fake string),
-    then regular strings with negative lookbehind for remaining r/# prefixes.
-    r#"..."# raw strings (hash-delimited) are not stripped here; their braces
-    typically balance and the multi-hash terminator needs a more complex parser.
-    """
-    # Pass 0a: plain raw r"..." (word boundary ensures no mid-identifier match)
-    s = re.sub(r'\br"[^"]*"', 'r""', line)
-    # Pass 0b: byte raw br"..."
-    s = re.sub(r'(?<!\w)br"[^"]*"', 'br""', s)
-    # Pass 1: collapse char literals  b?'(\\.|[^'\\])' -> ''
-    s = re.sub(r"b?'(\\.|[^'\\])'", "''", s)
-    # Pass 2: collapse regular + byte string literals -> ""
-    # Lookbehind (?<![r#]) skips r#"..."# and br#"..."# (char before " is r or #)
-    # After pass 0a/0b, r"" and br"" are already collapsed so pass 2 won't re-match.
-    s = re.sub(r'(?<![r#])b?"(?:\\.|[^"\\])*"', '""', s)
-    # Pass 3: strip // line comments (after strings collapsed)
-    m = s.find('//')
-    if m >= 0:
-        s = s[:m]
-    return s
-
-path = sys.argv[1]
-with open(path, encoding='utf-8', errors='replace') as fh:
-    lines = fh.readlines()
-
-brace_depth = 0
-cfg_test_entry = None   # brace_depth at entry of #[cfg(test)] mod
-test_fn_entry  = None   # brace_depth at entry of #[test] fn body
-saw_cfg_test   = False  # just saw #[cfg(test)] attribute
-saw_test_attr  = False  # just saw #[test]/#[tokio::test] attribute
-saw_test_fn    = False  # saw fn keyword after test attr (waiting for {)
-
-for lineno, line in enumerate(lines, 1):
-    s = line.strip()
-
-    # --- detect scope markers BEFORE brace counting ---
-    if re.match(r'#\[cfg\s*\(\s*(?!not\b)(?:(?:all|any)\s*\(\s*)?test\b', s):
-        saw_cfg_test = True
-    if re.match(r'#\[(?:(?:tokio::)?test|should_panic)(?:$|\s|\]|,)', s.rstrip()):
-        saw_test_attr = True
-    if saw_test_attr and not saw_test_fn and re.search(r'\bfn\s+\w', s):
-        saw_test_fn = True
-
-    # --- check for production expect BEFORE brace counting ---
-    in_test_scope = (cfg_test_entry is not None) or (test_fn_entry is not None)
-    if not in_test_scope and not s.startswith('//') and not s.startswith('/*'):
-        if re.search(r'\.expect\s*\(', line):
-            print(f'{lineno}:{s[:120]}')
-
-    # --- count braces with literal stripping ---
-    stripped = strip_str_lits(line)
-    for ch in stripped:
-        if ch == '{':
-            brace_depth += 1
-            if saw_cfg_test:
-                cfg_test_entry = brace_depth
-                saw_cfg_test = False
-            if saw_test_fn:
-                test_fn_entry = brace_depth
-                saw_test_fn = False
-                saw_test_attr = False
-        elif ch == '}':
-            brace_depth = max(0, brace_depth - 1)
-            if cfg_test_entry is not None and brace_depth < cfg_test_entry:
-                cfg_test_entry = None
-            if test_fn_entry is not None and brace_depth < test_fn_entry:
-                test_fn_entry = None
-                saw_test_attr = False
-                saw_test_fn = False
-PYEOF
 
 total=0
 found_any=0
 while IFS= read -r f; do
   [ -z "$f" ] && continue
-  # Skip allowlisted files
-  if [ -n "$_allowed_files" ] && echo "$_allowed_files" | grep -qF "$f"; then
+  if [ -n "$_allowed_files" ] && printf '%s\n' "$_allowed_files" | grep -qF "$f"; then
     continue
   fi
-  hits=$(python3 "$_PY_CHECKER" "$f" || true)
+  hits=$(strip_test_items "$f" | grep -nE '\.expect\(' || true)
   if [ -n "$hits" ]; then
     found_any=1
     printf '%s\n' "$hits" | sed "s|^|$f:|"

--- a/scripts/ci/test-strip-test-items.sh
+++ b/scripts/ci/test-strip-test-items.sh
@@ -56,6 +56,96 @@ fn x() {
 }
 '
 
+# --- a #[cfg(test)] DECLARATION must not swallow the next block (#1207) ---
+#
+# The bug this pins never lived here — it lived in three private copies of
+# this rule, one of which CI ran as the `expect` ratchet. Each read
+# `#[cfg(test)]` as an attribute waiting for a brace, so `mod tests;` left
+# the flag pending and the NEXT block became the "test" region. Measured on
+# two fixtures differing only in the module's shape: the shipped reader saw
+# 0 where this filter saw 1.
+#
+# The copies are gone and both ratchets read through here now, which makes
+# this the only place the behaviour can regress. It was correct and untested
+# for as long as it has existed; correct-and-untested is one edit from wrong.
+case_is 'a #[cfg(test)] mod DECLARATION does not hide the code after it' 1 'unwrap()' \
+  '#[cfg(test)]
+mod tests;
+
+pub fn production() -> String {
+    std::env::var("HOME").unwrap()
+}
+'
+
+case_is 'a #[cfg(test)] mod DECLARATION does not hide a later .expect(' 1 'expect(' \
+  '#[cfg(test)]
+mod tests;
+
+pub fn production() -> String {
+    std::env::var("HOME").expect("HOME must be set")
+}
+'
+
+# The same shape with a pub modifier and a doc comment between the attribute
+# and the declaration — the pending flag must still end at the `;`.
+case_is 'a documented pub mod DECLARATION does not hide the code after it' 1 'unwrap()' \
+  '#[cfg(test)]
+pub mod tests;
+
+/// Production, and it stays visible.
+pub fn production() -> String {
+    std::env::var("HOME").unwrap()
+}
+'
+
+# --- the cfg composites, and the one that must NOT hide (#1207) -----------
+#
+# The python copies this filter replaced accepted `all`/`any` around `test`
+# and rejected `not`. Teaching that here was not optional: nika-harness
+# guards its hermetic adapter fixtures with `#[cfg(all(test, unix))]`, so a
+# filter that only knew the bare attribute reported ten lines of real test
+# code as production the moment the ratchets started reading through it.
+# NO `#[test]` inside these two. A bare `#[test]` hides its own fn body, so a
+# fixture carrying one passes whether or not the composite attribute is
+# understood — it proves the predicate without proving it is wired. The
+# helper below is reachable ONLY through the `cfg` line above it.
+case_is 'a #[cfg(all(test, unix))] mod is hidden' 0 'expect(' \
+  '#[cfg(all(test, unix))]
+mod t {
+    fn helper() { let _ = std::env::var("HOME").expect("HOME"); }
+}
+'
+
+case_is 'a #[cfg(any(test, feature = "x"))] mod is hidden' 0 'unwrap()' \
+  '#[cfg(any(test, feature = "x"))]
+mod t {
+    fn helper() { let v: Option<u8> = None; let _ = v.unwrap(); }
+}
+'
+
+# `all(test)` with no second predicate. Valid Rust, and the first draft of
+# this fix dropped it: the trailing class admitted space and comma but not
+# `)`, so test code read as production. It went unnoticed because the same
+# class was ALSO what kept `not(test)` out — two guards for one job, and the
+# weak one hides behind the strong one until a fixture separates them.
+case_is 'a #[cfg(all(test))] mod is hidden' 0 'unwrap()' \
+  '#[cfg(all(test))]
+mod t {
+    fn helper() { let v: Option<u8> = None; let _ = v.unwrap(); }
+}
+'
+
+# The dangerous direction. `not(test)` guards code that ships; hiding it
+# would silence the ratchet exactly where it is most load-bearing. POSIX awk
+# has no negative lookahead, so the composite arm admits `all` and `any` and
+# nothing else — this case is what proves that construction holds.
+case_is 'a #[cfg(not(test))] mod is PRODUCTION and stays visible' 1 'unwrap()' \
+  '#[cfg(not(test))]
+mod shipped {
+    pub fn f() { let v: Option<u8> = None; let _ = v.unwrap(); }
+}
+'
+
 # --- the filter must SHOW production code ---------------------------------
 case_is 'plain production code survives' 1 'unwrap()' \
   'fn prod() { let x: Option<u8> = None; let _ = x.unwrap(); }

--- a/scripts/hygiene/check-unwraps.sh
+++ b/scripts/hygiene/check-unwraps.sh
@@ -1,125 +1,57 @@
 #!/usr/bin/env bash
 # Vector 11: zero .unwrap()/.expect() in PRODUCTION src/ (non-test code).
 #
-# Uses Python3 for context-aware detection: tracks brace depth to distinguish
-# #[cfg(test)] modules and #[test] function bodies from production code.
+# ONE RULE, ONE READER (#1207). This vector used to carry a private python
+# re-implementation of the test-item scope — the third of four copies of one
+# rule. It read `#[cfg(test)]` as an attribute waiting for a brace, so a
+# declaration —
 #
-# Workspace clippy lint `unwrap_used = "deny"` is the hard enforcement gate.
-# This script is a complementary check that counts at the grep level with
-# proper test-scope exclusion.
+#     #[cfg(test)]
+#     mod tests;
 #
-# Exit codes:
-#   0 — OK (0 production unwraps found)
-#   2 — RED (production unwraps found — must fix)
+# — left the flag pending and adopted the NEXT block as the "test" region,
+# hiding any production `.unwrap()` / `.expect(` inside it. The silent
+# direction: no false finding, just real ones that stop being reported.
+#
+# It now delegates to the two `scripts/ci/` ratchets, which read through
+# `_lib.sh::strip_test_items` — the one filter that ends a pending item at
+# `;` AND blanks string, raw-string and char literals before counting braces.
+# Both lessons were learned there and neither reached the copies. Delegating
+# means this vector cannot drift from what CI enforces, because it is now the
+# same code rather than a faithful-looking twin.
+#
+# Exit codes (the hygiene contract, NOT the ci one):
+#   0 — green · 1 — yellow · 2 — RED
+# The ci ratchets exit 1 on a finding. Passing that through would render a
+# real violation as YELLOW on the board — a failure read as a warning. The
+# mapping below is deliberate and load-bearing.
 set -uo pipefail
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-cd "$SCRIPT_DIR/../.." || exit 2
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CI="$HERE/../ci"
 
-output=$(
-  python3 - <<'PYEOF'
-import re, os, sys
+red=0
+detail=""
 
-def check_file(path):
-    with open(path, encoding='utf-8', errors='replace') as f:
-        content = f.read()
+for gate in check-unwrap.sh check-expect.sh; do
+  out="$(bash "$CI/$gate" 2>&1)"
+  rc=$?
+  case $rc in
+    0) : ;; # this half is clean
+    1)
+      red=1
+      detail="${detail}${out}"$'\n'
+      ;; # a finding
+    *)
+      red=1
+      detail="${detail}${gate} exited ${rc}: ${out}"$'\n'
+      ;;
+  esac
+done
 
-    # Skip files with file-level allow annotations (#![allow(clippy::*_used)])
-    if re.search(r'#!\[allow\([^\)]*clippy::(?:unwrap|expect)_used', content):
-        return []
-
-    lines = content.split('\n')
-    brace_depth = 0
-    cfg_test_entry = None   # depth inside #[cfg(test)] mod
-    test_fn_entry  = None   # depth inside #[test] fn body
-    saw_cfg_test   = False  # just saw #[cfg(test)] attribute
-    saw_test_attr  = False  # just saw #[test]/#[tokio::test] attribute
-    saw_test_fn    = False  # saw fn keyword after test attr (waiting for {)
-    prod_unwraps   = []
-
-    for lineno, line in enumerate(lines, 1):
-        s = line.strip()
-
-        # --- detect scope markers BEFORE brace counting on this line ---
-        # Match #[cfg(test)] OR #[cfg(all(test, ...))] OR #[cfg(any(test, ...))]
-        # (any() is iffy — could be non-test — but pragmatically rare; if false-pos
-        # arises, audit case-by-case). #[cfg(not(test))] explicitly rejected.
-        if re.match(r'#\[cfg\s*\(\s*(?!not\b)(?:(?:all|any)\s*\(\s*)?test\b', s):
-            saw_cfg_test = True
-        if re.match(r'#\[(?:(?:tokio::)?test|should_panic)(?:$|\s|\]|,)', s.rstrip()):
-            saw_test_attr = True
-        # Detect fn definition after test attribute
-        if saw_test_attr and not saw_test_fn and re.search(r'\bfn\s+\w', s):
-            saw_test_fn = True
-
-        # --- check for production unwrap BEFORE brace counting ---
-        # (unwrap call is on the content of the line, before any scope exits)
-        in_test_scope = (cfg_test_entry is not None) or (test_fn_entry is not None)
-        if not in_test_scope and not s.startswith('//') and not s.startswith('/*'):
-            if re.search(r'\.(unwrap|expect)\s*\(', line):
-                if not re.search(r'unwrap_or(?:_else|_default)?', line):
-                    prod_unwraps.append(f'  {path}:{lineno}: {s[:100]}')
-
-        # --- count braces (strip literals + // comments first so their brace
-        # characters do not unbalance the depth counter) ---
-        # Pass 0a: plain raw r"..." (word boundary, no backslash escaping)
-        stripped = re.sub(r'\br"[^"]*"', 'r""', line)
-        # Pass 0b: byte raw br"..."
-        stripped = re.sub(r'(?<!\w)br"[^"]*"', 'br""', stripped)
-        # Pass 1: char literals b?'(\\.|[^'\\])'
-        stripped = re.sub(r"b?'(\\.|[^'\\])'", "''", stripped)
-        # Pass 2: regular + byte string literals; (?<![r#]) skips r#"..."# / br#"..."#
-        stripped = re.sub(r'(?<![r#])b?"(?:\\.|[^"\\])*"', '""', stripped)
-        # Pass 3: strip // line comments (after literals collapsed)
-        slash = stripped.find('//')
-        if slash >= 0:
-            stripped = stripped[:slash]
-        for ch in stripped:
-            if ch == '{':
-                brace_depth += 1
-                if saw_cfg_test:
-                    cfg_test_entry = brace_depth
-                    saw_cfg_test = False
-                if saw_test_fn:
-                    test_fn_entry = brace_depth
-                    saw_test_fn = False
-                    saw_test_attr = False
-            elif ch == '}':
-                brace_depth = max(0, brace_depth - 1)
-                if cfg_test_entry is not None and brace_depth < cfg_test_entry:
-                    cfg_test_entry = None
-                if test_fn_entry is not None and brace_depth < test_fn_entry:
-                    test_fn_entry = None
-                    saw_test_attr = False
-                    saw_test_fn = False
-
-    return prod_unwraps
-
-total = []
-for root, dirs, files in os.walk('crates'):
-    dirs[:] = [d for d in dirs if d not in ['target', '.git']]
-    for fname in sorted(files):
-        if not fname.endswith('.rs'):
-            continue
-        if fname == 'tests.rs':   # 100% test code · the rs_prod_files convention
-            continue
-        path = os.path.join(root, fname)
-        if '/src/' not in path.replace(os.sep, '/'):
-            continue
-        total.extend(check_file(path))
-
-for line in total:
-    print(line)
-print(f'__TOTAL__{len(total)}')
-PYEOF
-)
-
-count=$(echo "$output" | grep '__TOTAL__' | grep -oE '[0-9]+$')
-detail=$(echo "$output" | grep -v '__TOTAL__')
-
-if [ "${count:-0}" -eq 0 ]; then
-  echo "OK (0 production unwrap/expect — all test-scoped, clippy verified)"
+if [ "$red" -eq 0 ]; then
+  echo "OK (0 production unwrap/expect — both ci ratchets green through the shared filter)"
   exit 0
 fi
-[ -n "$detail" ] && echo "$detail"
-echo "${count} production unwrap/expect in non-test src/ code"
+
+printf '%s' "$detail"
 exit 2


### PR DESCRIPTION
Closes #1207.

Four readers decided what the ratchets were allowed to see, and three were
private re-implementations of the fourth. Each had learned a different half of
the rule, so each was blind somewhere the others were not.

| reader | string literals | `;` declaration | `cfg(all(test, …))` |
|---|:-:|:-:|:-:|
| `_lib.sh::strip_test_items` (awk) | ✅ | ✅ | ❌ → **taught here** |
| `scripts/ci/prod-loc.py` | ✅ | ✅ | — |
| `scripts/ci/check-expect.sh` | ✅ | ❌ | ✅ → **now delegates** |
| `scripts/hygiene/check-unwraps.sh` | ✅ | ❌ | ✅ → **now delegates** |

## The declaration half (the filed bug)

A pending `#[cfg(test)]` waited for a brace. Given a declaration —

```rust
#[cfg(test)]
mod tests;
```

— no brace arrives on that line, the flag stays set, and the **next** block
becomes the test region. Verified on two fixtures differing only in the
module's shape, running the shipped `expect` reader verbatim:

```
declaration    production .expect( SEEN by the gate: 0     <- HIDDEN
normal_block   production .expect( SEEN by the gate: 1
```

The silent direction: no false finding, just real ones that stop being
reported. `check-expect.sh` is the reader CI runs as the `expect` ratchet, so
this was live rather than hygiene-only — the issue marked it "unverified, same
shape", and it is verified now.

## The composite half (found while fixing the first)

The private copies accepted `all`/`any` around `test` and rejected `not`. The
shared filter knew only the bare attribute. Delegating without teaching it that
would have traded one blindness for another: `nika-harness` guards its hermetic
adapter fixtures with `#[cfg(all(test, unix))]`, and the first delegation
reddened **ten lines of real test code** on today's `main`.

## A third hole, inside the fix itself

The trailing character class admitted space and comma but not `)`, which
silently dropped `#[cfg(all(test))]` — valid Rust with no second predicate,
test code read as production. It hid because that same class was **also** what
kept `not` out. Two guards for one job, and the weak one is invisible behind
the strong one until a fixture separates them. The literal list is the guard
now, and it is the only one.

## What it moves on today's tree

**Nothing.** Both readers see zero production `.expect(` over 782 files, which
is what the issue predicted. This was a latent weakness in the most-cited
invariant in the house, not a leak. The value is that there is no next copy to
drift.

```
 scripts/ci/_lib.sh                  |  22 ++-
 scripts/ci/check-expect.sh          | 133 +++-------------
 scripts/ci/test-strip-test-items.sh |  90 +++++++++++
 scripts/hygiene/check-unwraps.sh    | 152 ++++---------------
 4 files changed, 190 insertions(+), 213 deletions(-)
```

## Proof

Mutation-pinned in `test-strip-test-items.sh`, both directions:

- break the `;` arm → the three declaration cases go red, the other twelve stay green
- admit `not` into the composite arm → the `#[cfg(not(test))]` production case goes red

Worth recording: the **first draft** of the composite fixtures carried a bare
`#[test]` inside the module. That hides the line on its own, so they passed
against a deliberately broken filter — they proved the predicate's existence,
not that it was wired. Rewritten without it, they fail the mutant as they
should.

All five readers of the shared filter run green after the change, compared
against an unmodified `origin/main` worktree: `check-unwrap`, `check-expect`,
`check-dead-code`, `check-error-one-voice`, `check-seam-discipline`.

## One deliberate detail

Vector 11 maps the ci exit code `1` to `2`. The `scripts/ci/` ratchets exit 1
on a finding, and the hygiene runner reads `1` as **yellow** — passing it
through would render a real violation as a warning on the board. The mapping is
load-bearing, not ceremony.
