### PR TITLE
fix(ci): a proof marker is a declaration, not a mention

### DIFF
--- a/scripts/ci/issue-proof.sh
+++ b/scripts/ci/issue-proof.sh
@@ -90,6 +90,23 @@ waived_reason() {
   return 1
 }
 
+# Every DISTINCT job named by a line-initial `proven_by:` in a body, one per
+# line, sorted. A function and not an inline pipe so the self-test can source
+# it by name the way it sources waived_reason above — a reader nobody can
+# exercise is a reader nobody can trust, and this one decides verdicts.
+#
+# Reads $1, never the environment: the body is untrusted text and must not
+# reach the shell.
+body_proof_jobs() {
+  printf '%s\n' "$1" \
+    | awk '/^[[:space:]]*proven_by:[[:space:]]*/ {
+        sub(/^[[:space:]]*proven_by:[[:space:]]*/, "")
+        gsub(/["\047`]/, "")
+        gsub(/[[:space:]].*/, "")
+        if ($0 != "") { print }
+      }' | sort -u
+}
+
 while [ $# -gt 0 ]; do
   case "$1" in
     --issue)
@@ -138,29 +155,51 @@ LEDGER_JOB="$(
   awk -v want="$ISSUE" '
     /^capabilities:/{grab=1; next}
     grab && /^[a-z_]+:/ && $0 !~ /^[[:space:]]/{grab=0}
-    grab && $0 ~ /proven_by:[[:space:]]*/ {
-      sub(/.*proven_by:[[:space:]]*/, ""); gsub(/["\047]/, ""); job=$0
+    # Same anchor as the body reader below (#1218). A YAML value starts its
+    # line; a comment that names the key does not. The ledger is authored and
+    # less exposed to prose than an issue body, but two readers of one rule
+    # drift the moment one learns something — that is the lesson #1207 just
+    # paid for one file over.
+    grab && $0 ~ /^[[:space:]]*proven_by:[[:space:]]*/ {
+      sub(/^[[:space:]]*proven_by:[[:space:]]*/, ""); gsub(/["\047]/, ""); job=$0
     }
-    grab && $0 ~ /issue:[[:space:]]*/ {
-      sub(/.*issue:[[:space:]]*/, ""); gsub(/["\047]/, "")
+    grab && $0 ~ /^[[:space:]]*issue:[[:space:]]*/ {
+      sub(/^[[:space:]]*issue:[[:space:]]*/, ""); gsub(/["\047]/, "")
       if ($0 == want) { print job; exit }
     }
   ' "$LEDGER"
 )"
 
 # 2. body proven_by: <job> (env, never interpolated into the script source)
+#
+# A DECLARATION starts a line. A MENTION sits inside a sentence, and until
+# 2026-08-25 this read both (#1218). The pattern matched `proven_by:`
+# anywhere and exited on the first line that carried it, so the issue whose
+# whole subject is this marker refused itself: #1200's body quotes the
+# workflow guard —
+#
+#     contains(github.event.issue.body, 'proven_by:') ||
+#
+# — and the reader stripped up to the marker, dropped the quote, cut at the
+# space, and rendered the job name `)`. On the other side, a sentence that
+# happens to carry a plausible word HANDS the gate a proof nobody attached:
+# that is the false-green half, and it is the one that matters.
+#
+# Anchoring is necessary and not sufficient. #1200 also carries a wrapped
+# markdown span that begins a line, so first-match-wins would still have
+# guessed — correctly there, by coincidence, because the prose and the real
+# declaration name the same job. A gate must not be right by luck. So: read
+# only line-initial markers, collect the DISTINCT values, and refuse when
+# they disagree rather than pick one. Fail closed, like every other judge
+# here.
 BODY_JOB=""
+BODY_AMBIGUOUS=""
 if [ -n "${ISSUE_BODY:-}" ]; then
-  BODY_JOB="$(
-    printf '%s\n' "$ISSUE_BODY" \
-      | awk '/proven_by:[[:space:]]*/ {
-          sub(/.*proven_by:[[:space:]]*/, "")
-          gsub(/["\047`]/, "")
-          gsub(/[[:space:]].*/, "")
-          print
-          exit
-        }'
-  )"
+  _body_jobs="$(body_proof_jobs "$ISSUE_BODY")"
+  BODY_JOB="$(printf '%s\n' "$_body_jobs" | head -1)"
+  if [ "$(printf '%s\n' "$_body_jobs" | grep -c .)" -gt 1 ]; then
+    BODY_AMBIGUOUS="$(printf '%s' "$_body_jobs" | tr '\n' ' ')"
+  fi
 fi
 
 JOB="${LEDGER_JOB:-$BODY_JOB}"
@@ -191,6 +230,12 @@ What this gate no longer accepts is silence. Until 2026-08-25 it only judged clo
 
 if [ -z "$JOB" ] || [ "$JOB" = "null" ]; then
   refuse "no proven_by (not in wiring.yaml, not in the issue body) · a capability close needs a named CI job"
+fi
+
+# The ledger is authored and wins; only an unaided body can be ambiguous.
+# Detecting this and then picking one anyway would be a field nobody reads.
+if [ -z "$LEDGER_JOB" ] && [ -n "$BODY_AMBIGUOUS" ]; then
+  refuse "the body names more than one proven_by job (${BODY_AMBIGUOUS%% }) · say which, or put it in wiring.yaml"
 fi
 
 if printf '%s\n' "$JOBS" | grep -qxF "$JOB"; then

--- a/scripts/ci/test-issue-proof.sh
+++ b/scripts/ci/test-issue-proof.sh
@@ -90,5 +90,64 @@ expect judged completed 'invalidated' 'invalidated does NOT waive'
 # A state_reason that merely CONTAINS a waiving word is not that reason.
 expect judged 'not_planned_yet' '' 'not_planned_yet does NOT waive'
 
+# --- and HOW the proof is read (#1218) ---------------------------------------
+#
+# The cases above pin WHO may decline a proof. Nothing pinned how one is
+# found, and the reader matched `proven_by:` anywhere on a line and took the
+# first hit. Live consequence, 2026-08-25 on main: #1200's body quotes the
+# workflow guard `contains(github.event.issue.body, 'proven_by:')`, and the
+# gate refused the close naming the job `)`.
+eval "$(sed -n '/^body_proof_jobs() {$/,/^}$/p' "$HERE/issue-proof.sh")"
+if ! declare -F body_proof_jobs >/dev/null; then
+  printf 'FAIL  body_proof_jobs() not found in issue-proof.sh — the reader is untested\n' >&2
+  exit 2
+fi
+
+jobs_are() { # <want> <label> <body>
+  cases=$((cases + 1))
+  local got
+  got="$(body_proof_jobs "$3" | tr '\n' ' ')"
+  got="${got% }"
+  if [ "$got" = "$1" ]; then
+    printf 'ok    %s\n' "$2"
+  else
+    printf 'FAIL  %s — expected [%s], read [%s]\n' "$2" "$1" "$got" >&2
+    fails=$((fails + 1))
+  fi
+}
+
+jobs_are 'rust' 'a line-initial marker is the declaration' \
+  'Some prose about the fix.
+
+proven_by: rust'
+
+# The false-RED half. The mention must carry a PLAUSIBLE word after it: a
+# mention ending in punctuation collapses to the empty string under the old
+# reader too and gets filtered, so it would pass against the very bug this
+# pins — a fixture that proves the predicate without proving it is wired.
+jobs_are 'rust' 'a mid-sentence mention is NOT a declaration' \
+  'the guard needs proven_by: someJob written somewhere in the body
+
+proven_by: rust'
+
+# The false-GREEN half, and the one that matters: a sentence must not hand
+# the gate a proof nobody attached.
+jobs_are '' 'a mention alone supplies NO proof' \
+  'a closer should write proven_by: rust somewhere in the body'
+
+# Anchoring is not enough on its own. Markdown wrapping a code span can start
+# a line with the marker, so a body may carry several line-initial hits that
+# disagree. The reader reports all of them and the gate refuses rather than
+# guess — being right by luck is not being right.
+jobs_are 'proof proof)' 'disagreeing line-initial markers are all reported' \
+  'proven_by: proof` to the body
+
+proven_by: proof`) it returned success
+
+proven_by: proof'
+
+jobs_are 'rust' 'an indented marker still counts' \
+  '  proven_by: rust'
+
 printf '\n%d case(s) · %d failure(s)\n' "$cases" "$fails"
 [ "$fails" -eq 0 ] || exit 1

--- a/wiring.yaml
+++ b/wiring.yaml
@@ -43,6 +43,19 @@ capabilities:
     reachable_by: "a task blocked by a settled upstream binding"
     proven_by: rust
     issue: 1198
+  - id: gate.issue-proof.judges-every-close
+    kind: ci-gate
+    declared_at: .github/workflows/issue-proof.yml:48
+    shipped_when: "default"
+    reachable_by: "closing any issue as completed"
+    # The ledger, not the body. #1200's body is ABOUT this marker, so it
+    # carries three line-initial `proven_by:` occurrences — one real, two
+    # left by markdown wrapping a code span. The reader cannot tell which is
+    # the declaration and refuses rather than guess, which is the right
+    # refusal and an unclosable issue. An authored ledger row is what the
+    # refusal itself asks for.
+    proven_by: proof
+    issue: 1200
   - id: access.harness
     kind: cargo-feature
     declared_at: crates/nika-cli/Cargo.toml:72


### PR DESCRIPTION
Closes #1218. Fixes the `issue-proof` red on `main` at `4b2189219`.

## It fired in production while I was writing the issue

```
issue-proof · FAIL · #1200 · proven_by job `)` is in no workflow · the judge does not exist
```

#1200's body — the issue whose whole subject is this gate — quotes the
workflow guard:

```yaml
  contains(github.event.issue.body, 'proven_by:') ||
```

The reader stripped up to the marker, dropped the quote, cut at the space, and
named the job `)`. **The gate refused the close of the issue that described its
own hole.**

## Both directions were live

```
mention with nothing usable after it  →  []      FALSE RED   ← what fired
mention carrying a plausible word     →  [rust]  FALSE GREEN ← the half that matters
```

The second is the severe one: a sentence hands the gate a proof nobody
attached, and the real declaration below is never read because the reader
exits on the first matching line. #1220 had just removed the workflow's `if:`
guard so the gate judges **every** close — a correct fix that widened this
defect from *issues whose filer opted in* to *every issue*.

## Anchoring is necessary and not sufficient

Markdown wrapping a code span can begin a line with the marker. #1200 carries
**three** line-initial hits:

```
line 27   proven_by: proof` to the body                    ← wrap accident
line 67   proven_by: proof`) it returned `success`         ← wrap accident
line 78   proven_by: proof                                 ← the declaration
```

First-match-wins would still have guessed, and would have been right there **by
coincidence** — the prose and the declaration name the same job. A gate must not
be right by luck.

So the reader collects the **distinct** values and the gate refuses when they
disagree:

```
issue-proof · FAIL · #1200 · the body names more than one proven_by job (proof proof)) · say which, or put it in wiring.yaml
```

Fail closed, like every other judge here.

## Three changes

- **the body reader** is anchored, returns distinct values, and is a named
  function so the self-test can source it the way it already sources
  `waived_reason`. A reader nobody can exercise is a reader nobody can trust,
  and this one decides verdicts.
- **the ledger branch** carried the identical unanchored pattern and gets the
  same anchor. Two readers of one rule drift the moment one learns something —
  the lesson #1207 paid for one file over, closed an hour ago.
- **`wiring.yaml` gains the row for #1200.** Its body *cannot* carry an
  unambiguous declaration, so the refusal is correct and the issue is
  unclosable from its body. An authored row is exactly what the refusal asks
  for, and it is what #1221 did for #1198.

## Proof

Five new self-test cases, 19 total. Two kill the mutant that removes the anchor:

```
remove the anchor
  FAIL  a mid-sentence mention is NOT a declaration — expected [rust], read [rust someJob]
  FAIL  a mention alone supplies NO proof — expected [], read [rust]

remove the ambiguity refusal, run the REAL #1200 body with no ledger row
  issue-proof · HOLD · #1200 proven_by=proof exists      ← a guessed job, silently held
```

Verified against the three real bodies this touched: #1200 → `proof`, #1207 →
`rust`, #1203 → `ratchets`, all HOLD.

**One fixture had to be hardened first.** A mention ending in punctuation
collapses to the empty string under the old reader too and gets filtered, so it
passed against the very bug it was meant to pin. The word after the marker has
to be plausible for the case to separate the two readers — it proved the
predicate's existence, not that it was wired.

Note on running this locally: `refuse()` calls `gh issue reopen` and
`gh issue comment`, so the verification above ran with `PATH=/usr/bin:/bin`,
where `command -v gh` fails and the refusal only prints. A success path that
writes outward has no dry run either.
