### PR TITLE
fix(cli): read the cwd under the lease that governs it

### DIFF
--- a/changelog.d/arm-room-cwd-lease.fixed.md
+++ b/changelog.d/arm-room-cwd-lease.fixed.md
@@ -1,0 +1,12 @@
+- **The arm-room test reads the cwd under the lease that governs it.**
+  `concurrent_run_rooms_are_serialized_and_restore_the_caller` observed
+  the process-global cwd twice — the baseline and the restoration —
+  without holding `cwd::hold()`, so it measured whichever sibling
+  happened to own the process. It went red on three consecutive `main`
+  commits with `left` = `cwd::tests`'s chdir-storm room, while this
+  test's own restore had already put the process back. The production
+  path was never at fault: `enter_room` takes the crate lease and rides
+  `fchdir` exactly as `cwd.rs` documents. Both reads now ride the lease,
+  which is what makes the claim well-defined. Reproduced 2/20 by running
+  the test WITH the storm; 40/40 after (the full suite hides it — 12/12
+  green either way, which is why the red only ever surfaced in CI).

--- a/crates/nika-cli/src/verbs/arm/fire.rs
+++ b/crates/nika-cli/src/verbs/arm/fire.rs
@@ -213,7 +213,18 @@ mod tests {
     #[test]
     #[allow(clippy::disallowed_methods)] // process-global cwd needs real OS threads
     fn concurrent_run_rooms_are_serialized_and_restore_the_caller() {
-        let caller = std::env::current_dir().expect("caller cwd");
+        // Both reads of the cwd — the baseline here and the restoration at
+        // the end — ride the lease that governs it. Without them this test
+        // measured whichever sibling happened to own the process: it went
+        // red on main with `left` = `cwd::tests`'s chdir-storm room while
+        // this test's own restore had already put the process back. The
+        // production path was never at fault; the assertion was simply not
+        // well-defined outside the lease. Reproduced 2/20 by running this
+        // test WITH the storm (the full suite hides it — 12/12 green).
+        let caller = {
+            let _lease = crate::cwd::hold();
+            std::env::current_dir().expect("caller cwd")
+        };
         let first = tempfile::tempdir().expect("first room");
         let second = tempfile::tempdir().expect("second room");
         let first_path = first.path().to_path_buf();
@@ -247,6 +258,13 @@ mod tests {
             std::fs::canonicalize(second.path()).expect("canonical second")
         );
         second_thread.join().expect("second joins");
-        assert_eq!(std::env::current_dir().expect("restored cwd"), caller);
+        // Both rooms are closed, so taking the lease here cannot deadlock —
+        // it only excludes the siblings that are allowed to hold the
+        // process elsewhere while this claim is being read.
+        let restored = {
+            let _lease = crate::cwd::hold();
+            std::env::current_dir().expect("restored cwd")
+        };
+        assert_eq!(restored, caller);
     }
 }


### PR DESCRIPTION
**`main` has been red for four consecutive commits** on the `access-harness`
job — `concurrent_run_rooms_are_serialized_and_restore_the_caller`, the
assert at `fire.rs:250`.

## Qualified in both directions before touching anything

**The production path is not at fault.** `enter_room` takes the crate lease
(`cwd::hold()`) and rides `fchdir(2)` on unix, exactly as `cwd.rs` documents
— the module even says `hold()` exists *"for a caller that changes directory
by some route this module cannot perform for it… which is what `arm fire`
uses"*. The bare `set_current_dir` beside it is the `#[cfg(not(unix))]`
branch, dead on the runner.

**The commit that opened the red window cannot have caused it.** #1227
touched four shell scripts and no Rust.

## The test was the unsound part

It read the process-global cwd **twice** — the baseline and the restoration
— outside the lease, so it measured whichever sibling happened to own the
process. Captured locally:

```
left:  /…/T/nika-cwd-lease-12080     <- cwd::tests's chdir storm
right: /…/crates/nika-cli            <- the real caller
```

`cwd::tests::a_reader_holding_the_lease_sees_a_stable_cwd_under_a_chdir_storm`
is a deliberate storm (#1192) that runs in the same process, and it is
entirely within its rights: it holds the lease. This test did not.

Both reads now ride the lease. That does not weaken the claim — holding it
is the only condition under which *"the caller's cwd is restored"* is even
well-defined. Taking it after both rooms have closed cannot deadlock: it
excludes only the siblings allowed to hold the process elsewhere while the
claim is being read.

## Why it never reproduced from the full suite

```
cargo test -p nika-cli --lib --features access-harness   →  12/12 green
… -- --test-threads=8 concurrent_run_rooms chdir_storm cwd
                              BEFORE →  2/20 RED
                              AFTER  →  40/40 green
```

Running the whole suite hides it; running the test **with** the storm exposes
it. That is also why it only ever surfaced in CI: the `rust` leg runs
`cargo nextest run` — one process per test, so the race cannot form — while
`access-harness` runs `cargo test --lib`, threads in one process, and it can.

## Noted, not fixed here

The same shape is available to other tests: `check/budget.rs` mutates the cwd
in a test under its own reasoning, and several verbs read `current_dir()`
unguarded in production (`serve.rs`, `ceiling.rs`, `emit.rs`, …). Those reads
are single-shot and do not assert an invariant across a window, so none is
this defect — but the two-owner hazard `cwd.rs` was built for is not
structurally closed until every *asserting* reader rides the lease. Worth a
follow-up issue rather than a drive-by widening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)