### PR TITLE
docs(readme): name the seat rung between local and a key

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,8 +490,27 @@ tasks:
 
 (No model handy? The built-in `mock/echo` previews any workflow offline.)
 
-For real inference, run a local model (Ollama / LM Studio) or set a provider
-key, then see what's wired:
+Already paying for a coding agent? Run on that seat instead of buying a third
+subscription. If `qwen-code`, `gemini-cli`, `kimi-code` or `codex` is installed
+and signed in, nika drives it over ACP and the work rides the plan you already
+have:
+
+```sh
+nika doctor                              # which seats this machine can actually reach
+nika run pr-review.nika.yaml --access codex-acp
+```
+
+Two honest limits, because a seat is not a provider:
+
+- `agent:` sits on any attested seat. `infer:` sits on **one** admitted adapter
+  today (`codex exec --json`, single turn, schema-checked). A seat that cannot
+  meet that contract refuses at check time rather than guessing.
+- A seated run reports **no price and no token count**. It spends your
+  subscription's quota, and the receipt says exactly that. It names the seat and
+  the model you *asked* for, never a claim about which model answered.
+
+For real inference without a seat, run a local model (Ollama / LM Studio) or set
+a provider key, then see what's wired:
 
 ```sh
 nika doctor                  # provider keys + local servers, with the exact fix


### PR DESCRIPTION
The onboarding ladder in this README skips its third rung.

It goes zero-setup, then local model, then provider key. It never names the
thing most readers already have: a coding-agent subscription they are paying
for every month. P4 landed that capability this week and nothing on the public
face mentions it.

## What lands

Between the local-model paragraph and the provider-key one:

> Already paying for a coding agent? Run on that seat instead of buying a third
> subscription. If `qwen-code`, `gemini-cli`, `kimi-code` or `codex` is installed
> and signed in, nika drives it over ACP and the work rides the plan you already
> have.

## The two limits ride with it, deliberately

This file is a teaching surface, so the boundary is stated rather than left for
a user to discover at run time:

- **`agent:` sits on any attested seat. `infer:` has exactly one admitted
  adapter today** — `codex exec --json`, single turn, schema-checked
  (`crates/nika-harness/src/infer.rs:199`, *"the only admitted P4 adapter"*). A
  seat that cannot meet the infer-grade contract refuses at check rather than
  guessing.
- **A seated run reports no price and no token count.** It spends subscription
  quota, and the receipt says exactly that. It names the seat and the model that
  was *asked* for, never a claim about which model answered — the type it
  returns carries no meter field at all, so it could not lie if it tried.

## Verified rather than composed

```
--access in the cli surface          8 occurrences
run line                             copied from the wiring.yaml row for that seat
                                     (`reachable_by: "nika run F --access codex-acp"`)
infer seam on main                   run_on_harness present
em dashes added                      0
```

The invocation is lifted from the ledger row rather than written by hand, so the
README and the capability ledger cite one source and cannot drift apart. Seat
order follows the house presentation rule: local and open-weight first, Anthropic
never the default example.
