### PR TITLE
fix(runtime): journal the unwind outcome · a refused cleanup is visible

### DIFF
--- a/changelog.d/1252.fixed.md
+++ b/changelog.d/1252.fixed.md
@@ -1,0 +1,8 @@
+- **A refused cleanup is no longer invisible.** An `after: { x: unwind }`
+  cleanup that failed — a permit refusal, a non-zero exit, a timeout, even
+  a closed `when:` gate — used to vanish without a frame: the trace read
+  pixel-identical to a cleanup that never fired. The lane still never
+  propagates (best-effort by spec), but its outcome is journaled now: one
+  `permit_checked` frame on plane `on_finally` per skipped, failed, or
+  timed-out cleanup, naming the error code (`NIKA-SEC-004` and friends) —
+  spec 03's « its errors are logged » guarantee, kept.

--- a/crates/nika-runtime/src/secret.rs
+++ b/crates/nika-runtime/src/secret.rs
@@ -22,8 +22,10 @@ use crate::EventSink;
 const WIDE_SCRUB_MIN: usize = 8;
 
 /// The event fields whose payload may carry a resolved value (the
-/// terminal frame's outcome/output and the failure detail).
-const PAYLOAD_FIELDS: [&str; 3] = ["outcome", crate::resume::fields::OUTPUT, "detail"];
+/// terminal frame's outcome/output and the failure detail). `why` rides
+/// the unwind lane's outcome frames — a failed cleanup's error message
+/// can embed a stderr tail, the same class `detail` carries.
+const PAYLOAD_FIELDS: [&str; 4] = ["outcome", crate::resume::fields::OUTPUT, "detail", "why"];
 
 /// The dynamic-flow backstop (S1). The static IFC sanctions every
 /// DECLARED secret flow; it cannot see a value that reaches a task's

--- a/crates/nika-runtime/src/task/finally.rs
+++ b/crates/nika-runtime/src/task/finally.rs
@@ -2,8 +2,8 @@
 // Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
 
 //! The `on_finally` cleanup lane (spec 03 · sequential · best-effort ·
-//! errors swallowed · per-cleanup timeout 30s) — split out of `task.rs`
-//! under the ADR-023 1,500-LOC ceiling.
+//! errors journaled, never propagated · per-cleanup timeout 30s) —
+//! split out of `task.rs` under the ADR-023 1,500-LOC ceiling.
 
 use std::time::Duration;
 
@@ -107,7 +107,8 @@ where
     C: ClockDyn + Sync,
 {
     /// Run the cleanup mini-tasks (spec 03 §`on_finally` · sequential ·
-    /// best-effort · errors swallowed · per-cleanup timeout 30s).
+    /// best-effort · a failure/timeout/skip is journaled on the
+    /// witness, never propagated · per-cleanup timeout 30s).
     pub(crate) async fn run_finally(
         &self,
         task: &RawTask,
@@ -156,8 +157,11 @@ where
     }
 
     /// One cleanup TASK · its own `when:` + `timeout:` · outcome
-    /// swallowed (best-effort by construction · its failure never
-    /// propagates to the producer · spec 03 §unwind guarantee 3).
+    /// journaled, never propagated (best-effort by construction · its
+    /// failure never reaches the producer · spec 03 §unwind guarantee
+    /// 3: « its errors are logged » — a skip/failure/timeout rides the
+    /// witness as a `permit_checked` frame on plane `on_finally`, so a
+    /// refused cleanup is distinguishable from a dead trigger).
     async fn run_one_cleanup(
         &self,
         cleanup: &RawTask,
@@ -167,11 +171,19 @@ where
         run_start: nika_kernel::tool_executor::ToolRunStart,
     ) {
         if let Some(gate) = cleanup.when.as_ref() {
-            match eval_gate(&gate.value, scope) {
-                Ok(true) => {}
-                // Closed gate OR eval error → the cleanup is skipped
-                // (a cleanup error never propagates).
-                _ => return,
+            // Closed gate OR eval error → the cleanup is skipped
+            // (a cleanup error never propagates) — and the skip is
+            // journaled: without this frame a gate-closed cleanup
+            // is pixel-identical to a dead trigger on the trace.
+            if !matches!(eval_gate(&gate.value, scope), Ok(true)) {
+                witness.record(
+                    "on_finally",
+                    format!("cleanup #{index}"),
+                    "skipped",
+                    "when: gate closed or errored — the cleanup did not run \
+                     (best-effort lane · spec 03 §unwind)",
+                );
+                return;
             }
         }
         let limit = cleanup
@@ -221,8 +233,60 @@ where
             None,
         ));
         let timer = std::pin::pin!(self.clock.sleep(limit));
-        // Either way the outcome is dropped — cleanup observability is
-        // the cleanup's own effects (e.g. `nika:emit` · spec 03).
-        let _ = futures_util::future::select(attempt, timer).await;
+        match futures_util::future::select(attempt, timer).await {
+            futures_util::future::Either::Left((dispatched, _)) => {
+                if let Err(failed) = dispatched.result {
+                    Self::journal_cleanup_failure(witness, index, &failed.record);
+                }
+            }
+            futures_util::future::Either::Right(((), _)) => {
+                Self::journal_cleanup_timeout(witness, index, limit);
+            }
+        }
+    }
+
+    /// The outcome never PROPAGATES (best-effort lane) but it is
+    /// JOURNALED (spec 03 §unwind guarantee 3 · « its errors are
+    /// logged »): a failure rides the parent's witness as one more
+    /// `permit_checked` frame on plane `on_finally`. A cleanup refused
+    /// at the permit/sandbox boundary (NIKA-SEC-004) lands here with
+    /// its code — no longer pixel-identical to a dead trigger. A clean
+    /// finish stays silent: the cleanup's own effects are its
+    /// observability (e.g. `nika:emit` · spec 03).
+    fn journal_cleanup_failure(
+        witness: &crate::witness::PermitWitness,
+        index: usize,
+        record: &nika_dataflow::TaskErrorRecord,
+    ) {
+        witness.record(
+            "on_finally",
+            format!("cleanup #{index}"),
+            "failure",
+            format!(
+                "cleanup failed — the error does not propagate but is journaled \
+                 (spec 03 §unwind guarantee 3) · {}: {}",
+                record.code, record.message
+            ),
+        );
+    }
+
+    /// The cleanup's own timer won: abandoned, never propagated — and
+    /// the abandon is journaled, so a timed-out cleanup is
+    /// distinguishable from a dead trigger (spec 03 §unwind).
+    fn journal_cleanup_timeout(
+        witness: &crate::witness::PermitWitness,
+        index: usize,
+        limit: std::time::Duration,
+    ) {
+        witness.record(
+            "on_finally",
+            format!("cleanup #{index}"),
+            "timeout",
+            format!(
+                "cleanup exceeded its {}s budget — abandoned, not propagated \
+                 (spec 03 §unwind)",
+                limit.as_secs()
+            ),
+        );
     }
 }

--- a/crates/nika-runtime/tests/unwind.rs
+++ b/crates/nika-runtime/tests/unwind.rs
@@ -190,8 +190,10 @@ tasks:
     assert_eq!(str_field(exec_frame, "gate"), Some("echo"));
 }
 
-/// A cleanup error is swallowed — the parent's status reflects ONLY
-/// the main verb (spec 03 · best-effort semantics).
+/// A cleanup error never propagates — the parent's status reflects ONLY
+/// the main verb (spec 03 · best-effort semantics) — but it IS journaled
+/// (guarantee 3 · « its errors are logged »): the outcome rides the
+/// parent's witness as a `permit_checked` frame on plane `on_finally`.
 #[tokio::test]
 async fn unwind_errors_are_swallowed() {
     let yaml = r#"
@@ -223,5 +225,122 @@ tasks:
             .filter(|e| e.kind == EventKind::TaskFailed)
             .count(),
         0
+    );
+    // …but the failure is NOT invisible: one journaled outcome frame
+    // names the cleanup's error code (a dead trigger carries none).
+    let outcome_frame = events
+        .iter()
+        .find(|e| {
+            e.kind == EventKind::PermitChecked
+                && str_field(e, "plane") == Some("on_finally")
+                && str_field(e, "decision") == Some("failure")
+        })
+        .expect("a failed cleanup is journaled, not swallowed");
+    let why = str_field(outcome_frame, "why").expect("the frame carries its why");
+    assert!(
+        why.contains("NIKA-"),
+        "the outcome frame names the cleanup's error code: {why}"
+    );
+}
+
+/// A cleanup refused at the permit boundary is VISIBLE (the adjudicated
+/// defect of #1252): the boundary's own `deny` decision was already
+/// witnessed (NEP-0007), but the cleanup's terminal outcome was
+/// swallowed — pixel-identical to a dead trigger. The outcome frame now
+/// names the refusal code.
+#[tokio::test]
+async fn unwind_refused_cleanup_leaves_a_visible_outcome_frame() {
+    // argv[0] computed from the parent's RUNTIME output: the static
+    // ladder cannot resolve it (« a templated argv is the RUN's
+    // verdict »), so the file is check-clean and the refusal exists
+    // only at run time — the rendered `rm` is outside `permits.exec`.
+    let yaml = r#"
+nika: cleanup-refused
+permits:
+  exec: ["work"]
+tasks:
+  main:
+    exec: { command: ["work"] }
+  main_sweep:
+    after: { main: unwind }
+    exec: { command: ["${{ tasks.main.output }}", "-f", "scratch"] }
+"#;
+    let (outcome, events) = run_to_events(
+        yaml,
+        MockShell::new().enqueue_ok("rm\n"), // the refused cleanup spawns nothing
+        MockToolExecutor::new(),
+        MockProvider::new("mock"),
+        RuntimeConfig::default(),
+    )
+    .await;
+    assert!(outcome.ok, "the refusal never propagates");
+    assert_eq!(
+        events
+            .iter()
+            .filter(|e| e.kind == EventKind::TaskFailed)
+            .count(),
+        0
+    );
+    // The boundary's own deny decision…
+    assert!(
+        events.iter().any(|e| {
+            e.kind == EventKind::PermitChecked
+                && str_field(e, "plane") == Some("exec")
+                && str_field(e, "decision") == Some("deny")
+        }),
+        "the permit boundary witnesses its refusal"
+    );
+    // …and the cleanup's OUTCOME frame, naming the refusal code.
+    let outcome_frame = events
+        .iter()
+        .find(|e| {
+            e.kind == EventKind::PermitChecked
+                && str_field(e, "plane") == Some("on_finally")
+                && str_field(e, "decision") == Some("failure")
+        })
+        .expect("a refused cleanup is journaled, not invisible");
+    let why = str_field(outcome_frame, "why").expect("the frame carries its why");
+    assert!(
+        why.contains("NIKA-SEC-004"),
+        "the outcome frame names the refusal code: {why}"
+    );
+}
+
+/// A gate-closed cleanup is VISIBLE too: without the skip frame it was
+/// pixel-identical to a dead trigger on the trace.
+#[tokio::test]
+async fn unwind_gate_closed_cleanup_leaves_a_visible_frame() {
+    let yaml = r#"
+nika: cleanup-gated
+permits: { exec: true }
+tasks:
+  main:
+    exec: { command: ["work"] }
+  main_alert:
+    after: { main: unwind }
+    when: ${{ tasks.main.status == 'failure' }}
+    exec: { command: ["alert", "on-call"] }
+"#;
+    let (outcome, events) = run_to_events(
+        yaml,
+        MockShell::new().enqueue_ok("worked\n"), // the closed gate dequeues nothing
+        MockToolExecutor::new(),
+        MockProvider::new("mock"),
+        RuntimeConfig::default(),
+    )
+    .await;
+    assert!(outcome.ok);
+    assert_eq!(outcome.records["main"].status, TaskStatus::Success);
+    let frame = events
+        .iter()
+        .find(|e| {
+            e.kind == EventKind::PermitChecked
+                && str_field(e, "plane") == Some("on_finally")
+                && str_field(e, "decision") == Some("skipped")
+        })
+        .expect("a gate-closed cleanup leaves a skip frame");
+    assert!(
+        str_field(frame, "why").is_some_and(|w| w.contains("gate")),
+        "the skip frame says why"
     );
 }

--- a/crates/nika-schema/src/parser/retired.rs
+++ b/crates/nika-schema/src/parser/retired.rs
@@ -66,7 +66,10 @@ pub(super) fn task(key: &str) -> Option<&'static str> {
         "on_finally" => Some(
             "cleanup is a TASK now, joined by an unwind edge (2026-08-11) — write \
              it as its own task with `after: { <parent>: unwind }` (a `finally` \
-             node in `graph_format: 3`); the second grammar for a task body died",
+             node in `graph_format: 3`); the second grammar for a task body died. \
+             A cleanup runs under the SAME `permits:` boundary as any task — an \
+             undeclared effect refuses, and the refusal is journaled on the trace \
+             (`permit_checked` · plane `on_finally`), never propagated",
         ),
         "output" => Some(
             "renamed `extract:` (2026-08-11) — same shape, the truthful word for \


### PR DESCRIPTION
## What

A cleanup joined by `after: { x: unwind }` that failed — a permit refusal, a non-zero exit, a timeout, even a closed `when:` gate — vanished without a frame: the trace read pixel-identical to a dead trigger, though spec 03 guarantee 3 promises its errors are logged. The `select()` in `run_one_cleanup` dropped the outcome outright.

The outcome still never propagates (best-effort by spec), but a skip/failure/timeout now rides the parent's witness as one more `permit_checked` frame on plane `on_finally`, naming the error code. No new `EventKind`: the NEP-0007 witness merge already carries the lane's frames into the parent's attested stream. The new `why` field rides the journal redacted.

## R6 review → fix mapping

- **R6 observability find** (a failed cleanup was indistinguishable from a dead trigger in the trace) → the outcome now journals as a `permit_checked` frame on `on_finally` with the error code.
- **R6 security-lens find** (a failed cleanup's stderr tail could ride the journal raw) → the `why` field joins the secret scrub's payload fields, redacted.

## Tracker

References #1252 — covers the unwind-observability half; the Ctrl+C half stays open, this PR does NOT close the issue.

## Test plan

- [x] `cargo test --lib` green on the branch (gates run pre-push)
- [ ] Diamond CI