### PR TITLE
fix(access): one census, one truth — seat rung, doctor fix, refusals

### DIFF
--- a/changelog.d/access-census-one-truth.fixed.md
+++ b/changelog.d/access-census-one-truth.fixed.md
@@ -1,0 +1,17 @@
+---
+- **One access census, one truth — the seat in the first screen, the doctor
+  fix, and the refusal tail.** Three surfaces each read a different source of
+  access truth. `welcome` and `doctor --json` classified a machine with a
+  signed-in harness seat as `installed · no inference path` (the probe filled
+  from provider rows only, the seat rows one call away and never joined in);
+  the doctor per-seat fix taught `install: @zed-industries/claude-agent-acp@…`
+  — the wrapper id `run --access` refuses as retired (NIKA-1802) — and the
+  NIKA-1800/INFER-001 witnesses never named the seat escape hatch nor the
+  credential's custody. The census (`nika_providers::census::AccessCensus`)
+  joins provider rows and harness seats in ONE read; the adoption ladder gains
+  the `seat_ready` rung between `key_present` and `real_ready`; the cascade
+  names seats by their live pin token (`claude-code`, not the wrapper id);
+  doctor's seat fixes name `--access <seat>` plus the gesture; the admission
+  witness says `<VAR> unset in process env`; and the L4 refusal render plus
+  `nika explain` append « or use a signed-in seat: `--access …` » — printed
+  only when this machine actually has one.

--- a/changelog.d/access-census-one-truth.fixed.md
+++ b/changelog.d/access-census-one-truth.fixed.md
@@ -1,4 +1,3 @@
----
 - **One access census, one truth — the seat in the first screen, the doctor
   fix, and the refusal tail.** Three surfaces each read a different source of
   access truth. `welcome` and `doctor --json` classified a machine with a

--- a/crates/nika-cli-host/public-api.txt
+++ b/crates/nika-cli-host/public-api.txt
@@ -286,7 +286,7 @@ pub fn nika_cli_host::doctor::diagnose(probe: &nika_cli_host::probe::Probe) -> a
 pub fn nika_cli_host::doctor::exit_code(findings: &[nika_cli_host::doctor::Finding]) -> u8
 pub fn nika_cli_host::doctor::redact_userinfo(url: &str) -> alloc::string::String
 pub fn nika_cli_host::doctor::render(findings: &[nika_cli_host::doctor::Finding], verbose: bool, theme: nika_display::theme::Theme) -> alloc::string::String
-pub fn nika_cli_host::doctor::render_json(findings: &[nika_cli_host::doctor::Finding], state: nika_cli_host::probe::AdoptionState, receipts: &[nika_cli_host::probe::HostCapabilityReceipt]) -> alloc::string::String
+pub fn nika_cli_host::doctor::render_json(findings: &[nika_cli_host::doctor::Finding], state: nika_cli_host::probe::AdoptionState, receipts: &[nika_cli_host::probe::HostCapabilityReceipt], census: &nika_providers::census::AccessCensus) -> alloc::string::String
 pub fn nika_cli_host::doctor::run(ping: bool, json: bool, verbose: bool, theme: nika_display::theme::Theme) -> nika_cli_host::output::VerbOutput
 pub mod nika_cli_host::door
 pub enum nika_cli_host::door::DoorId
@@ -1766,6 +1766,7 @@ pub nika_cli_host::probe::AdoptionState::KeyPresent
 pub nika_cli_host::probe::AdoptionState::LocalDetected
 pub nika_cli_host::probe::AdoptionState::LocalReachable
 pub nika_cli_host::probe::AdoptionState::RealReady
+pub nika_cli_host::probe::AdoptionState::SeatReady
 impl nika_cli_host::probe::AdoptionState
 pub const fn nika_cli_host::probe::AdoptionState::as_str(self) -> &'static str
 pub const fn nika_cli_host::probe::AdoptionState::cta(self) -> &'static str
@@ -2154,6 +2155,7 @@ impl<T> zvariant::optional::NoneValue for nika_cli_host::probe::PricingProbe whe
 pub type nika_cli_host::probe::PricingProbe::NoneType = T
 pub fn nika_cli_host::probe::PricingProbe::null_value() -> T
 pub struct nika_cli_host::probe::Probe
+pub nika_cli_host::probe::Probe::census: nika_providers::census::AccessCensus
 pub nika_cli_host::probe::Probe::clients: alloc::vec::Vec<nika_cli_host::probe::ClientProbe>
 pub nika_cli_host::probe::Probe::clients_registry: nika_cli_host::clients_registry::RegistryCoverage
 pub nika_cli_host::probe::Probe::config_path: core::option::Option<alloc::string::String>
@@ -2324,11 +2326,15 @@ pub type nika_cli_host::probe::TtsProbe::NoneType = T
 pub fn nika_cli_host::probe::TtsProbe::null_value() -> T
 pub fn nika_cli_host::probe::access_probes_with_harness() -> alloc::vec::Vec<nika_providers::probe::ProviderProbe>
 pub fn nika_cli_host::probe::adoption_state(probe: &nika_cli_host::probe::Probe) -> nika_cli_host::probe::AdoptionState
+pub fn nika_cli_host::probe::auth_class_witness(detail: &str) -> bool
 pub fn nika_cli_host::probe::capability_receipts(probe: &nika_cli_host::probe::Probe) -> alloc::vec::Vec<nika_cli_host::probe::HostCapabilityReceipt>
 pub fn nika_cli_host::probe::collect(ping: bool) -> nika_cli_host::probe::Probe
 pub fn nika_cli_host::probe::environment_json(probe: &nika_cli_host::probe::Probe) -> serde_json::value::Value
+pub fn nika_cli_host::probe::print_seat_escape<'a, W: core::io::write::Write>(witnesses: impl core::iter::traits::collect::IntoIterator<Item = &'a str>, prefix: &str, out: &mut W)
 pub fn nika_cli_host::probe::sandbox_probe() -> nika_cli_host::probe::SandboxProbe
+pub fn nika_cli_host::probe::seat_escape_tail() -> core::option::Option<alloc::string::String>
 pub fn nika_cli_host::probe::train_differs(a: &str, b: &str) -> bool
+pub fn nika_cli_host::probe::with_seat_tail(code: &str, tail: core::option::Option<&str>, text: alloc::string::String) -> alloc::string::String
 pub mod nika_cli_host::repair
 pub fn nika_cli_host::repair::repair_target_for_path(path: &str) -> nika_display::check_render::RepairTarget
 pub fn nika_cli_host::repair::repair_target_for_path_under(path: &str, registry_root: core::option::Option<&std::path::Path>) -> nika_display::check_render::RepairTarget

--- a/crates/nika-cli-host/src/choice/mod.rs
+++ b/crates/nika-cli-host/src/choice/mod.rs
@@ -97,13 +97,13 @@ struct Seat {
     detected: bool,
     authenticated: bool,
     /// Whether the ACP ADAPTER — the binary a session actually spawns —
-    /// is on PATH. The overlay below sees `claude` and names the seat
-    /// `claude-agent-acp`, which is a DIFFERENT npm package; a person can
-    /// have the first and not the second. Without this field the screen
-    /// read a signed-in Claude Code as a runnable seat and said
-    /// `ready · no API key` for a path that cannot spawn (gauntlet P1/P4,
-    /// 2026-08-25). Detected means "you have the app"; ready means "a run
-    /// can start", and only the adapter proves the second.
+    /// is on PATH. A person can have `claude` the app and not
+    /// `claude-agent-acp` the speaker, and the census keeps the two
+    /// halves distinct. Without this field the screen read a signed-in
+    /// Claude Code as a runnable seat and said `ready · no API key` for
+    /// a path that cannot spawn (gauntlet P1/P4, 2026-08-25). Detected
+    /// means "you have the app"; ready means "a run can start", and
+    /// only the adapter proves the second.
     adapter_present: bool,
 }
 
@@ -138,7 +138,7 @@ pub(crate) fn collect() -> InferenceChoice {
     let pull = resolve_tier(&table, ram).map_or_else(|| ALIAS.to_owned(), |t| t.pull.clone());
     let choice = collect_from(&Machine {
         ram,
-        seats: detect_seats(&table),
+        seats: census_seats(&table),
         pulled: featured_is_installed(&pull),
         keys,
         harness_in_binary: cfg!(feature = "access-harness"),
@@ -261,19 +261,20 @@ fn harness_rung(seats: &[Seat], ready_seat: Option<&Seat>, in_binary: bool) -> R
             }
             // Detected but not runnable. Two different walls, and a
             // person can only act on the one that is actually theirs:
-            // the app is here but unsigned, or it is here and signed in
-            // and the ACP adapter it spawns is simply not installed.
+            // the app is here but unsigned, or (the wrapper class) the
+            // ACP adapter a session spawns is simply not installed. The
+            // adapter gap is keyed on the CLASS, not the sign-in
+            // witness: a command-auth seat reads signed-in only with
+            // its adapter, so `authenticated && !adapter` cannot see
+            // the wrapper wall (R4).
             (None, _) if any_detected => seat.map_or_else(
                 || {
                     "here · we'd run on the plan you already pay for · sign in to the app"
                         .to_owned()
                 },
                 |s| {
-                    if s.authenticated && !s.adapter_present {
-                        format!(
-                            "here · signed in · needs its ACP adapter · npm i -g {}",
-                            adapter_package(&s.id)
-                        )
+                    if !s.adapter_present && wrapper_class(&s.id) {
+                        "here · needs its ACP adapter · the install line: nika doctor".to_owned()
                     } else {
                         "here · we'd run on the plan you already pay for · sign in to the app"
                             .to_owned()
@@ -282,18 +283,6 @@ fn harness_rung(seats: &[Seat], ready_seat: Option<&Seat>, in_binary: bool) -> R
             ),
             _ => "Claude Code · Codex · Kimi · Gemini · already on this computer".to_owned(),
         },
-    }
-}
-
-/// The npm package that installs a seat's ACP adapter — the binary a
-/// session spawns, distinct from the app the person already has. The
-/// registry carries the same strings in its `package:` field; this is the
-/// install half of that row, said where a person can act on it.
-fn adapter_package(seat_id: &str) -> &'static str {
-    match seat_id {
-        "claude-agent-acp" => "@zed-industries/claude-agent-acp",
-        "codex-acp" => "@zed-industries/codex-acp",
-        _ => "the adapter for this seat",
     }
 }
 
@@ -467,103 +456,41 @@ fn ram_gb_hw_memsize() -> Option<u32> {
     }
 }
 
-fn detect_seats(table: &Table) -> Vec<Seat> {
-    let mut seats: Vec<Seat> = Vec::new();
-    #[cfg(feature = "access-harness")]
-    {
-        if let Ok(rows) = nika_harness::registry() {
-            let probed = nika_harness::probe_adapters_sync(rows);
-            for row in probed {
-                let detected = row.version.is_some();
-                let authenticated = row.authenticated == Some(true);
-                let name = table
-                    .harness_names
-                    .get(&row.id)
-                    .cloned()
-                    .unwrap_or_else(|| row.id.clone());
-                seats.push(Seat {
-                    id: row.id,
-                    // The registry probed the adapter itself: a version
-                    // means the adapter binary answered.
-                    adapter_present: detected,
-                    name,
-                    detected,
-                    authenticated,
-                });
-            }
-        }
-    }
-    // First-wow overlays: the person has `claude` / `codex`, not the ACP wrapper.
-    for (bin, id) in [
-        ("claude", "claude-agent-acp"),
-        ("codex", "codex-acp"),
-        ("gemini", "gemini-cli"),
-        ("kimi", "kimi-code"),
-    ] {
-        if seats.iter().any(|s| s.id == id && s.detected) {
-            continue;
-        }
-        let detected = on_path(bin);
-        if !detected && !seats.iter().any(|s| s.id == id) {
-            continue;
-        }
-        if !detected {
-            continue;
-        }
-        let authenticated = overlay_authenticated(bin);
-        let name = table
-            .harness_names
-            .get(bin)
-            .or_else(|| table.harness_names.get(id))
-            .cloned()
-            .unwrap_or_else(|| bin.to_owned());
-        // The overlay saw `bin`, never `id`. It may only ADD the app's
-        // presence and its sign-in; it must never claim the adapter,
-        // because it did not look for one.
-        if let Some(existing) = seats.iter_mut().find(|s| s.id == id) {
-            existing.detected = true;
-            existing.authenticated = existing.authenticated || authenticated;
-            existing.name = name;
-        } else {
-            seats.push(Seat {
-                id: id.to_owned(),
+/// The seats the census measured (R4 · one census, one truth). The
+/// cascade used to walk PATH on its own — and name the seat by the
+/// retired ACP wrapper id (`claude-agent-acp`, NIKA-1802 as a pin),
+/// which `chosen_access` then taught to `doctor --json`. The seat id is
+/// now the LIVE pin token (`claude-code`) straight from the registry's
+/// presence pass (PATH + auth surface, never a spawn, never a
+/// credential read).
+fn census_seats(table: &Table) -> Vec<Seat> {
+    nika_providers::census::collect_seats()
+        .into_iter()
+        .map(|fact| {
+            let name = table
+                .harness_names
+                .get(&fact.id)
+                .cloned()
+                .unwrap_or_else(|| fact.id.clone());
+            Seat {
+                detected: fact.product_present || fact.adapter_present || fact.signed_in,
+                authenticated: fact.signed_in,
+                adapter_present: fact.adapter_present,
+                id: fact.id,
                 name,
-                detected: true,
-                authenticated,
-                adapter_present: false,
-            });
-        }
-    }
-    seats
+            }
+        })
+        .collect()
 }
 
-fn overlay_authenticated(bin: &str) -> bool {
-    let Some(home) = probe::home_dir() else {
-        return false;
-    };
-    let files: &[&str] = match bin {
-        "claude" => &[
-            ".claude.json",
-            ".claude/.credentials.json",
-            ".config/claude",
-        ],
-        "codex" => &[".codex", ".codex/auth.json"],
-        "gemini" => &[".gemini/google_accounts.json"],
-        "kimi" => &[".kimi-code/credentials"],
-        _ => &[],
-    };
-    files.iter().any(|rel| home.join(rel).exists())
-}
-
-#[allow(clippy::disallowed_methods)]
-fn on_path(name: &str) -> bool {
-    let Some(path) = std::env::var_os("PATH") else {
-        return false;
-    };
-    std::env::split_paths(&path).any(|dir| {
-        let candidate = dir.join(name);
-        candidate.is_file()
-    })
+/// The wrapper class: the ACP speaker is a DIFFERENT binary from the
+/// product CLI (`claude-agent-acp` ≠ `claude`). For those seats the
+/// adapter gap is the actionable one — and the install line lives in
+/// `nika doctor`, never teaching the wrapper id as if it were the pin
+/// (R4 · it is NIKA-1802 « retired »).
+fn wrapper_class(seat_id: &str) -> bool {
+    nika_types::access::HarnessRuntime::lookup(seat_id)
+        .is_some_and(|rt| rt.detect_bin != rt.acp_bin)
 }
 
 impl InferenceChoice {

--- a/crates/nika-cli-host/src/choice/models.yaml
+++ b/crates/nika-cli-host/src/choice/models.yaml
@@ -42,13 +42,10 @@ keys:
     model: anthropic/claude-sonnet-4-6
 harness_names:
   # The seat keys are the LIVE pin tokens (R4 — the wrapper ids were
-  # NIKA-1802 as pins); the bare product bins stay for the PATH overlay
-  # class of callers.
+  # NIKA-1802 as pins). The census looks a seat up by its pin ONLY, so
+  # a bare product bin here would be a dead row (measured: no caller).
   gemini-cli: Gemini CLI
   qwen-code: Qwen Code
   kimi-code: Kimi
   claude-code: Claude Code
   codex: Codex
-  claude: Claude Code
-  gemini: Gemini CLI
-  kimi: Kimi

--- a/crates/nika-cli-host/src/choice/models.yaml
+++ b/crates/nika-cli-host/src/choice/models.yaml
@@ -41,12 +41,14 @@ keys:
     name: Your Anthropic key
     model: anthropic/claude-sonnet-4-6
 harness_names:
+  # The seat keys are the LIVE pin tokens (R4 — the wrapper ids were
+  # NIKA-1802 as pins); the bare product bins stay for the PATH overlay
+  # class of callers.
   gemini-cli: Gemini CLI
   qwen-code: Qwen Code
   kimi-code: Kimi
-  codex-acp: Codex
-  claude-agent-acp: Claude Code
-  claude: Claude Code
+  claude-code: Claude Code
   codex: Codex
+  claude: Claude Code
   gemini: Gemini CLI
   kimi: Kimi

--- a/crates/nika-cli-host/src/choice/tests.rs
+++ b/crates/nika-cli-host/src/choice/tests.rs
@@ -20,10 +20,12 @@ fn machine(
 }
 
 /// Claude Code, signed in, WITH its ACP adapter on PATH — a seat a
-/// session can actually start on.
+/// session can actually start on. The id is the LIVE pin token
+/// (`claude-code` · R4) — the retired wrapper id was NIKA-1802 as a
+/// pin, and `chosen_access` used to teach it.
 fn claude() -> Seat {
     Seat {
-        id: "claude-agent-acp".to_owned(),
+        id: "claude-code".to_owned(),
         name: "Claude Code".to_owned(),
         detected: true,
         authenticated: true,
@@ -34,8 +36,8 @@ fn claude() -> Seat {
 /// What the gauntlet actually met (P1/P4 · 2026-08-25): the person has
 /// `claude` and is signed into it, and `claude-agent-acp` — a different
 /// npm package, the binary a session spawns — is not installed. The
-/// overlay in `detect_seats` names the seat from the app, so this shape
-/// is what a real first-wow machine produces.
+/// census names the seat by its pin token, so this shape is what a real
+/// first-wow machine produces.
 fn claude_without_its_adapter() -> Seat {
     Seat {
         adapter_present: false,
@@ -170,9 +172,16 @@ fn a_signed_in_app_without_its_acp_adapter_is_not_ready() {
     assert!(harness.available, "the app is here: {choice:?}");
     let human = choice.render_human_at(Theme::new(false, false, false), None);
     assert!(human.contains("Claude Code"), "{human}");
+    // R4 — the row names the wall (the ACP adapter) and the door
+    // (`nika doctor` carries the install line); it no longer teaches
+    // the wrapper's npm id, which `run --access` refuses as retired.
     assert!(
-        human.contains("@zed-industries/claude-agent-acp"),
-        "the row names the one command that closes the gap: {human}"
+        human.contains("needs its ACP adapter") && human.contains("nika doctor"),
+        "the row names the gap and the door: {human}"
+    );
+    assert!(
+        !human.contains("claude-agent-acp"),
+        "the wrapper id is never taught as the fix: {human}"
     );
     assert!(
         !human.contains("no API key"),
@@ -188,8 +197,8 @@ fn the_same_seat_with_its_adapter_is_ready_again() {
     assert_eq!(choice.arrow, "harness", "{choice:?}");
     assert_eq!(
         choice.chosen_access.as_deref(),
-        Some("claude-agent-acp"),
-        "{choice:?}"
+        Some("claude-code"),
+        "the chosen access is the LIVE pin token (R4): {choice:?}"
     );
 }
 
@@ -548,9 +557,9 @@ fn first_wow_slug_is_not_the_lesson_pack() {
 #[test]
 fn chosen_access_is_the_seat_when_harness_has_the_arrow() {
     let choice = collect_from(&machine(Some(18), vec![claude()], false, &[], true));
-    assert_eq!(choice.chosen_access.as_deref(), Some("claude-agent-acp"));
+    assert_eq!(choice.chosen_access.as_deref(), Some("claude-code"));
     let json = choice.doctor_cascade_json();
-    assert_eq!(json["chosen_access"], "claude-agent-acp");
+    assert_eq!(json["chosen_access"], "claude-code");
 }
 
 #[test]

--- a/crates/nika-cli-host/src/doctor.rs
+++ b/crates/nika-cli-host/src/doctor.rs
@@ -245,15 +245,19 @@ fn provider_findings(probe: &Probe, out: &mut Vec<Finding>) {
     out.push(pricing_finding(&probe.pricing));
 
     // The ONE Fail that drives exit 3 · no inference path AT ALL (a broken or
-    // empty catalog). A merely-unset cloud key is a ⚠ above, never fatal.
-    if cloud_keys == 0 && local_ids.is_empty() {
+    // empty catalog). A merely-unset cloud key is a ⚠ above, never fatal —
+    // and a signed-in harness seat IS an inference path (R4 · the census
+    // joins what the provider rows alone never saw; the ladder's SeatReady
+    // rung reads the same `seats_ready`).
+    if cloud_keys == 0 && local_ids.is_empty() && probe.census.seats_ready.is_empty() {
         out.push(Finding {
             level: Level::Fail,
             label: "providers".to_owned(),
-            detail: "no inference provider available — neither a cloud key nor a local server"
+            detail: "no inference path — no cloud key, no local server, no signed-in harness seat"
                 .to_owned(),
             fix: Some(
-                "export <PROVIDER>_API_KEY=…  · or run a local server (ollama · llama.cpp · vLLM)"
+                "export <PROVIDER>_API_KEY=… · run a local server (ollama · llama.cpp · vLLM) · \
+                 or sign in to a harness seat (`--access claude-code`)"
                     .to_owned(),
             ),
         });

--- a/crates/nika-cli-host/src/doctor.rs
+++ b/crates/nika-cli-host/src/doctor.rs
@@ -768,14 +768,30 @@ pub fn exit_code(findings: &[Finding]) -> u8 {
 /// the adoption rung rides alongside (additive) — ONE state token the
 /// flat findings could never express. H5: the per-host runtime receipts
 /// ride alongside too (additive) — what each host earned, what was
-/// verified versus assumed, and the repair, per host.
+/// verified versus assumed, and the repair, per host. R4: the access
+/// census rides alongside (additive) — every path with its custody and
+/// fix, the ready seats, the best path; one read, never recomputed.
 #[must_use]
 pub fn render_json(
     findings: &[Finding],
     state: AdoptionState,
     receipts: &[HostCapabilityReceipt],
+    census: &nika_providers::census::AccessCensus,
 ) -> String {
     let count = |lvl: Level| findings.iter().filter(|f| f.level == lvl).count();
+    let paths: Vec<serde_json::Value> = census
+        .paths
+        .iter()
+        .map(|p| {
+            serde_json::json!({
+                "id": p.id,
+                "class": p.class.as_str(),
+                "configured": p.configured,
+                "custody": p.custody,
+                "fix": p.fix_line,
+            })
+        })
+        .collect();
     let payload = serde_json::json!({
         "summary": {
             "ok": count(Level::Ok),
@@ -785,6 +801,11 @@ pub fn render_json(
         "adoption_state": state.as_str(),
         "findings": findings,
         "receipts": receipts,
+        "access": {
+            "paths": paths,
+            "seats_ready": census.seats_ready,
+            "best": census.best.as_ref().map(|p| p.id.clone()),
+        },
     });
     format!("{payload:#}")
 }
@@ -1068,6 +1089,7 @@ pub fn run(ping: bool, json: bool, verbose: bool, theme: Theme) -> VerbOutput {
                 &findings,
                 crate::probe::adoption_state(&probe),
                 &crate::probe::capability_receipts(&probe),
+                &probe.census,
             ))
         } else {
             // The same sobriety seam the concierge rides: `--plain`
@@ -1081,6 +1103,8 @@ pub fn run(ping: bool, json: bool, verbose: bool, theme: Theme) -> VerbOutput {
     }
 }
 
+#[cfg(test)]
+mod json_tests;
 #[cfg(test)]
 mod pricing_tests;
 #[cfg(test)]
@@ -1155,19 +1179,26 @@ fn harness_finding_from_parts(
             detail: format!(
                 "{id} — {display} · detected (v{major}.{minor}) · not signed in · `--access {id}`"
             ),
-            fix: Some(format!("sign in to {display} itself")),
+            fix: Some(format!(
+                "sign in to {display} itself · then `--access {id}`"
+            )),
         },
         (true, None, _) => Finding {
             level: Level::Warn,
             label: "runtime".to_owned(),
             detail: format!("{id} — {display} · installed, ACP speaker missing · `--access {id}`"),
-            fix: Some(format!("install: {package}")),
+            fix: Some(format!(
+                "install the ACP speaker: {package} · the wrapper is never the pin — `--access {id}`"
+            )),
         },
         (false, None, _) => Finding {
             level: Level::Warn,
             label: "runtime".to_owned(),
             detail: format!("{id} — {display} · not installed · `--access {id}`"),
-            fix: Some(format!("install: {package}")),
+            // The app first — teaching the ACP wrapper package here was
+            // the R4 lie: the operator installed the wrapper (never the
+            // app), then ate NIKA-1802 trying it as a pin.
+            fix: Some(format!("install {display} itself · then `--access {id}`")),
         },
     }
 }

--- a/crates/nika-cli-host/src/doctor/json_tests.rs
+++ b/crates/nika-cli-host/src/doctor/json_tests.rs
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The `doctor --json` machine-lane tests (split from `tests.rs` at the
+//! 1,500-LOC file law): the adoption token ladder and the R4 access
+//! census lane.
+#![allow(clippy::expect_used)]
+
+use super::{AdoptionState, Finding, Level, render_json};
+use nika_providers::census::AccessCensus;
+
+fn findings() -> Vec<Finding> {
+    vec![Finding {
+        level: Level::Ok,
+        label: "binary".to_owned(),
+        detail: "v0".to_owned(),
+        fix: None,
+    }]
+}
+
+/// P0-21 — the machine lane carries the adoption rung next to the
+/// findings: agents/CI branch on ONE state token, not on a parse of
+/// the flat finding rows. R4 added the seat rung.
+#[test]
+fn doctor_json_serializes_the_adoption_state() {
+    for (state, token) in [
+        (AdoptionState::Installed, "installed"),
+        (AdoptionState::LocalDetected, "local_detected"),
+        (AdoptionState::LocalReachable, "local_reachable"),
+        (AdoptionState::KeyPresent, "key_present"),
+        (AdoptionState::SeatReady, "seat_ready"),
+        (AdoptionState::RealReady, "real_ready"),
+    ] {
+        let json: serde_json::Value = serde_json::from_str(&render_json(
+            &findings(),
+            state,
+            &[],
+            &AccessCensus::default(),
+        ))
+        .expect("valid JSON");
+        assert_eq!(json["adoption_state"], token, "{state:?}");
+    }
+}
+
+/// R4 — the machine lane renders the CENSUS (one read, never
+/// recomputed): every path with its class · custody · fix, the ready
+/// seats, the best path. The pre-census fields stay verbatim.
+#[test]
+fn doctor_json_renders_the_access_census() {
+    let census = AccessCensus::from_parts(
+        &[],
+        vec![nika_providers::census::SeatFact::new(
+            "claude-code",
+            vec!["anthropic".to_owned()],
+            true,
+            true,
+            true,
+        )],
+    );
+    let json: serde_json::Value = serde_json::from_str(&render_json(
+        &findings(),
+        AdoptionState::SeatReady,
+        &[],
+        &census,
+    ))
+    .expect("valid JSON");
+    assert_eq!(json["access"]["seats_ready"][0], "claude-code");
+    assert_eq!(json["access"]["best"], "claude-code");
+    let path = &json["access"]["paths"][0];
+    assert_eq!(path["id"], "claude-code");
+    assert_eq!(path["class"], "harness");
+    assert_eq!(path["configured"], true);
+    // A ready seat teaches nothing — `fix` is null, never a wrapper id.
+    assert_eq!(path["fix"], serde_json::Value::Null);
+    // Mutation pin: an unready seat keeps its fix and leaves `best` null.
+    let unready = AccessCensus::from_parts(
+        &[],
+        vec![nika_providers::census::SeatFact::new(
+            "claude-code",
+            vec!["anthropic".to_owned()],
+            true,
+            false,
+            true,
+        )],
+    );
+    let json: serde_json::Value = serde_json::from_str(&render_json(
+        &findings(),
+        AdoptionState::Installed,
+        &[],
+        &unready,
+    ))
+    .expect("valid JSON");
+    assert!(
+        json["access"]["seats_ready"]
+            .as_array()
+            .expect("array")
+            .is_empty()
+    );
+    assert_eq!(json["access"]["best"], serde_json::Value::Null);
+    assert!(
+        json["access"]["paths"][0]["fix"]
+            .as_str()
+            .expect("the fix line")
+            .contains("--access claude-code"),
+        "{json:#}"
+    );
+}

--- a/crates/nika-cli-host/src/doctor/runtime_tests.rs
+++ b/crates/nika-cli-host/src/doctor/runtime_tests.rs
@@ -71,3 +71,43 @@ fn codex_without_acp_still_names_the_direct_infer_path() {
         finding.fix
     );
 }
+
+/// R4 — the per-seat fix used to teach `install: @zed-industries/
+/// claude-agent-acp@0.23.1` on a machine WITHOUT Claude Code: the
+/// operator installed the ACP WRAPPER (never the app), tried it as
+/// `--access claude-agent-acp`, and ate NIKA-1802 « retired ». Every
+/// seat fix now names the LIVE pin and the gesture; the wrapper id is
+/// disambiguated where the package itself must be named (the adapter
+/// install), and absent where it was the whole lie (app not installed).
+#[cfg(feature = "access-harness")]
+#[test]
+fn the_seat_fix_names_the_live_pin_never_teaches_the_wrapper_as_a_pin() {
+    let package =
+        "@zed-industries/claude-agent-acp@0.23.1 (npm i -g · wraps the claude CLI's own auth)";
+    // Not installed: the fix teaches installing the APP, and names the
+    // pin — the wrapper string does not appear at all.
+    let absent = super::harness_finding_from_parts("claude-code", None, None, package, false);
+    let fix = absent.fix.as_deref().expect("a fix");
+    assert!(fix.contains("--access claude-code"), "{fix}");
+    assert!(
+        !fix.contains("claude-agent-acp"),
+        "a machine without the app was told to install the wrapper: {fix}"
+    );
+    // App installed, adapter missing: the package IS the adapter, so it
+    // is named — beside the explicit « never the pin » clause and the
+    // live token.
+    let no_adapter = super::harness_finding_from_parts("claude-code", None, None, package, true);
+    let fix = no_adapter.fix.as_deref().expect("a fix");
+    assert!(fix.contains("--access claude-code"), "{fix}");
+    assert!(fix.contains("never the pin"), "{fix}");
+    // Not signed in: the gesture, then the pin.
+    let unsigned =
+        super::harness_finding_from_parts("claude-code", Some((0, 23)), Some(false), package, true);
+    let fix = unsigned.fix.as_deref().expect("a fix");
+    assert!(fix.contains("sign in to Claude Code itself"), "{fix}");
+    assert!(fix.contains("--access claude-code"), "{fix}");
+    // The authenticated seat teaches nothing.
+    let ready =
+        super::harness_finding_from_parts("claude-code", Some((0, 23)), Some(true), package, true);
+    assert_eq!(ready.fix, None);
+}

--- a/crates/nika-cli-host/src/doctor/tests.rs
+++ b/crates/nika-cli-host/src/doctor/tests.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use nika_providers::ProviderRegistry;
+use nika_providers::census::AccessCensus;
 
 use super::*;
 use crate::probe::client_probe_any;
@@ -116,6 +117,7 @@ fn a_lan_override_is_named_on_the_local_lane() {
         version: "0.0.0".to_owned(),
         config_path: None,
         providers: vec![ollama],
+        census: AccessCensus::default(),
         clients: Vec::new(),
         kits: Vec::new(),
         clients_registry: RegistryCoverage::default(),
@@ -139,6 +141,7 @@ fn a_lan_override_is_named_on_the_local_lane() {
     // A loopback ollama earns NO extra row — the exception gets the ink.
     let quiet = Probe {
         providers: vec![local("ollama")],
+        census: AccessCensus::default(),
         ..probe
     };
     let findings = diagnose(&quiet);
@@ -172,6 +175,7 @@ fn key_present_is_ok_and_exits_zero() {
         version: "0.81.0".to_owned(),
         config_path: Some("~/.nika/config.toml".to_owned()),
         providers: vec![cloud("anthropic", "ANTHROPIC_API_KEY", true)],
+        census: AccessCensus::default(),
         clients: vec![],
         kits: vec![],
         clients_registry: RegistryCoverage::default(),
@@ -206,6 +210,7 @@ fn unset_key_is_a_warn_with_a_fix_not_a_fail() {
             cloud("anthropic", "ANTHROPIC_API_KEY", false),
             local("ollama"),
         ],
+        census: AccessCensus::default(),
         clients: vec![],
         kits: vec![],
         clients_registry: RegistryCoverage::default(),
@@ -245,6 +250,7 @@ fn never_prints_a_secret_value() {
         version: "0.81.0".to_owned(),
         config_path: None,
         providers: vec![cloud("openai", "OPENAI_API_KEY", false)],
+        census: AccessCensus::default(),
         clients: vec![],
         kits: vec![],
         clients_registry: RegistryCoverage::default(),
@@ -274,6 +280,7 @@ fn no_provider_at_all_fails_with_exit_three() {
         version: "0.81.0".to_owned(),
         config_path: None,
         providers: vec![cloud("anthropic", "ANTHROPIC_API_KEY", false)],
+        census: AccessCensus::default(),
         clients: vec![],
         kits: vec![],
         clients_registry: RegistryCoverage::default(),
@@ -298,6 +305,7 @@ fn local_provider_alone_is_a_usable_path_exit_zero() {
         version: "0.81.0".to_owned(),
         config_path: None,
         providers: vec![local("ollama"), local("vllm")],
+        census: AccessCensus::default(),
         clients: vec![],
         kits: vec![],
         clients_registry: RegistryCoverage::default(),
@@ -333,37 +341,17 @@ fn json_lane_carries_summary_and_findings_verbatim() {
             fix: Some("nika wire claude".to_owned()),
         },
     ];
-    let json: serde_json::Value =
-        serde_json::from_str(&render_json(&findings, AdoptionState::KeyPresent, &[]))
-            .expect("valid JSON");
+    let json: serde_json::Value = serde_json::from_str(&render_json(
+        &findings,
+        AdoptionState::KeyPresent,
+        &[],
+        &AccessCensus::default(),
+    ))
+    .expect("valid JSON");
     assert_eq!(json["summary"]["ok"], 1);
     assert_eq!(json["summary"]["fail"], 1);
     assert_eq!(json["findings"][0]["level"], "ok");
     assert_eq!(json["findings"][1]["fix"], "nika wire claude");
-}
-
-/// P0-21 — the machine lane carries the adoption rung next to the
-/// findings: agents/CI branch on ONE state token, not on a parse of
-/// the flat finding rows.
-#[test]
-fn doctor_json_serializes_the_adoption_state() {
-    let findings = vec![Finding {
-        level: Level::Ok,
-        label: "binary".to_owned(),
-        detail: "v0".to_owned(),
-        fix: None,
-    }];
-    for (state, token) in [
-        (AdoptionState::Installed, "installed"),
-        (AdoptionState::LocalDetected, "local_detected"),
-        (AdoptionState::LocalReachable, "local_reachable"),
-        (AdoptionState::KeyPresent, "key_present"),
-        (AdoptionState::RealReady, "real_ready"),
-    ] {
-        let json: serde_json::Value =
-            serde_json::from_str(&render_json(&findings, state, &[])).expect("valid JSON");
-        assert_eq!(json["adoption_state"], token, "{state:?}");
-    }
 }
 
 /// H5 — the machine lane gains the per-host runtime receipts
@@ -377,6 +365,7 @@ fn doctor_json_adds_host_receipts_without_touching_existing_fields() {
         version: "0.96.0".to_owned(),
         config_path: None,
         providers: vec![local("ollama")],
+        census: AccessCensus::default(),
         clients: vec![
             ClientProbe {
                 id: "hermes".to_owned(),
@@ -412,6 +401,7 @@ fn doctor_json_adds_host_receipts_without_touching_existing_fields() {
         &findings,
         AdoptionState::KeyPresent,
         &crate::probe::capability_receipts(&probe),
+        &probe.census,
     ))
     .expect("valid JSON");
     // The pre-H5 fields are untouched (additive means additive).
@@ -461,6 +451,7 @@ fn sidecar_row_tracks_the_build_feature() {
         version: "0.99.0".to_owned(),
         config_path: None,
         providers: vec![local("ollama")],
+        census: AccessCensus::default(),
         clients: vec![],
         kits: vec![],
         clients_registry: RegistryCoverage::default(),
@@ -555,6 +546,7 @@ fn the_ascii_theme_folds_every_doctor_glyph() {
         version: "0.106.0".to_owned(),
         config_path: None,
         providers: vec![],
+        census: AccessCensus::default(),
         clients: vec![wired("hermes"), wired("cursor")],
         kits: vec![KitProbe {
             client: "cursor".to_owned(),
@@ -597,6 +589,7 @@ fn doctor_names_each_host_capability_level() {
         version: "0.106.0".to_owned(),
         config_path: None,
         providers: vec![],
+        census: AccessCensus::default(),
         clients: vec![wired("hermes"), wired("cursor")],
         kits: vec![KitProbe {
             client: "cursor".to_owned(),
@@ -637,6 +630,7 @@ fn client_probe_reports_stale_wiring_with_a_wire_fix() {
         version: "0.90.0".to_owned(),
         config_path: None,
         providers: vec![local("ollama")],
+        census: AccessCensus::default(),
         clients: vec![ClientProbe {
             id: "cursor".to_owned(),
             path: "~/.cursor/mcp.json".to_owned(),
@@ -743,6 +737,7 @@ fn diagnose_carries_one_kit_row_per_found_surface() {
         version: "0.106.1".to_owned(),
         config_path: None,
         providers: vec![local("ollama")],
+        census: AccessCensus::default(),
         clients: vec![],
         kits: vec![kit("codex", "0.106.0"), kit("claude", "0.104.0")],
         clients_registry: RegistryCoverage::default(),
@@ -968,6 +963,7 @@ fn local_line_hands_off_to_ping_and_ping_lines_render() {
         version: "0.0.0".to_owned(),
         config_path: None,
         providers: vec![local("ollama")],
+        census: AccessCensus::default(),
         clients: Vec::new(),
         kits: Vec::new(),
         clients_registry: RegistryCoverage::default(),
@@ -1059,6 +1055,7 @@ fn diagnose_surfaces_the_tracked_traces_row_without_failing() {
         version: "0.0.0".to_owned(),
         config_path: None,
         providers: vec![local("ollama")],
+        census: AccessCensus::default(),
         clients: vec![],
         kits: vec![],
         clients_registry: RegistryCoverage::default(),
@@ -1199,6 +1196,7 @@ fn diagnose_emits_one_registry_coverage_row() {
         version: "0.0.0".to_owned(),
         config_path: None,
         providers: vec![],
+        census: AccessCensus::default(),
         clients: Vec::new(),
         kits: Vec::new(),
         clients_registry: RegistryCoverage {

--- a/crates/nika-cli-host/src/probe.rs
+++ b/crates/nika-cli-host/src/probe.rs
@@ -16,6 +16,7 @@ use std::path::{Path, PathBuf};
 
 pub use crate::harness::access_probes_with_harness;
 use nika_providers::ProviderRegistry;
+use nika_providers::census::AccessCensus;
 use nika_providers::probe::ExecutionLocus;
 pub use nika_providers::probe::{PingState, ProviderProbe, env_present};
 
@@ -31,6 +32,12 @@ pub struct Probe {
     /// `Some(path)` when a user config file exists.
     pub config_path: Option<String>,
     pub providers: Vec<ProviderProbe>,
+    /// The access census (R4 · one census, one truth): the provider rows
+    /// PLUS the harness seats joined in, so no surface ever again reads
+    /// provider rows alone and calls a signed-in seat « no inference
+    /// path ». Derived ONCE here from the same rows; `doctor`, `welcome`
+    /// and the refusal tail READ it, none recomputes.
+    pub census: AccessCensus,
     pub clients: Vec<ClientProbe>,
     /// Installed plugin-kit surfaces (found only — absence is silence,
     /// the kit is optional).
@@ -366,10 +373,15 @@ pub fn collect(ping: bool) -> Probe {
     // here made --ping probe seeds the operator had redirected away).
     let registry = ProviderRegistry::without_http(nika_runtime::compose::config_from_env());
     let providers = nika_providers::probe::collect_provider_probes(&registry);
+    // R4 — the census joins the harness seats the provider rows never
+    // carried: SAME rows, ONE derivation (`from_parts` is the pure fold;
+    // `collect_seats` is the PATH/auth-surface presence pass).
+    let census = AccessCensus::from_parts(&providers, nika_providers::census::collect_seats());
     let probe = Probe {
         version: env!("CARGO_PKG_VERSION").to_owned(),
         config_path: config_path(),
         providers,
+        census,
         clients: client_probes(),
         kits: kit_probes(),
         clients_registry: clients_registry::vendored()
@@ -784,6 +796,10 @@ pub fn environment_json(probe: &Probe) -> serde_json::Value {
         "models_bytes": probe.models.bytes,
         "cloud_keys_present": present,
         "cloud_keys_total": total,
+        // R4 — the seats a run can start on ride the mirrors too
+        // (additive): a signed-in seat is an inference path, and the
+        // machine lanes must say so.
+        "seats_ready": probe.census.seats_ready,
     })
 }
 
@@ -807,6 +823,14 @@ fn recorded_run_count() -> usize {
 /// with it, `doctor --json` serializes it — no surface recomputes its
 /// own truth.
 ///
+/// AMENDED R4 (2026-08-25): the ladder read the PROVIDER rows only, so
+/// a signed-in harness seat — inference that runs on the plan the
+/// operator already pays for — was invisible to it, and the first
+/// screen said « installed · no inference path » while a seat sat
+/// ready. The `SeatReady` rung (between `KeyPresent` and `RealReady`)
+/// is earned by the CENSUS (`probe.census.seats_ready`: signed in AND
+/// the ACP adapter a session spawns on PATH), never re-derived here.
+///
 /// Two rungs of the audited scale are deliberately ABSENT, and the
 /// absence is the honesty law applied:
 /// - `NotInstalled` — unreachable: the observing surface IS the running
@@ -816,11 +840,14 @@ fn recorded_run_count() -> usize {
 ///   `.nika/traces/*.ndjson`, 2026-07-31), so « a simulated run
 ///   happened » cannot be told from a real one. The rung is not
 ///   invented; runs without a live path today read `Installed`.
+///   (R4: still absent — the journal still can't name the model, and
+///   welcome never pings.)
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AdoptionState {
-    /// The floor: no cloud key, no local engagement, no recorded run.
-    /// The keyless engines in the catalog are SEED facts — present on
-    /// every machine, so they can never count as detection.
+    /// The floor: no cloud key, no local engagement, no seat, no
+    /// recorded run. The keyless engines in the catalog are SEED facts
+    /// — present on every machine, so they can never count as
+    /// detection.
     Installed,
     /// The local lane shows an operator signal — an endpoint override
     /// (locus `lan`/`remote`), pulled GGUF bytes, or an explicit ping —
@@ -832,10 +859,17 @@ pub enum AdoptionState {
     /// At least one cloud provider is CONFIGURED (key present). Never
     /// « verified »: cloud endpoints are never pinged, by design.
     KeyPresent,
-    /// A live path today (verified local OR configured cloud) AND ≥1
-    /// run journal on record. The claim is « path live + runs on
-    /// record » — the journal proves the engine ran, never which model
-    /// answered, so this rung never says « a real model answered ».
+    /// A signed-in harness seat can serve a run TODAY (R4 · the census
+    /// `seats_ready` lane: the sign-in witness AND the ACP adapter on
+    /// PATH). Outranks a bare metered key — the operator's own plan is
+    /// the sovereign path. Never « verified »: the session judges the
+    /// seat's own auth at run (NIKA-1805).
+    SeatReady,
+    /// A live path today (verified local OR configured cloud OR a ready
+    /// seat) AND ≥1 run journal on record. The claim is « path live +
+    /// runs on record » — the journal proves the engine ran, never
+    /// which model answered, so this rung never says « a real model
+    /// answered ».
     RealReady,
 }
 
@@ -848,6 +882,7 @@ impl AdoptionState {
             Self::LocalDetected => "local_detected",
             Self::LocalReachable => "local_reachable",
             Self::KeyPresent => "key_present",
+            Self::SeatReady => "seat_ready",
             Self::RealReady => "real_ready",
         }
     }
@@ -901,6 +936,17 @@ impl AdoptionState {
                     .count();
                 format!("key present · {present} of {total} clouds configured")
             }
+            // R4 — the seat rung names the seat (the census owns the
+            // list; the rung READS it). The promise is the plan the
+            // operator already pays for, never « verified ».
+            Self::SeatReady => {
+                let seat = probe
+                    .census
+                    .seats_ready
+                    .first()
+                    .map_or("a seat", String::as_str);
+                format!("seat ready · {seat} signed in")
+            }
             Self::RealReady => {
                 let path = if probe
                     .local_pings
@@ -908,8 +954,10 @@ impl AdoptionState {
                     .any(|(_, _, s)| matches!(s, PingState::Reachable(_)))
                 {
                     "endpoint verified"
-                } else {
+                } else if probe.census.seats_ready.is_empty() {
                     "path configured"
+                } else {
+                    "seat ready"
                 };
                 format!(
                     "real-ready · {} on record · {path}",
@@ -929,15 +977,16 @@ impl AdoptionState {
             Self::LocalDetected => "start it, then nika doctor --ping",
             Self::LocalReachable => "point a run at it",
             Self::KeyPresent => "ready for a real run",
+            Self::SeatReady => "runs on the plan you pay for",
             Self::RealReady => "nika run",
         }
     }
 }
 
-/// THE one classifier (P0-21) — pure over the probe facts, so welcome,
-/// doctor and the tests all climb the SAME ladder. Highest earned rung
-/// wins; a rung is only ever earned by a fact the probe actually
-/// measured.
+/// THE one classifier (P0-21 · amended R4 2026-08-25 — the seat rung
+/// reads the census) — pure over the probe facts, so welcome, doctor
+/// and the tests all climb the SAME ladder. Highest earned rung wins;
+/// a rung is only ever earned by a fact the probe actually measured.
 #[must_use]
 pub fn adoption_state(probe: &Probe) -> AdoptionState {
     let cloud_configured = probe
@@ -948,11 +997,18 @@ pub fn adoption_state(probe: &Probe) -> AdoptionState {
         .local_pings
         .iter()
         .any(|(_, _, state)| matches!(state, PingState::Reachable(_)));
-    if (cloud_configured || local_reachable) && probe.recorded_runs > 0 {
+    // R4 — a ready seat is a live path today: it earns RealReady beside
+    // a key or a verified endpoint, and outranks a bare metered key
+    // (the operator's own plan is the sovereign path).
+    let seat_ready = !probe.census.seats_ready.is_empty();
+    if (cloud_configured || local_reachable || seat_ready) && probe.recorded_runs > 0 {
         return AdoptionState::RealReady;
     }
     if local_reachable {
         return AdoptionState::LocalReachable;
+    }
+    if seat_ready {
+        return AdoptionState::SeatReady;
     }
     if cloud_configured {
         return AdoptionState::KeyPresent;
@@ -972,6 +1028,60 @@ pub fn adoption_state(probe: &Probe) -> AdoptionState {
     AdoptionState::Installed
 }
 
+/// The R4 seat-escape line an auth-class witness earns when THIS
+/// machine has a signed-in harness seat (NIKA-1800 at admission ·
+/// NIKA-INFER-001 at the call). Census-derived: printed only when it
+/// is TRUE, naming the live pin token — never the retired ACP wrapper
+/// id. The collector is presence-only (no ping, no spawn), cheap enough
+/// for a refusal path.
+#[must_use]
+pub fn seat_escape_tail() -> Option<String> {
+    AccessCensus::collect(nika_runtime::compose::config_from_env()).seat_escape()
+}
+
+/// The auth-class witness predicate (R4): a missing credential
+/// (NIKA-INFER-001) or a refused admission (NIKA-1800) earns the seat
+/// escape hatch. Pure over the witness text — the journal's own words.
+#[must_use]
+pub fn auth_class_witness(detail: &str) -> bool {
+    detail.contains("NIKA-INFER-001") || detail.contains("NIKA-1800")
+}
+
+/// Print the seat escape line when any witness is auth-class AND the
+/// census found a ready seat — the ONE seam every run lane calls (the
+/// lane picks the stream; `writeln!` to a locked handle, so the print
+/// lints stay silent and the bytes stay the lane's choice).
+pub fn print_seat_escape<'a, W: std::io::Write>(
+    witnesses: impl IntoIterator<Item = &'a str>,
+    prefix: &str,
+    out: &mut W,
+) {
+    if !witnesses.into_iter().any(auth_class_witness) {
+        return;
+    }
+    if let Some(tail) = seat_escape_tail() {
+        let _ = writeln!(out, "{prefix}{tail}");
+    }
+}
+
+/// The teaching-side half (R4 · `nika explain`): the auth-class codes
+/// (the INFER-001 canon row · the 1800 admission refusal) append the
+/// seat escape hatch when THIS machine has a signed-in seat. The tail
+/// is census-derived (`Some` only when a seat is ready), so the
+/// teaching never promises a path the machine does not have; the low
+/// layers keep their own voice (the provider layer cannot see seats —
+/// the L4 renderer can).
+#[must_use]
+pub fn with_seat_tail(code: &str, tail: Option<&str>, text: String) -> String {
+    if !matches!(code, "NIKA-INFER-001" | "NIKA-1800") {
+        return text;
+    }
+    match tail {
+        Some(tail) => format!("{text}\n  {tail}\n"),
+        None => text,
+    }
+}
+
 /// `~/.nika/config.toml` when it exists (presence only · never read). `HOME` is
 /// a path, not a secret — the scoped allow mirrors `env_present`'s.
 #[allow(clippy::disallowed_methods)]
@@ -984,512 +1094,4 @@ fn config_path() -> Option<String> {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[allow(clippy::disallowed_methods)]
-    fn temp_dir(name: &str) -> PathBuf {
-        let base = std::env::var_os("CARGO_TARGET_TMPDIR").map_or_else(
-            || {
-                std::env::current_dir()
-                    .expect("current dir")
-                    .join("target")
-                    .join("tmp")
-            },
-            PathBuf::from,
-        );
-        let dir = base.join(format!("nika-probe-{name}-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).expect("temp dir");
-        dir
-    }
-
-    #[test]
-    fn manifest_version_reads_the_one_field() {
-        let dir = temp_dir("manifest");
-        let path = dir.join("plugin.json");
-        std::fs::write(&path, r#"{"name":"nika","version":"0.106.0"}"#).expect("fixture");
-        assert_eq!(manifest_version(&path).as_deref(), Some("0.106.0"));
-        assert_eq!(manifest_version(&dir.join("absent.json")), None);
-        std::fs::write(&path, "not json").expect("fixture");
-        assert_eq!(manifest_version(&path), None, "unreadable is silence");
-        let _ = std::fs::remove_dir_all(dir);
-    }
-
-    #[test]
-    fn claude_install_rung_is_the_json_of_record() {
-        let dir = temp_dir("claude-install");
-        std::fs::write(
-            dir.join("installed_plugins.json"),
-            r#"{"version":2,"plugins":{"nika@nika":[{"scope":"user","version":"0.105.0"}],
-                "other@x":[{"version":"9.9.9"}]}}"#,
-        )
-        .expect("fixture");
-        assert_eq!(
-            claude_installed_version(&dir).as_deref(),
-            Some("0.105.0"),
-            "the ACTIVE entry, never another plugin's"
-        );
-        assert_eq!(claude_installed_version(&temp_dir("claude-empty")), None);
-        let _ = std::fs::remove_dir_all(dir);
-    }
-
-    #[test]
-    fn codex_cache_picks_the_highest_version_numerically() {
-        let dir = temp_dir("codex-cache");
-        for d in ["0.9.0", "0.105.0", "0.104.2", "tmp", "0.105"] {
-            std::fs::create_dir_all(dir.join(d)).expect("fixture dir");
-        }
-        // 0.9.0 > 0.105.0 lexically — numeric ordering is the assertion.
-        assert_eq!(codex_cache_version(&dir).as_deref(), Some("0.105.0"));
-        assert_eq!(codex_cache_version(&dir.join("absent")), None);
-        let _ = std::fs::remove_dir_all(dir);
-    }
-
-    #[test]
-    fn train_differs_compares_trains_and_never_guesses() {
-        assert!(train_differs("0.105.0", "0.106.1"));
-        assert!(!train_differs("0.106.0", "0.106.1"), "patch is not a train");
-        assert!(
-            !train_differs("garbage", "0.106.1"),
-            "unparseable = never guess"
-        );
-        assert!(!train_differs("0.106.0", ""), "either side");
-    }
-
-    #[test]
-    fn version_key_is_numeric_and_rejects_non_versions() {
-        assert!(version_key("0.105.0") > version_key("0.9.0"));
-        assert_eq!(
-            version_key("0.105"),
-            Some((0, 105, 0)),
-            "missing patch reads 0"
-        );
-        assert_eq!(version_key("tmp"), None);
-        assert_eq!(version_key("1"), None, "a version needs major.minor");
-    }
-
-    #[test]
-    fn iso_to_epoch_days_civil_math() {
-        assert_eq!(iso_to_epoch_days("1970-01-01"), Some(0));
-        assert_eq!(iso_to_epoch_days("1970-01-02"), Some(1));
-        // The leap day: 2000-02-29 exists, 03-01 is exactly one later.
-        let feb29 = iso_to_epoch_days("2000-02-29").expect("leap day");
-        let mar01 = iso_to_epoch_days("2000-03-01").expect("march 1");
-        assert_eq!(mar01 - feb29, 1);
-        assert!(iso_to_epoch_days("2026-07-07").expect("modern date") > 20_000);
-        for bad in ["2026-13-01", "2026-7-07", "garbage", ""] {
-            assert_eq!(iso_to_epoch_days(bad), None, "{bad:?}");
-        }
-    }
-
-    #[test]
-    fn snapshot_age_never_reads_the_future_as_stale() {
-        let today = iso_to_epoch_days("2026-07-08");
-        assert_eq!(snapshot_age_days("2026-07-07", today), Some(1));
-        assert_eq!(snapshot_age_days("2026-07-08", today), Some(0));
-        // Clock skew: a snapshot "from tomorrow" reads unknowable, never stale.
-        assert_eq!(snapshot_age_days("2026-07-09", today), None);
-        assert_eq!(snapshot_age_days("garbage", today), None);
-        assert_eq!(snapshot_age_days("2026-07-07", None), None);
-    }
-
-    #[test]
-    fn the_real_probe_fills_pricing_from_the_vendored_snapshot() {
-        // Derived counts (born-stale law): non-empty · providers ≥ the
-        // cloud set · identity mirrors the catalog accessor.
-        let p = pricing_probe();
-        assert!(p.rules > 100, "got {}", p.rules);
-        assert!(p.providers >= 5, "got {}", p.providers);
-        assert_eq!(p.as_of, nika_catalog::pricing_snapshot().as_of);
-        assert_eq!(p.sha, nika_catalog::pricing_snapshot().source_sha256_16);
-    }
-
-    // ── The adoption ladder (P0-21 · audit UX 2026-07-30) ──
-
-    use nika_providers::probe::{ExecutionLocus, ProviderReadiness};
-
-    /// One synthetic machine, rung ZERO: the registry's keyless engines
-    /// are CATALOG facts (always present, always "configured" — a keyless
-    /// seed needs nothing), never adoption. Detection needs an operator
-    /// signal: an override, bytes on disk, or an explicit `--ping`.
-    fn ladder_probe() -> Probe {
-        let readiness = |configured, locus: ExecutionLocus| {
-            ProviderReadiness::new(
-                true,
-                configured,
-                None,
-                None,
-                false,
-                locus,
-                // Mirrors Profile::access_class on the synthetic machine.
-                match locus {
-                    ExecutionLocus::Loopback | ExecutionLocus::Lan => {
-                        nika_providers::probe::AccessClass::Local
-                    }
-                    _ => nika_providers::probe::AccessClass::Api,
-                },
-            )
-        };
-        Probe {
-            version: "0.0.0-test".to_owned(),
-            config_path: None,
-            providers: vec![
-                ProviderProbe::new(
-                    "ollama",
-                    false,
-                    false,
-                    "",
-                    true,
-                    readiness(true, ExecutionLocus::Loopback),
-                    "http://127.0.0.1:11434",
-                ),
-                ProviderProbe::new(
-                    "mistral",
-                    true,
-                    false,
-                    "MISTRAL_API_KEY",
-                    true,
-                    readiness(false, ExecutionLocus::Cloud),
-                    "https://api.mistral.ai/v1/chat/completions",
-                ),
-            ],
-            clients: vec![],
-            kits: vec![],
-            clients_registry: RegistryCoverage::default(),
-            image: ImageProbe::default(),
-            tts: TtsProbe::default(),
-            local_pings: vec![],
-            pricing: PricingProbe::default(),
-            retention: RetentionConfig::default(),
-            retention_notes: vec![],
-            models: ModelsProbe::default(),
-            recorded_runs: 0,
-            tracked_traces: None,
-        }
-    }
-
-    /// One rung per fact — each transition is earned by exactly ONE new
-    /// observation, and no fact is ever claimed beyond its measurement.
-    #[test]
-    fn adoption_ladder_climbs_one_rung_per_fact() {
-        let base = ladder_probe();
-        // Installed — the catalog's keyless seed is NOT detection.
-        assert_eq!(adoption_state(&base), AdoptionState::Installed);
-
-        // KeyPresent — a cloud key is CONFIGURED, never « verified ».
-        let mut keyed = base.clone();
-        keyed.providers[1].key_present = true;
-        keyed.providers[1].readiness.configured = true;
-        assert_eq!(adoption_state(&keyed), AdoptionState::KeyPresent);
-
-        // LocalDetected — an override moves the engine off its seed…
-        let mut override_lan = base.clone();
-        override_lan.providers[0].endpoint = "http://gpu.lan:11434".to_owned();
-        override_lan.providers[0].readiness.execution_locus = ExecutionLocus::Lan;
-        assert_eq!(adoption_state(&override_lan), AdoptionState::LocalDetected);
-        // …or bytes on disk (a pulled GGUF)…
-        let mut pulled = base.clone();
-        pulled.models.count = 1;
-        assert_eq!(adoption_state(&pulled), AdoptionState::LocalDetected);
-        // …or a ping that found NOTHING (engaged, honestly unproven).
-        let mut dead_ping = base.clone();
-        dead_ping.local_pings = vec![(
-            "ollama".to_owned(),
-            "127.0.0.1:11434".to_owned(),
-            PingState::Unreachable,
-        )];
-        assert_eq!(adoption_state(&dead_ping), AdoptionState::LocalDetected);
-
-        // LocalReachable — ONLY an explicit --ping measurement proves it.
-        let mut reachable = base.clone();
-        reachable.local_pings = vec![(
-            "ollama".to_owned(),
-            "127.0.0.1:11434".to_owned(),
-            PingState::Reachable(3),
-        )];
-        assert_eq!(adoption_state(&reachable), AdoptionState::LocalReachable);
-
-        // RealReady — a live path AND runs on record (either lane earns
-        // the path: a verified local endpoint or a configured cloud key).
-        let mut real_local = reachable.clone();
-        real_local.recorded_runs = 2;
-        assert_eq!(adoption_state(&real_local), AdoptionState::RealReady);
-        let mut real_cloud = keyed.clone();
-        real_cloud.recorded_runs = 1;
-        assert_eq!(adoption_state(&real_cloud), AdoptionState::RealReady);
-        // Runs ALONE prove nothing about today's path (the journal never
-        // records the serving model — mock-vs-real is unknowable, so the
-        // rung is not invented: no path today = the honest floor).
-        let mut ran_once = base.clone();
-        ran_once.recorded_runs = 3;
-        assert_eq!(adoption_state(&ran_once), AdoptionState::Installed);
-    }
-
-    /// The enum is exhaustive over the ladder and every rung owns its
-    /// own label, metric and CTA — no two states render the same line.
-    #[test]
-    fn every_adoption_rung_renders_its_own_line() {
-        let probe = ladder_probe();
-        let mut lines = std::collections::BTreeSet::new();
-        for state in [
-            AdoptionState::Installed,
-            AdoptionState::LocalDetected,
-            AdoptionState::LocalReachable,
-            AdoptionState::KeyPresent,
-            AdoptionState::RealReady,
-        ] {
-            assert!(!state.metric(&probe).is_empty(), "{state:?}");
-            assert!(!state.cta().is_empty(), "{state:?}");
-            assert!(lines.insert(state.as_str()), "labels are unique");
-            assert!(lines.insert(state.cta()), "every rung owns its CTA");
-        }
-    }
-
-    // ── Capability levels (P0-9 · audit UX 2026-07-30) + Hermes (H2) ──
-
-    /// One synthetic client row (wired or not).
-    fn client(id: &str, current: bool) -> ClientProbe {
-        ClientProbe {
-            id: id.to_owned(),
-            path: format!("~/.{id}/config"),
-            present: true,
-            current,
-            stale: false,
-        }
-    }
-
-    fn versioned_kit(client: &str) -> KitProbe {
-        KitProbe {
-            client: client.to_owned(),
-            version: "0.106.0".to_owned(),
-        }
-    }
-
-    #[test]
-    fn capability_ladder_never_calls_mcp_only_guarded() {
-        // The audit's lie: every wired host read as one flat « wired ».
-        // MCP alone is the oracle rung — the guard is EARNED by hooks,
-        // never implied by the wire.
-        let hermes = client("hermes", true);
-        assert_eq!(hermes.capability(&[]), CapabilityLevel::OracleOnly);
-        // A kit for ANOTHER host does not raise this one.
-        assert_eq!(
-            hermes.capability(&[versioned_kit("cursor")]),
-            CapabilityLevel::OracleOnly
-        );
-        // Unwired is the floor, kit or no kit.
-        assert_eq!(
-            client("cursor", false).capability(&[versioned_kit("cursor")]),
-            CapabilityLevel::OracleOnly
-        );
-        // A kit without hooks (the codex kit ships none) = authoring,
-        // never guard.
-        let codex = client("codex", true);
-        assert_eq!(
-            codex.capability(&[versioned_kit("codex")]),
-            CapabilityLevel::AuthoringEnabled
-        );
-        // A kit WITH hooks (claude · cursor ship them in the same drop
-        // as the manifest) earns the guard.
-        let cursor = client("cursor", true);
-        assert_eq!(
-            cursor.capability(&[versioned_kit("cursor")]),
-            CapabilityLevel::Guarded
-        );
-        let claude = client("claude", true);
-        assert_eq!(
-            claude.capability(&[versioned_kit("claude")]),
-            CapabilityLevel::Guarded
-        );
-        // Every rung owns a machine token.
-        assert_eq!(CapabilityLevel::OracleOnly.as_str(), "oracle-only");
-        assert_eq!(
-            CapabilityLevel::AuthoringEnabled.as_str(),
-            "authoring-enabled"
-        );
-        assert_eq!(CapabilityLevel::Guarded.as_str(), "guarded");
-        assert_eq!(
-            CapabilityLevel::FullyIntegrated.as_str(),
-            "fully-integrated"
-        );
-    }
-
-    // ── The per-host runtime receipt (H5 · audit UX 2026-07-30) ──
-
-    #[test]
-    fn receipt_separates_verified_canaries_from_the_assumed_level() {
-        // H5 — hermes wired MCP-only: the receipt says oracle-only,
-        // names the missing rails (kit · hooks), prints the repair,
-        // and NOTHING is assumed — the wire was parsed, not inferred.
-        let hermes = client("hermes", true);
-        let r = hermes.capability_receipt(&[]);
-        assert_eq!(r.host, "hermes");
-        assert_eq!(r.version, None);
-        assert_eq!(r.surface, "mcp");
-        assert_eq!(r.root.as_deref(), Some(hermes.path.as_str()));
-        assert_eq!(r.components, ["mcp"]);
-        assert_eq!(r.capability, "oracle-only");
-        assert_eq!(r.canaries, ["config-parsed"]);
-        assert!(
-            r.missing_rails.iter().any(|rail| rail == "hooks"),
-            "{:?}",
-            r.missing_rails
-        );
-        assert_eq!(r.repair.as_deref(), Some("nika wire hermes"));
-        assert!(!r.level_assumed);
-
-        // cursor wired + kit: the hooks component rides on the STATIC
-        // `kit_ships_hooks` table — the receipt must NAME the assumption
-        // (canary + level_assumed), never render it as observed.
-        let cursor = client("cursor", true);
-        let r = cursor.capability_receipt(&[versioned_kit("cursor")]);
-        assert_eq!(r.host, "cursor");
-        assert_eq!(r.version.as_deref(), Some("0.106.0"));
-        assert_eq!(r.surface, "hooks");
-        assert_eq!(r.components, ["mcp", "kit", "hooks"]);
-        assert_eq!(r.capability, "guarded");
-        assert!(
-            r.canaries
-                .iter()
-                .any(|canary| canary == "hooks-assumed-from-kit"),
-            "{:?}",
-            r.canaries
-        );
-        assert!(r.missing_rails.is_empty(), "{:?}", r.missing_rails);
-        assert_eq!(r.repair, None);
-        assert!(r.level_assumed, "the hooks claim is a table lookup");
-        // UX107-04: the guard evidence rung is `declared` — a table
-        // lookup, never `loaded` or `proven` until a live canary exists.
-        assert_eq!(r.guard_evidence.as_deref(), Some("declared"));
-
-        // codex wired + kit without hooks: authoring is EARNED (the
-        // manifest is found), the missing guard rail is named, and the
-        // level still rests on the static table (hooks absence is a
-        // lookup, not an observation).
-        let codex = client("codex", true);
-        let r = codex.capability_receipt(&[versioned_kit("codex")]);
-        assert_eq!(r.components, ["mcp", "kit"]);
-        assert_eq!(r.capability, "authoring-enabled");
-        assert_eq!(r.missing_rails, ["hooks"]);
-        assert!(r.level_assumed);
-        assert_eq!(r.guard_evidence, None, "no hooks — no guard rung at all");
-
-        // An unwired host is BELOW the floor: no component, every rail
-        // missing, the repair is the wire — and the receipt never lends
-        // it the « oracle-only » rung it did not earn.
-        let r = client("cursor", false).capability_receipt(&[]);
-        assert_eq!(r.components, Vec::<String>::new());
-        assert_eq!(r.surface, "none");
-        assert_eq!(r.capability, "unwired");
-        assert_eq!(r.missing_rails, ["mcp", "kit", "hooks"]);
-        assert_eq!(r.repair.as_deref(), Some("nika wire cursor"));
-        assert!(!r.level_assumed);
-    }
-
-    #[test]
-    fn hermes_yaml_probe_recognizes_the_wire_contract() {
-        // H2 — Hermes is wireable (`nika wire hermes`) and proven, but
-        // its config is YAML: the JSON probe cannot see it. Recognition
-        // mirrors patch_hermes: a `nika:` server whose command line
-        // names the binary.
-        let dir = temp_dir("hermes");
-        let path = dir.join("config.yaml");
-        std::fs::write(
-            &path,
-            "mcp_servers:\n  nika:\n    command: nika\n    args: [mcp]\n    timeout: 120\n",
-        )
-        .expect("fixture");
-        let p = hermes_probe(&path);
-        assert!(p.present && p.current && !p.stale, "{p:?}");
-        assert_eq!(p.id, "hermes");
-        // A foreign config is present but NOT wired — never a guess.
-        std::fs::write(
-            &path,
-            "# my hermes\nmodel: hermes-4\nmcp_servers:\n  other: { command: x }\n",
-        )
-        .expect("fixture");
-        let p = hermes_probe(&path);
-        assert!(p.present && !p.current, "{p:?}");
-        // Absent is silence.
-        let p = hermes_probe(&dir.join("absent.yaml"));
-        assert!(!p.present && !p.current, "{p:?}");
-        let _ = std::fs::remove_dir_all(dir);
-    }
-
-    #[test]
-    fn collect_offline_never_pings_and_never_binds_a_value() {
-        // The default (welcome + doctor sans --ping) is fully offline:
-        // zero ping observations, and the probe carries booleans/names
-        // only — no field can hold a key VALUE by construction.
-        let probe = collect(false);
-        assert!(probe.local_pings.is_empty(), "offline = no ping rows");
-        assert!(!probe.version.is_empty());
-        assert!(
-            probe.providers.iter().all(|p| !p.id.is_empty()),
-            "provider rows are ids, not values"
-        );
-    }
-
-    // ── The client registry (H6 · Q1 2026-07-31 — the binary consumes
-    // the vendored nika-plugins matrix) ──
-
-    #[test]
-    fn the_real_probe_derives_registry_coverage_from_the_vendored_matrix() {
-        let probe = collect(false);
-        let cov = &probe.clients_registry;
-        assert!(
-            cov.declared >= 27,
-            "the matrix is 27+ clients, got {}",
-            cov.declared
-        );
-        // Every wireable client is probed or honestly declared — and
-        // the probed rows are a SUBSET of what the matrix wires (a
-        // row the matrix drops leaves the probe list with it).
-        assert_eq!(
-            cov.probed + cov.declared_not_probed.len(),
-            cov.wireable,
-            "{cov:?}"
-        );
-        assert!(cov.probed >= 6, "the 6 known mechanisms, got {cov:?}");
-        for client in &probe.clients {
-            assert!(
-                clients_registry::registry_wires(&client.id),
-                "probed {} is not matrix-claimed",
-                client.id
-            );
-            assert!(
-                !cov.declared_not_probed.contains(&client.id),
-                "{} cannot be probed AND declared-not-probed",
-                client.id
-            );
-        }
-        // The kit lanes ride the same derivation.
-        for kit in &probe.kits {
-            assert!(
-                clients_registry::registry_ships_kit(&kit.client),
-                "kit {} is not a matrix class-A wire row",
-                kit.client
-            );
-        }
-    }
-
-    #[test]
-    fn environment_json_carries_the_registry_lane() {
-        let probe = collect(false);
-        let env = environment_json(&probe);
-        let lane = &env["clients_registry"];
-        assert_eq!(
-            lane["declared"].as_u64(),
-            Some(probe.clients_registry.declared as u64)
-        );
-        assert_eq!(
-            lane["probed"].as_u64(),
-            Some(probe.clients_registry.probed as u64)
-        );
-        assert!(
-            lane["declared_not_probed"].is_array(),
-            "the not-probed are named, machine-readable: {lane}"
-        );
-    }
-}
+mod tests;

--- a/crates/nika-cli-host/src/probe/tests.rs
+++ b/crates/nika-cli-host/src/probe/tests.rs
@@ -1,0 +1,557 @@
+use super::*;
+
+#[allow(clippy::disallowed_methods)]
+fn temp_dir(name: &str) -> PathBuf {
+    let base = std::env::var_os("CARGO_TARGET_TMPDIR").map_or_else(
+        || {
+            std::env::current_dir()
+                .expect("current dir")
+                .join("target")
+                .join("tmp")
+        },
+        PathBuf::from,
+    );
+    let dir = base.join(format!("nika-probe-{name}-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("temp dir");
+    dir
+}
+
+#[test]
+fn manifest_version_reads_the_one_field() {
+    let dir = temp_dir("manifest");
+    let path = dir.join("plugin.json");
+    std::fs::write(&path, r#"{"name":"nika","version":"0.106.0"}"#).expect("fixture");
+    assert_eq!(manifest_version(&path).as_deref(), Some("0.106.0"));
+    assert_eq!(manifest_version(&dir.join("absent.json")), None);
+    std::fs::write(&path, "not json").expect("fixture");
+    assert_eq!(manifest_version(&path), None, "unreadable is silence");
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn claude_install_rung_is_the_json_of_record() {
+    let dir = temp_dir("claude-install");
+    std::fs::write(
+        dir.join("installed_plugins.json"),
+        r#"{"version":2,"plugins":{"nika@nika":[{"scope":"user","version":"0.105.0"}],
+                "other@x":[{"version":"9.9.9"}]}}"#,
+    )
+    .expect("fixture");
+    assert_eq!(
+        claude_installed_version(&dir).as_deref(),
+        Some("0.105.0"),
+        "the ACTIVE entry, never another plugin's"
+    );
+    assert_eq!(claude_installed_version(&temp_dir("claude-empty")), None);
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn codex_cache_picks_the_highest_version_numerically() {
+    let dir = temp_dir("codex-cache");
+    for d in ["0.9.0", "0.105.0", "0.104.2", "tmp", "0.105"] {
+        std::fs::create_dir_all(dir.join(d)).expect("fixture dir");
+    }
+    // 0.9.0 > 0.105.0 lexically — numeric ordering is the assertion.
+    assert_eq!(codex_cache_version(&dir).as_deref(), Some("0.105.0"));
+    assert_eq!(codex_cache_version(&dir.join("absent")), None);
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn train_differs_compares_trains_and_never_guesses() {
+    assert!(train_differs("0.105.0", "0.106.1"));
+    assert!(!train_differs("0.106.0", "0.106.1"), "patch is not a train");
+    assert!(
+        !train_differs("garbage", "0.106.1"),
+        "unparseable = never guess"
+    );
+    assert!(!train_differs("0.106.0", ""), "either side");
+}
+
+#[test]
+fn version_key_is_numeric_and_rejects_non_versions() {
+    assert!(version_key("0.105.0") > version_key("0.9.0"));
+    assert_eq!(
+        version_key("0.105"),
+        Some((0, 105, 0)),
+        "missing patch reads 0"
+    );
+    assert_eq!(version_key("tmp"), None);
+    assert_eq!(version_key("1"), None, "a version needs major.minor");
+}
+
+#[test]
+fn iso_to_epoch_days_civil_math() {
+    assert_eq!(iso_to_epoch_days("1970-01-01"), Some(0));
+    assert_eq!(iso_to_epoch_days("1970-01-02"), Some(1));
+    // The leap day: 2000-02-29 exists, 03-01 is exactly one later.
+    let feb29 = iso_to_epoch_days("2000-02-29").expect("leap day");
+    let mar01 = iso_to_epoch_days("2000-03-01").expect("march 1");
+    assert_eq!(mar01 - feb29, 1);
+    assert!(iso_to_epoch_days("2026-07-07").expect("modern date") > 20_000);
+    for bad in ["2026-13-01", "2026-7-07", "garbage", ""] {
+        assert_eq!(iso_to_epoch_days(bad), None, "{bad:?}");
+    }
+}
+
+#[test]
+fn snapshot_age_never_reads_the_future_as_stale() {
+    let today = iso_to_epoch_days("2026-07-08");
+    assert_eq!(snapshot_age_days("2026-07-07", today), Some(1));
+    assert_eq!(snapshot_age_days("2026-07-08", today), Some(0));
+    // Clock skew: a snapshot "from tomorrow" reads unknowable, never stale.
+    assert_eq!(snapshot_age_days("2026-07-09", today), None);
+    assert_eq!(snapshot_age_days("garbage", today), None);
+    assert_eq!(snapshot_age_days("2026-07-07", None), None);
+}
+
+#[test]
+fn the_real_probe_fills_pricing_from_the_vendored_snapshot() {
+    // Derived counts (born-stale law): non-empty · providers ≥ the
+    // cloud set · identity mirrors the catalog accessor.
+    let p = pricing_probe();
+    assert!(p.rules > 100, "got {}", p.rules);
+    assert!(p.providers >= 5, "got {}", p.providers);
+    assert_eq!(p.as_of, nika_catalog::pricing_snapshot().as_of);
+    assert_eq!(p.sha, nika_catalog::pricing_snapshot().source_sha256_16);
+}
+
+// ── The adoption ladder (P0-21 · audit UX 2026-07-30) ──
+
+use nika_providers::probe::{ExecutionLocus, ProviderReadiness};
+
+/// One synthetic machine, rung ZERO: the registry's keyless engines
+/// are CATALOG facts (always present, always "configured" — a keyless
+/// seed needs nothing), never adoption. Detection needs an operator
+/// signal: an override, bytes on disk, or an explicit `--ping`.
+fn ladder_probe() -> Probe {
+    let readiness = |configured, locus: ExecutionLocus| {
+        ProviderReadiness::new(
+            true,
+            configured,
+            None,
+            None,
+            false,
+            locus,
+            // Mirrors Profile::access_class on the synthetic machine.
+            match locus {
+                ExecutionLocus::Loopback | ExecutionLocus::Lan => {
+                    nika_providers::probe::AccessClass::Local
+                }
+                _ => nika_providers::probe::AccessClass::Api,
+            },
+        )
+    };
+    Probe {
+        version: "0.0.0-test".to_owned(),
+        config_path: None,
+        providers: vec![
+            ProviderProbe::new(
+                "ollama",
+                false,
+                false,
+                "",
+                true,
+                readiness(true, ExecutionLocus::Loopback),
+                "http://127.0.0.1:11434",
+            ),
+            ProviderProbe::new(
+                "mistral",
+                true,
+                false,
+                "MISTRAL_API_KEY",
+                true,
+                readiness(false, ExecutionLocus::Cloud),
+                "https://api.mistral.ai/v1/chat/completions",
+            ),
+        ],
+        clients: vec![],
+        census: AccessCensus::default(),
+        kits: vec![],
+        clients_registry: RegistryCoverage::default(),
+        image: ImageProbe::default(),
+        tts: TtsProbe::default(),
+        local_pings: vec![],
+        pricing: PricingProbe::default(),
+        retention: RetentionConfig::default(),
+        retention_notes: vec![],
+        models: ModelsProbe::default(),
+        recorded_runs: 0,
+        tracked_traces: None,
+    }
+}
+
+/// One rung per fact — each transition is earned by exactly ONE new
+/// observation, and no fact is ever claimed beyond its measurement.
+#[test]
+fn adoption_ladder_climbs_one_rung_per_fact() {
+    let base = ladder_probe();
+    // Installed — the catalog's keyless seed is NOT detection.
+    assert_eq!(adoption_state(&base), AdoptionState::Installed);
+
+    // KeyPresent — a cloud key is CONFIGURED, never « verified ».
+    let mut keyed = base.clone();
+    keyed.providers[1].key_present = true;
+    keyed.providers[1].readiness.configured = true;
+    assert_eq!(adoption_state(&keyed), AdoptionState::KeyPresent);
+
+    // LocalDetected — an override moves the engine off its seed…
+    let mut override_lan = base.clone();
+    override_lan.providers[0].endpoint = "http://gpu.lan:11434".to_owned();
+    override_lan.providers[0].readiness.execution_locus = ExecutionLocus::Lan;
+    assert_eq!(adoption_state(&override_lan), AdoptionState::LocalDetected);
+    // …or bytes on disk (a pulled GGUF)…
+    let mut pulled = base.clone();
+    pulled.models.count = 1;
+    assert_eq!(adoption_state(&pulled), AdoptionState::LocalDetected);
+    // …or a ping that found NOTHING (engaged, honestly unproven).
+    let mut dead_ping = base.clone();
+    dead_ping.local_pings = vec![(
+        "ollama".to_owned(),
+        "127.0.0.1:11434".to_owned(),
+        PingState::Unreachable,
+    )];
+    assert_eq!(adoption_state(&dead_ping), AdoptionState::LocalDetected);
+
+    // LocalReachable — ONLY an explicit --ping measurement proves it.
+    let mut reachable = base.clone();
+    reachable.local_pings = vec![(
+        "ollama".to_owned(),
+        "127.0.0.1:11434".to_owned(),
+        PingState::Reachable(3),
+    )];
+    assert_eq!(adoption_state(&reachable), AdoptionState::LocalReachable);
+
+    // RealReady — a live path AND runs on record (any lane earns
+    // the path: a verified local endpoint, a configured cloud key,
+    // or a ready seat · R4).
+    let mut real_local = reachable.clone();
+    real_local.recorded_runs = 2;
+    assert_eq!(adoption_state(&real_local), AdoptionState::RealReady);
+    let mut real_cloud = keyed.clone();
+    real_cloud.recorded_runs = 1;
+    assert_eq!(adoption_state(&real_cloud), AdoptionState::RealReady);
+    // Runs ALONE prove nothing about today's path (the journal never
+    // records the serving model — mock-vs-real is unknowable, so the
+    // rung is not invented: no path today = the honest floor).
+    let mut ran_once = base.clone();
+    ran_once.recorded_runs = 3;
+    assert_eq!(adoption_state(&ran_once), AdoptionState::Installed);
+}
+
+/// R4 — the seat rung the pre-census ladder could not see: a
+/// signed-in harness seat (the census `seats_ready` lane) earns
+/// `SeatReady` between `KeyPresent` and `RealReady`. Mutation pins:
+/// emptying the lane drops the machine to the keyless floor, and a
+/// seat + a key renders the SEAT (the sovereign order — the
+/// operator's own plan outranks the metered key).
+#[test]
+fn the_seat_rung_is_earned_by_the_census_never_recomputed() {
+    let base = ladder_probe();
+    let seated = |p: &mut Probe| {
+        p.census = AccessCensus::from_parts(
+            &[],
+            vec![nika_providers::census::SeatFact::new(
+                "claude-code",
+                vec!["anthropic".to_owned()],
+                true,
+                true,
+                true,
+            )],
+        );
+    };
+    // SeatReady — the seat alone earns the rung.
+    let mut seated_only = base.clone();
+    seated(&mut seated_only);
+    assert_eq!(adoption_state(&seated_only), AdoptionState::SeatReady);
+    assert_eq!(
+        seated_only.census.seat_escape().as_deref(),
+        Some("or use a signed-in seat: `--access claude-code`")
+    );
+    // The seat OUTRANKS a configured cloud key.
+    let mut both = seated_only.clone();
+    both.providers[1].key_present = true;
+    both.providers[1].readiness.configured = true;
+    assert_eq!(adoption_state(&both), AdoptionState::SeatReady);
+    // A ready seat + runs on record = the top rung (the seat is a
+    // live path today).
+    let mut real_seat = seated_only.clone();
+    real_seat.recorded_runs = 1;
+    assert_eq!(adoption_state(&real_seat), AdoptionState::RealReady);
+    // The metric names the seat; the line owns its rung.
+    let metric = AdoptionState::SeatReady.metric(&seated_only);
+    assert!(
+        metric.contains("claude-code") && metric.contains("signed in"),
+        "{metric}"
+    );
+}
+
+/// The enum is exhaustive over the ladder and every rung owns its
+/// own label, metric and CTA — no two states render the same line.
+#[test]
+fn every_adoption_rung_renders_its_own_line() {
+    let probe = ladder_probe();
+    let mut lines = std::collections::BTreeSet::new();
+    for state in [
+        AdoptionState::Installed,
+        AdoptionState::LocalDetected,
+        AdoptionState::LocalReachable,
+        AdoptionState::KeyPresent,
+        AdoptionState::SeatReady,
+        AdoptionState::RealReady,
+    ] {
+        assert!(!state.metric(&probe).is_empty(), "{state:?}");
+        assert!(!state.cta().is_empty(), "{state:?}");
+        assert!(lines.insert(state.as_str()), "labels are unique");
+        assert!(lines.insert(state.cta()), "every rung owns its CTA");
+    }
+}
+
+// ── Capability levels (P0-9 · audit UX 2026-07-30) + Hermes (H2) ──
+
+/// One synthetic client row (wired or not).
+fn client(id: &str, current: bool) -> ClientProbe {
+    ClientProbe {
+        id: id.to_owned(),
+        path: format!("~/.{id}/config"),
+        present: true,
+        current,
+        stale: false,
+    }
+}
+
+fn versioned_kit(client: &str) -> KitProbe {
+    KitProbe {
+        client: client.to_owned(),
+        version: "0.106.0".to_owned(),
+    }
+}
+
+#[test]
+fn capability_ladder_never_calls_mcp_only_guarded() {
+    // The audit's lie: every wired host read as one flat « wired ».
+    // MCP alone is the oracle rung — the guard is EARNED by hooks,
+    // never implied by the wire.
+    let hermes = client("hermes", true);
+    assert_eq!(hermes.capability(&[]), CapabilityLevel::OracleOnly);
+    // A kit for ANOTHER host does not raise this one.
+    assert_eq!(
+        hermes.capability(&[versioned_kit("cursor")]),
+        CapabilityLevel::OracleOnly
+    );
+    // Unwired is the floor, kit or no kit.
+    assert_eq!(
+        client("cursor", false).capability(&[versioned_kit("cursor")]),
+        CapabilityLevel::OracleOnly
+    );
+    // A kit without hooks (the codex kit ships none) = authoring,
+    // never guard.
+    let codex = client("codex", true);
+    assert_eq!(
+        codex.capability(&[versioned_kit("codex")]),
+        CapabilityLevel::AuthoringEnabled
+    );
+    // A kit WITH hooks (claude · cursor ship them in the same drop
+    // as the manifest) earns the guard.
+    let cursor = client("cursor", true);
+    assert_eq!(
+        cursor.capability(&[versioned_kit("cursor")]),
+        CapabilityLevel::Guarded
+    );
+    let claude = client("claude", true);
+    assert_eq!(
+        claude.capability(&[versioned_kit("claude")]),
+        CapabilityLevel::Guarded
+    );
+    // Every rung owns a machine token.
+    assert_eq!(CapabilityLevel::OracleOnly.as_str(), "oracle-only");
+    assert_eq!(
+        CapabilityLevel::AuthoringEnabled.as_str(),
+        "authoring-enabled"
+    );
+    assert_eq!(CapabilityLevel::Guarded.as_str(), "guarded");
+    assert_eq!(
+        CapabilityLevel::FullyIntegrated.as_str(),
+        "fully-integrated"
+    );
+}
+
+// ── The per-host runtime receipt (H5 · audit UX 2026-07-30) ──
+
+#[test]
+fn receipt_separates_verified_canaries_from_the_assumed_level() {
+    // H5 — hermes wired MCP-only: the receipt says oracle-only,
+    // names the missing rails (kit · hooks), prints the repair,
+    // and NOTHING is assumed — the wire was parsed, not inferred.
+    let hermes = client("hermes", true);
+    let r = hermes.capability_receipt(&[]);
+    assert_eq!(r.host, "hermes");
+    assert_eq!(r.version, None);
+    assert_eq!(r.surface, "mcp");
+    assert_eq!(r.root.as_deref(), Some(hermes.path.as_str()));
+    assert_eq!(r.components, ["mcp"]);
+    assert_eq!(r.capability, "oracle-only");
+    assert_eq!(r.canaries, ["config-parsed"]);
+    assert!(
+        r.missing_rails.iter().any(|rail| rail == "hooks"),
+        "{:?}",
+        r.missing_rails
+    );
+    assert_eq!(r.repair.as_deref(), Some("nika wire hermes"));
+    assert!(!r.level_assumed);
+
+    // cursor wired + kit: the hooks component rides on the STATIC
+    // `kit_ships_hooks` table — the receipt must NAME the assumption
+    // (canary + level_assumed), never render it as observed.
+    let cursor = client("cursor", true);
+    let r = cursor.capability_receipt(&[versioned_kit("cursor")]);
+    assert_eq!(r.host, "cursor");
+    assert_eq!(r.version.as_deref(), Some("0.106.0"));
+    assert_eq!(r.surface, "hooks");
+    assert_eq!(r.components, ["mcp", "kit", "hooks"]);
+    assert_eq!(r.capability, "guarded");
+    assert!(
+        r.canaries
+            .iter()
+            .any(|canary| canary == "hooks-assumed-from-kit"),
+        "{:?}",
+        r.canaries
+    );
+    assert!(r.missing_rails.is_empty(), "{:?}", r.missing_rails);
+    assert_eq!(r.repair, None);
+    assert!(r.level_assumed, "the hooks claim is a table lookup");
+    // UX107-04: the guard evidence rung is `declared` — a table
+    // lookup, never `loaded` or `proven` until a live canary exists.
+    assert_eq!(r.guard_evidence.as_deref(), Some("declared"));
+
+    // codex wired + kit without hooks: authoring is EARNED (the
+    // manifest is found), the missing guard rail is named, and the
+    // level still rests on the static table (hooks absence is a
+    // lookup, not an observation).
+    let codex = client("codex", true);
+    let r = codex.capability_receipt(&[versioned_kit("codex")]);
+    assert_eq!(r.components, ["mcp", "kit"]);
+    assert_eq!(r.capability, "authoring-enabled");
+    assert_eq!(r.missing_rails, ["hooks"]);
+    assert!(r.level_assumed);
+    assert_eq!(r.guard_evidence, None, "no hooks — no guard rung at all");
+
+    // An unwired host is BELOW the floor: no component, every rail
+    // missing, the repair is the wire — and the receipt never lends
+    // it the « oracle-only » rung it did not earn.
+    let r = client("cursor", false).capability_receipt(&[]);
+    assert_eq!(r.components, Vec::<String>::new());
+    assert_eq!(r.surface, "none");
+    assert_eq!(r.capability, "unwired");
+    assert_eq!(r.missing_rails, ["mcp", "kit", "hooks"]);
+    assert_eq!(r.repair.as_deref(), Some("nika wire cursor"));
+    assert!(!r.level_assumed);
+}
+
+#[test]
+fn hermes_yaml_probe_recognizes_the_wire_contract() {
+    // H2 — Hermes is wireable (`nika wire hermes`) and proven, but
+    // its config is YAML: the JSON probe cannot see it. Recognition
+    // mirrors patch_hermes: a `nika:` server whose command line
+    // names the binary.
+    let dir = temp_dir("hermes");
+    let path = dir.join("config.yaml");
+    std::fs::write(
+        &path,
+        "mcp_servers:\n  nika:\n    command: nika\n    args: [mcp]\n    timeout: 120\n",
+    )
+    .expect("fixture");
+    let p = hermes_probe(&path);
+    assert!(p.present && p.current && !p.stale, "{p:?}");
+    assert_eq!(p.id, "hermes");
+    // A foreign config is present but NOT wired — never a guess.
+    std::fs::write(
+        &path,
+        "# my hermes\nmodel: hermes-4\nmcp_servers:\n  other: { command: x }\n",
+    )
+    .expect("fixture");
+    let p = hermes_probe(&path);
+    assert!(p.present && !p.current, "{p:?}");
+    // Absent is silence.
+    let p = hermes_probe(&dir.join("absent.yaml"));
+    assert!(!p.present && !p.current, "{p:?}");
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn collect_offline_never_pings_and_never_binds_a_value() {
+    // The default (welcome + doctor sans --ping) is fully offline:
+    // zero ping observations, and the probe carries booleans/names
+    // only — no field can hold a key VALUE by construction.
+    let probe = collect(false);
+    assert!(probe.local_pings.is_empty(), "offline = no ping rows");
+    assert!(!probe.version.is_empty());
+    assert!(
+        probe.providers.iter().all(|p| !p.id.is_empty()),
+        "provider rows are ids, not values"
+    );
+}
+
+// ── The client registry (H6 · Q1 2026-07-31 — the binary consumes
+// the vendored nika-plugins matrix) ──
+
+#[test]
+fn the_real_probe_derives_registry_coverage_from_the_vendored_matrix() {
+    let probe = collect(false);
+    let cov = &probe.clients_registry;
+    assert!(
+        cov.declared >= 27,
+        "the matrix is 27+ clients, got {}",
+        cov.declared
+    );
+    // Every wireable client is probed or honestly declared — and
+    // the probed rows are a SUBSET of what the matrix wires (a
+    // row the matrix drops leaves the probe list with it).
+    assert_eq!(
+        cov.probed + cov.declared_not_probed.len(),
+        cov.wireable,
+        "{cov:?}"
+    );
+    assert!(cov.probed >= 6, "the 6 known mechanisms, got {cov:?}");
+    for client in &probe.clients {
+        assert!(
+            clients_registry::registry_wires(&client.id),
+            "probed {} is not matrix-claimed",
+            client.id
+        );
+        assert!(
+            !cov.declared_not_probed.contains(&client.id),
+            "{} cannot be probed AND declared-not-probed",
+            client.id
+        );
+    }
+    // The kit lanes ride the same derivation.
+    for kit in &probe.kits {
+        assert!(
+            clients_registry::registry_ships_kit(&kit.client),
+            "kit {} is not a matrix class-A wire row",
+            kit.client
+        );
+    }
+}
+
+#[test]
+fn environment_json_carries_the_registry_lane() {
+    let probe = collect(false);
+    let env = environment_json(&probe);
+    let lane = &env["clients_registry"];
+    assert_eq!(
+        lane["declared"].as_u64(),
+        Some(probe.clients_registry.declared as u64)
+    );
+    assert_eq!(
+        lane["probed"].as_u64(),
+        Some(probe.clients_registry.probed as u64)
+    );
+    assert!(
+        lane["declared_not_probed"].is_array(),
+        "the not-probed are named, machine-readable: {lane}"
+    );
+}

--- a/crates/nika-cli-host/src/welcome/tests.rs
+++ b/crates/nika-cli-host/src/welcome/tests.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::clients_registry::RegistryCoverage;
 use crate::output::exit;
 use crate::probe::{ClientProbe, ImageProbe, PingState, PricingProbe, ProviderProbe, TtsProbe};
+use nika_providers::census::AccessCensus;
 use nika_providers::probe::{ExecutionLocus, ProviderReadiness};
 
 /// The default synthetic readiness — recognized · loopback · the
@@ -59,6 +60,7 @@ fn synthetic_probe() -> Probe {
                 "https://api.anthropic.com/v1/messages",
             ),
         ],
+        census: AccessCensus::default(),
         clients: vec![
             ClientProbe {
                 id: "cursor".to_owned(),
@@ -545,17 +547,38 @@ fn the_mirror_greets_each_adoption_rung_with_its_own_cta() {
         ready.contains("state      real-ready · 2 runs on record · path configured — nika run"),
         "RealReady claims the record, never « a real model answered »:\n{ready}"
     );
-    // Every rung's line is its own — the five renders differ.
-    let lines: std::collections::BTreeSet<String> = [keyed, installed, detected, reachable, ready]
-        .iter()
-        .map(|t| {
-            t.lines()
-                .find(|l| l.contains("  state"))
-                .expect("a state line")
-                .to_owned()
-        })
-        .collect();
-    assert_eq!(lines.len(), 5, "five rungs, five distinct lines");
+    // SeatReady (R4) — a signed-in harness seat is an inference path:
+    // the census seats lane earns the rung, the line names the seat.
+    let mut seated = bare.clone();
+    seated.census = AccessCensus::from_parts(
+        &[],
+        vec![nika_providers::census::SeatFact::new(
+            "claude-code",
+            vec!["anthropic".to_owned()],
+            true,
+            true,
+            true,
+        )],
+    );
+    let seat = render_human(&seated, glance, counts(), plain());
+    assert!(
+        seat.contains(
+            "state      seat ready · claude-code signed in — runs on the plan you pay for"
+        ),
+        "SeatReady names the seat and the plan:\n{seat}"
+    );
+    // Every rung's line is its own — the six renders differ.
+    let lines: std::collections::BTreeSet<String> =
+        [keyed, installed, detected, reachable, ready, seat]
+            .iter()
+            .map(|t| {
+                t.lines()
+                    .find(|l| l.contains("  state"))
+                    .expect("a state line")
+                    .to_owned()
+            })
+            .collect();
+    assert_eq!(lines.len(), 6, "six rungs, six distinct lines");
 }
 
 #[test]
@@ -670,6 +693,7 @@ fn shipped_shape_probe() -> Probe {
                 .map(cloud),
             )
             .collect(),
+        census: AccessCensus::default(),
         // DERIVED from the registry, never listed by hand. The hand-
         // written four here were two short of what the binary probes,
         // so the 80-column ratchet was measuring a machine that does

--- a/crates/nika-cli/src/verbs/explain.rs
+++ b/crates/nika-cli/src/verbs/explain.rs
@@ -195,9 +195,8 @@ fn retired_row(code: &str) -> Option<String> {
 /// live here, never in the SSOT).
 fn cli_fix_hint(code: &str) -> Option<&'static str> {
     match code {
-        // R4: the credential refusal names the seat escape hatch — the
-        // env ladder alone sent keyless-but-seated operators to a
-        // vendor signup they did not need.
+        // R4: the credential refusal names the seat escape hatch (the env
+        // ladder alone sent seated operators to a vendor signup).
         "NIKA-INFER-001" => Some(
             "set the key the witness names (custody is the process env: \
              `export <VAR>=…`), or run through a signed-in seat: \
@@ -212,10 +211,9 @@ fn cli_fix_hint(code: &str) -> Option<&'static str> {
              `const:` resolve only from their own declared block, and `item` / \
              `index` exist only inside a `for_each` task",
         ),
-        // The high-traffic conformance codes whose fix is one obvious
-        // YAML edit teach it concretely (#145 P1 — the failure states
-        // WHAT, this states the edit; the canon row never carries
-        // per-CLI affordances, so the fix-form lives here).
+        // The high-traffic conformance codes teach the one obvious YAML
+        // edit concretely (#145 P1 — the fix-form lives here, never in
+        // the canon row).
         "NIKA-DAG-001" => Some(
             "break the loop — one task in the cycle must drop the `with:` \
              binding or `after:` entry that closes it (a task can never \
@@ -283,6 +281,13 @@ fn cli_fix_hint(code: &str) -> Option<&'static str> {
              task typed `{ array: … }`, or a literal list), and comparisons \
              need both sides the same type",
         ),
+        _ => decide_fix_hint(code).or_else(|| run_decl_fix_hint(code)),
+    }
+}
+
+/// The `decide` bundle hints — split at the fn-length wall.
+fn decide_fix_hint(code: &str) -> Option<&'static str> {
+    match code {
         "NIKA-DECIDE-001" => Some(
             "the bundle breaks its own laws — weights/thresholds are INTEGER \
              basis-points (8735 = 87.35% · never a float), rules read only \
@@ -298,7 +303,7 @@ fn cli_fix_hint(code: &str) -> Option<&'static str> {
              above the declared floor; a MISSING required key is not an \
              error (the evaluation defers — abstention is a safety property)",
         ),
-        _ => run_decl_fix_hint(code),
+        _ => None,
     }
 }
 

--- a/crates/nika-cli/src/verbs/explain.rs
+++ b/crates/nika-cli/src/verbs/explain.rs
@@ -49,7 +49,11 @@ pub fn run(wire: &str, theme: Theme) -> VerbOutput {
         // (NIKA-DAG-002 …) live in the embedded canon's error_codes
         // table. Same binary, same single source of truth.
         if let Some(text) = canon_row(&normalized) {
-            return VerbOutput::ok(text);
+            return VerbOutput::ok(nika_cli_host::probe::with_seat_tail(
+                &normalized,
+                nika_cli_host::probe::seat_escape_tail().as_deref(),
+                text,
+            ));
         }
         // Retired conformance codes are ANSWERED, not 404'd: the hole in
         // the registry is deliberate (spec 05 · never reuse) and the
@@ -82,7 +86,11 @@ pub fn run(wire: &str, theme: Theme) -> VerbOutput {
         slug = code.slug,
         help = code_help(code),
     );
-    VerbOutput::ok(text)
+    VerbOutput::ok(nika_cli_host::probe::with_seat_tail(
+        &normalized,
+        nika_cli_host::probe::seat_escape_tail().as_deref(),
+        text,
+    ))
 }
 
 /// Teach a spec conformance code from the embedded canon's registry —
@@ -187,6 +195,15 @@ fn retired_row(code: &str) -> Option<String> {
 /// live here, never in the SSOT).
 fn cli_fix_hint(code: &str) -> Option<&'static str> {
     match code {
+        // R4: the credential refusal names the seat escape hatch — the
+        // env ladder alone sent keyless-but-seated operators to a
+        // vendor signup they did not need.
+        "NIKA-INFER-001" => Some(
+            "set the key the witness names (custody is the process env: \
+             `export <VAR>=…`), or run through a signed-in seat: \
+             `nika run <file> --access claude-code` — any agentic CLI you're \
+             signed into serves (`nika doctor` lists them)",
+        ),
         // F4: the unresolved-vars class is fixable from the CLI.
         "NIKA-VAR-001" => Some(
             "an unbound `inputs:` entry is supplied on the CLI — `nika run <file> \
@@ -318,6 +335,56 @@ mod tests {
     /// machine surface reads.
     fn run(wire: &str) -> VerbOutput {
         super::run(wire, Theme::new(false, false, false))
+    }
+
+    /// R4 — the credential refusal teaches the seat escape hatch: the
+    /// static fix names `--access claude-code` (the census-derived tail
+    /// is gated in the host's `with_seat_tail`, pinned separately).
+    #[test]
+    fn infer_001_teaches_the_seat_escape() {
+        let out = run("NIKA-INFER-001");
+        assert_eq!(out.code, exit::OK, "{}", out.text);
+        assert!(
+            out.text.contains("--access claude-code"),
+            "the seat door is taught:\n{}",
+            out.text
+        );
+        assert!(
+            out.text.contains("custody is the process env"),
+            "custody is named:\n{}",
+            out.text
+        );
+    }
+
+    /// Mutation pins for the tail gate: only the auth-class codes earn
+    /// the tail, and only when the census found a seat (inverting the
+    /// match or dropping the `None` arm must redden this).
+    #[test]
+    fn the_seat_tail_is_gated_on_code_class_and_census_truth() {
+        let text = "body".to_owned();
+        let with = nika_cli_host::probe::with_seat_tail(
+            "NIKA-INFER-001",
+            Some("or use a signed-in seat: `--access claude-code`"),
+            text.clone(),
+        );
+        assert!(with.contains("--access claude-code"), "{with}");
+        assert!(with.starts_with("body"), "{with}");
+        // NIKA-1800 rides the same gate.
+        assert!(
+            nika_cli_host::probe::with_seat_tail("NIKA-1800", Some("tail"), text.clone())
+                .contains("tail"),
+            "the admission refusal earns the tail too"
+        );
+        // Another class never does, even with a seat present.
+        assert_eq!(
+            nika_cli_host::probe::with_seat_tail("NIKA-DAG-002", Some("tail"), text.clone()),
+            "body"
+        );
+        // No seat, no tail — the teaching never promises a phantom path.
+        assert_eq!(
+            nika_cli_host::probe::with_seat_tail("NIKA-INFER-001", None, text.clone()),
+            "body"
+        );
     }
 
     #[test]

--- a/crates/nika-cli/src/verbs/run/epilogue.rs
+++ b/crates/nika-cli/src/verbs/run/epilogue.rs
@@ -341,6 +341,18 @@ pub(super) fn error_envelope_line(message: &str) -> String {
     .to_string()
 }
 
+/// R4 — the witness texts a failure card speaks (workflow detail +
+/// row details), the input of the census-derived seat-escape gate
+/// (`nika_cli_host::probe::print_seat_escape` — printed only when THIS
+/// machine has a signed-in seat).
+pub(super) fn failure_witnesses(view: &crate::RunView) -> Vec<&str> {
+    view.workflow_detail
+        .iter()
+        .map(String::as_str)
+        .chain(view.rows().iter().map(|row| row.detail.as_str()))
+        .collect()
+}
+
 /// Best-effort wire-code extraction: the first `NIKA-…` token in a
 /// diagnostic (findings render `[NIKA-PARSE-009]` · run details lead with
 /// `NIKA-431 · …`). Never invents — no token, no code.
@@ -466,6 +478,45 @@ mod tests {
     fn outputs_json_line_empty_is_braces() {
         // No `outputs:` declared → still a JSON object on stdout.
         assert_eq!(outputs_json_line(&BTreeMap::new()), "{}");
+    }
+
+    // ── R4 · the auth-class tail gate ──
+
+    /// Mutation pins for the witness gate: the tail is earned by an
+    /// auth-class witness (NIKA-INFER-001 · NIKA-1800) on a failed row
+    /// or the workflow detail — never by another class, never on a
+    /// healthy view. The view→witnesses fold feeds the host predicate
+    /// (`nika_cli_host::probe::auth_class_witness`); inverting either
+    /// reddens this.
+    #[test]
+    fn the_seat_escape_gate_reads_the_auth_class_witness() {
+        use nika_types::resource::{KeyValue, Value as RValue};
+
+        let gate = |view: &crate::RunView| {
+            super::failure_witnesses(view)
+                .into_iter()
+                .any(nika_cli_host::probe::auth_class_witness)
+        };
+        let mut view = crate::RunView::new();
+        assert!(!gate(&view), "an empty view earns none");
+        let failed = nika_cli_display_demo_bare(nika_event::EventKind::TaskFailed, 1)
+            .with_field(KeyValue::new("task", RValue::String("reply".to_owned())))
+            .with_field(KeyValue::new(
+                "detail",
+                RValue::String(
+                    "NIKA-INFER-001 · no API key for 'anthropic' · set one of […]".to_owned(),
+                ),
+            ));
+        view.apply(&failed);
+        assert!(gate(&view), "the missing-credential witness earns the tail");
+        // The admission refusal class rides the same gate.
+        let mut view1800 = crate::RunView::new();
+        view1800.workflow_detail = Some("NIKA-1800 · no access path survives admission".to_owned());
+        assert!(gate(&view1800));
+        // Another class earns nothing.
+        let mut other = crate::RunView::new();
+        other.workflow_detail = Some("NIKA-VAR-001 · unresolved reference".to_owned());
+        assert!(!gate(&other));
     }
 
     // ── F6 · the `--output json` machine failure envelope ────────────

--- a/crates/nika-cli/src/verbs/run/mod.rs
+++ b/crates/nika-cli/src/verbs/run/mod.rs
@@ -954,6 +954,16 @@ async fn execute_output_json_lane(
     let (code, outcome) = drive(runtime, stamper, &mut events).await;
     let (mut sink, mut trace) = events.into_inner().into_parts();
     sink.print_final();
+    // R4 — the auth-class tail rides stderr (stdout stays the clean
+    // JSON object · the export contract).
+    if code == exit::WORKFLOW {
+        let mut err = std::io::stderr().lock();
+        nika_cli_host::probe::print_seat_escape(
+            epilogue::failure_witnesses(sink.view()),
+            "nika run: ",
+            &mut err,
+        );
+    }
     // Pause delivery is journaled before the seal (ADR-111).
     if let (Some(p), Some(pause)) = (
         trace.path().map(std::path::Path::to_path_buf),
@@ -1168,6 +1178,17 @@ fn fold_lane_verdict(
         .iter()
         .find(|r| r.state == crate::TaskState::Failed)
         .map(|r| r.id.clone());
+    // R4 — an auth-class failure (a missing credential · a refused
+    // admission) names the seat escape hatch beside its card, when this
+    // machine has a signed-in seat.
+    if code == exit::WORKFLOW {
+        let mut out = std::io::stdout().lock();
+        nika_cli_host::probe::print_seat_escape(
+            epilogue::failure_witnesses(sink.view()),
+            "  ",
+            &mut out,
+        );
+    }
     // F-P14 · the failure lane's quarantine runs BEFORE the seal.
     let teardown = attended_facts(wf, report, outcome, trace.path());
     let trace_path = match surfaced_trace(surface_trace(
@@ -1309,6 +1330,15 @@ fn map_run_result(result: Result<RunOutcome, RuntimeError>) -> (u8, RunOutcome) 
                     | RuntimeError::AccessUnavailable { .. }
             ) {
                 let _ = writeln!(stderr, "nika run: {err}");
+                // R4 — the 1800 witness names the missing credential's
+                // custody; the L4 renderer (which knows seats, unlike
+                // the provider layer) appends the seat escape hatch —
+                // census-derived, so it prints only when TRUE.
+                if matches!(err, RuntimeError::AccessNoPath { .. })
+                    && let Some(tail) = nika_cli_host::probe::seat_escape_tail()
+                {
+                    let _ = writeln!(stderr, "nika run: {tail}");
+                }
             } else if let RuntimeError::ReportMismatch { .. } = err {
                 // Audit-before-run (spec §4): the report does not describe
                 // THESE bytes — the file-findings class (the F-P2

--- a/crates/nika-providers/public-api.txt
+++ b/crates/nika-providers/public-api.txt
@@ -1,4 +1,132 @@
 pub mod nika_providers
+pub mod nika_providers::census
+pub struct nika_providers::census::AccessCensus
+pub nika_providers::census::AccessCensus::best: core::option::Option<nika_providers::census::AccessPath>
+pub nika_providers::census::AccessCensus::paths: alloc::vec::Vec<nika_providers::census::AccessPath>
+pub nika_providers::census::AccessCensus::seats: alloc::vec::Vec<nika_providers::census::SeatFact>
+pub nika_providers::census::AccessCensus::seats_ready: alloc::vec::Vec<alloc::string::String>
+impl nika_providers::census::AccessCensus
+pub fn nika_providers::census::AccessCensus::collect(config: nika_providers::registry::ProvidersConfig) -> Self
+pub fn nika_providers::census::AccessCensus::from_parts(probes: &[nika_providers::probe::ProviderProbe], seats: alloc::vec::Vec<nika_providers::census::SeatFact>) -> Self
+pub fn nika_providers::census::AccessCensus::seat_escape(&self) -> core::option::Option<alloc::string::String>
+impl core::clone::Clone for nika_providers::census::AccessCensus
+pub fn nika_providers::census::AccessCensus::clone(&self) -> nika_providers::census::AccessCensus
+impl core::cmp::Eq for nika_providers::census::AccessCensus
+impl core::cmp::PartialEq for nika_providers::census::AccessCensus
+pub fn nika_providers::census::AccessCensus::eq(&self, other: &nika_providers::census::AccessCensus) -> bool
+impl core::default::Default for nika_providers::census::AccessCensus
+pub fn nika_providers::census::AccessCensus::default() -> nika_providers::census::AccessCensus
+impl core::fmt::Debug for nika_providers::census::AccessCensus
+pub fn nika_providers::census::AccessCensus::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for nika_providers::census::AccessCensus
+impl<D> owo_colors::OwoColorize for nika_providers::census::AccessCensus
+impl<T, U> core::convert::Into<U> for nika_providers::census::AccessCensus where U: core::convert::From<T>
+pub fn nika_providers::census::AccessCensus::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_providers::census::AccessCensus where U: core::convert::Into<T>
+pub type nika_providers::census::AccessCensus::Error = core::convert::Infallible
+pub fn nika_providers::census::AccessCensus::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_providers::census::AccessCensus where U: core::convert::TryFrom<T>
+pub type nika_providers::census::AccessCensus::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_providers::census::AccessCensus::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_providers::census::AccessCensus where T: core::clone::Clone
+pub type nika_providers::census::AccessCensus::Owned = T
+pub fn nika_providers::census::AccessCensus::clone_into(&self, target: &mut T)
+pub fn nika_providers::census::AccessCensus::to_owned(&self) -> T
+impl<T> core::any::Any for nika_providers::census::AccessCensus where T: 'static + ?core::marker::Sized
+pub fn nika_providers::census::AccessCensus::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_providers::census::AccessCensus where T: ?core::marker::Sized
+pub fn nika_providers::census::AccessCensus::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_providers::census::AccessCensus where T: ?core::marker::Sized
+pub fn nika_providers::census::AccessCensus::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_providers::census::AccessCensus where T: core::clone::Clone
+pub unsafe fn nika_providers::census::AccessCensus::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_providers::census::AccessCensus
+pub fn nika_providers::census::AccessCensus::from(t: T) -> T
+impl<T> nika_error::traits::AsAny for nika_providers::census::AccessCensus where T: 'static
+pub fn nika_providers::census::AccessCensus::as_any(&self) -> &(dyn core::any::Any + 'static)
+#[non_exhaustive] pub struct nika_providers::census::AccessPath
+pub nika_providers::census::AccessPath::class: nika_types::access::AccessClass
+pub nika_providers::census::AccessPath::configured: bool
+pub nika_providers::census::AccessPath::custody: core::option::Option<alloc::string::String>
+pub nika_providers::census::AccessPath::fix_line: core::option::Option<alloc::string::String>
+pub nika_providers::census::AccessPath::id: alloc::string::String
+impl core::clone::Clone for nika_providers::census::AccessPath
+pub fn nika_providers::census::AccessPath::clone(&self) -> nika_providers::census::AccessPath
+impl core::cmp::Eq for nika_providers::census::AccessPath
+impl core::cmp::PartialEq for nika_providers::census::AccessPath
+pub fn nika_providers::census::AccessPath::eq(&self, other: &nika_providers::census::AccessPath) -> bool
+impl core::fmt::Debug for nika_providers::census::AccessPath
+pub fn nika_providers::census::AccessPath::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for nika_providers::census::AccessPath
+impl<D> owo_colors::OwoColorize for nika_providers::census::AccessPath
+impl<T, U> core::convert::Into<U> for nika_providers::census::AccessPath where U: core::convert::From<T>
+pub fn nika_providers::census::AccessPath::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_providers::census::AccessPath where U: core::convert::Into<T>
+pub type nika_providers::census::AccessPath::Error = core::convert::Infallible
+pub fn nika_providers::census::AccessPath::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_providers::census::AccessPath where U: core::convert::TryFrom<T>
+pub type nika_providers::census::AccessPath::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_providers::census::AccessPath::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_providers::census::AccessPath where T: core::clone::Clone
+pub type nika_providers::census::AccessPath::Owned = T
+pub fn nika_providers::census::AccessPath::clone_into(&self, target: &mut T)
+pub fn nika_providers::census::AccessPath::to_owned(&self) -> T
+impl<T> core::any::Any for nika_providers::census::AccessPath where T: 'static + ?core::marker::Sized
+pub fn nika_providers::census::AccessPath::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_providers::census::AccessPath where T: ?core::marker::Sized
+pub fn nika_providers::census::AccessPath::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_providers::census::AccessPath where T: ?core::marker::Sized
+pub fn nika_providers::census::AccessPath::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_providers::census::AccessPath where T: core::clone::Clone
+pub unsafe fn nika_providers::census::AccessPath::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_providers::census::AccessPath
+pub fn nika_providers::census::AccessPath::from(t: T) -> T
+impl<T> nika_error::traits::AsAny for nika_providers::census::AccessPath where T: 'static
+pub fn nika_providers::census::AccessPath::as_any(&self) -> &(dyn core::any::Any + 'static)
+#[non_exhaustive] pub struct nika_providers::census::SeatFact
+pub nika_providers::census::SeatFact::adapter_present: bool
+pub nika_providers::census::SeatFact::id: alloc::string::String
+pub nika_providers::census::SeatFact::product_present: bool
+pub nika_providers::census::SeatFact::serves: alloc::vec::Vec<alloc::string::String>
+pub nika_providers::census::SeatFact::signed_in: bool
+impl nika_providers::census::SeatFact
+pub fn nika_providers::census::SeatFact::as_path(&self) -> nika_providers::census::AccessPath
+pub fn nika_providers::census::SeatFact::new(id: impl core::convert::Into<alloc::string::String>, serves: alloc::vec::Vec<alloc::string::String>, product_present: bool, adapter_present: bool, signed_in: bool) -> Self
+pub const fn nika_providers::census::SeatFact::ready(&self) -> bool
+impl core::clone::Clone for nika_providers::census::SeatFact
+pub fn nika_providers::census::SeatFact::clone(&self) -> nika_providers::census::SeatFact
+impl core::cmp::Eq for nika_providers::census::SeatFact
+impl core::cmp::PartialEq for nika_providers::census::SeatFact
+pub fn nika_providers::census::SeatFact::eq(&self, other: &nika_providers::census::SeatFact) -> bool
+impl core::fmt::Debug for nika_providers::census::SeatFact
+pub fn nika_providers::census::SeatFact::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for nika_providers::census::SeatFact
+impl<D> owo_colors::OwoColorize for nika_providers::census::SeatFact
+impl<T, U> core::convert::Into<U> for nika_providers::census::SeatFact where U: core::convert::From<T>
+pub fn nika_providers::census::SeatFact::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_providers::census::SeatFact where U: core::convert::Into<T>
+pub type nika_providers::census::SeatFact::Error = core::convert::Infallible
+pub fn nika_providers::census::SeatFact::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_providers::census::SeatFact where U: core::convert::TryFrom<T>
+pub type nika_providers::census::SeatFact::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_providers::census::SeatFact::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_providers::census::SeatFact where T: core::clone::Clone
+pub type nika_providers::census::SeatFact::Owned = T
+pub fn nika_providers::census::SeatFact::clone_into(&self, target: &mut T)
+pub fn nika_providers::census::SeatFact::to_owned(&self) -> T
+impl<T> core::any::Any for nika_providers::census::SeatFact where T: 'static + ?core::marker::Sized
+pub fn nika_providers::census::SeatFact::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_providers::census::SeatFact where T: ?core::marker::Sized
+pub fn nika_providers::census::SeatFact::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_providers::census::SeatFact where T: ?core::marker::Sized
+pub fn nika_providers::census::SeatFact::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_providers::census::SeatFact where T: core::clone::Clone
+pub unsafe fn nika_providers::census::SeatFact::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_providers::census::SeatFact
+pub fn nika_providers::census::SeatFact::from(t: T) -> T
+impl<T> nika_error::traits::AsAny for nika_providers::census::SeatFact where T: 'static
+pub fn nika_providers::census::SeatFact::as_any(&self) -> &(dyn core::any::Any + 'static)
+pub fn nika_providers::census::collect_seats() -> alloc::vec::Vec<nika_providers::census::SeatFact>
 pub mod nika_providers::probe
 pub use nika_providers::probe::AccessClass
 pub enum nika_providers::probe::ExecutionLocus
@@ -750,6 +878,89 @@ impl<T> core::convert::From<T> for nika_providers::resolve_access::AccessCandida
 pub fn nika_providers::resolve_access::AccessCandidate::from(t: T) -> T
 impl<T> nika_error::traits::AsAny for nika_providers::resolve_access::AccessCandidate where T: 'static
 pub fn nika_providers::resolve_access::AccessCandidate::as_any(&self) -> &(dyn core::any::Any + 'static)
+pub struct nika_providers::AccessCensus
+pub nika_providers::AccessCensus::best: core::option::Option<nika_providers::census::AccessPath>
+pub nika_providers::AccessCensus::paths: alloc::vec::Vec<nika_providers::census::AccessPath>
+pub nika_providers::AccessCensus::seats: alloc::vec::Vec<nika_providers::census::SeatFact>
+pub nika_providers::AccessCensus::seats_ready: alloc::vec::Vec<alloc::string::String>
+impl nika_providers::census::AccessCensus
+pub fn nika_providers::census::AccessCensus::collect(config: nika_providers::registry::ProvidersConfig) -> Self
+pub fn nika_providers::census::AccessCensus::from_parts(probes: &[nika_providers::probe::ProviderProbe], seats: alloc::vec::Vec<nika_providers::census::SeatFact>) -> Self
+pub fn nika_providers::census::AccessCensus::seat_escape(&self) -> core::option::Option<alloc::string::String>
+impl core::clone::Clone for nika_providers::census::AccessCensus
+pub fn nika_providers::census::AccessCensus::clone(&self) -> nika_providers::census::AccessCensus
+impl core::cmp::Eq for nika_providers::census::AccessCensus
+impl core::cmp::PartialEq for nika_providers::census::AccessCensus
+pub fn nika_providers::census::AccessCensus::eq(&self, other: &nika_providers::census::AccessCensus) -> bool
+impl core::default::Default for nika_providers::census::AccessCensus
+pub fn nika_providers::census::AccessCensus::default() -> nika_providers::census::AccessCensus
+impl core::fmt::Debug for nika_providers::census::AccessCensus
+pub fn nika_providers::census::AccessCensus::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for nika_providers::census::AccessCensus
+impl<D> owo_colors::OwoColorize for nika_providers::census::AccessCensus
+impl<T, U> core::convert::Into<U> for nika_providers::census::AccessCensus where U: core::convert::From<T>
+pub fn nika_providers::census::AccessCensus::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_providers::census::AccessCensus where U: core::convert::Into<T>
+pub type nika_providers::census::AccessCensus::Error = core::convert::Infallible
+pub fn nika_providers::census::AccessCensus::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_providers::census::AccessCensus where U: core::convert::TryFrom<T>
+pub type nika_providers::census::AccessCensus::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_providers::census::AccessCensus::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_providers::census::AccessCensus where T: core::clone::Clone
+pub type nika_providers::census::AccessCensus::Owned = T
+pub fn nika_providers::census::AccessCensus::clone_into(&self, target: &mut T)
+pub fn nika_providers::census::AccessCensus::to_owned(&self) -> T
+impl<T> core::any::Any for nika_providers::census::AccessCensus where T: 'static + ?core::marker::Sized
+pub fn nika_providers::census::AccessCensus::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_providers::census::AccessCensus where T: ?core::marker::Sized
+pub fn nika_providers::census::AccessCensus::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_providers::census::AccessCensus where T: ?core::marker::Sized
+pub fn nika_providers::census::AccessCensus::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_providers::census::AccessCensus where T: core::clone::Clone
+pub unsafe fn nika_providers::census::AccessCensus::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_providers::census::AccessCensus
+pub fn nika_providers::census::AccessCensus::from(t: T) -> T
+impl<T> nika_error::traits::AsAny for nika_providers::census::AccessCensus where T: 'static
+pub fn nika_providers::census::AccessCensus::as_any(&self) -> &(dyn core::any::Any + 'static)
+#[non_exhaustive] pub struct nika_providers::AccessPath
+pub nika_providers::AccessPath::class: nika_types::access::AccessClass
+pub nika_providers::AccessPath::configured: bool
+pub nika_providers::AccessPath::custody: core::option::Option<alloc::string::String>
+pub nika_providers::AccessPath::fix_line: core::option::Option<alloc::string::String>
+pub nika_providers::AccessPath::id: alloc::string::String
+impl core::clone::Clone for nika_providers::census::AccessPath
+pub fn nika_providers::census::AccessPath::clone(&self) -> nika_providers::census::AccessPath
+impl core::cmp::Eq for nika_providers::census::AccessPath
+impl core::cmp::PartialEq for nika_providers::census::AccessPath
+pub fn nika_providers::census::AccessPath::eq(&self, other: &nika_providers::census::AccessPath) -> bool
+impl core::fmt::Debug for nika_providers::census::AccessPath
+pub fn nika_providers::census::AccessPath::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for nika_providers::census::AccessPath
+impl<D> owo_colors::OwoColorize for nika_providers::census::AccessPath
+impl<T, U> core::convert::Into<U> for nika_providers::census::AccessPath where U: core::convert::From<T>
+pub fn nika_providers::census::AccessPath::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_providers::census::AccessPath where U: core::convert::Into<T>
+pub type nika_providers::census::AccessPath::Error = core::convert::Infallible
+pub fn nika_providers::census::AccessPath::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_providers::census::AccessPath where U: core::convert::TryFrom<T>
+pub type nika_providers::census::AccessPath::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_providers::census::AccessPath::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_providers::census::AccessPath where T: core::clone::Clone
+pub type nika_providers::census::AccessPath::Owned = T
+pub fn nika_providers::census::AccessPath::clone_into(&self, target: &mut T)
+pub fn nika_providers::census::AccessPath::to_owned(&self) -> T
+impl<T> core::any::Any for nika_providers::census::AccessPath where T: 'static + ?core::marker::Sized
+pub fn nika_providers::census::AccessPath::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_providers::census::AccessPath where T: ?core::marker::Sized
+pub fn nika_providers::census::AccessPath::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_providers::census::AccessPath where T: ?core::marker::Sized
+pub fn nika_providers::census::AccessPath::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_providers::census::AccessPath where T: core::clone::Clone
+pub unsafe fn nika_providers::census::AccessPath::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_providers::census::AccessPath
+pub fn nika_providers::census::AccessPath::from(t: T) -> T
+impl<T> nika_error::traits::AsAny for nika_providers::census::AccessPath where T: 'static
+pub fn nika_providers::census::AccessPath::as_any(&self) -> &(dyn core::any::Any + 'static)
 #[non_exhaustive] pub struct nika_providers::AccessRefusal
 pub nika_providers::AccessRefusal::model: alloc::string::String
 pub nika_providers::AccessRefusal::provider: alloc::string::String
@@ -1012,6 +1223,49 @@ impl<TraitVariantBlanketType> nika_kernel_ai::provider::ProviderInfer for nika_p
 pub async fn nika_providers::registry::ResolvedProvider<H>::infer(&self, request: nika_kernel_ai::provider::InferRequest) -> core::result::Result<nika_kernel_ai::provider::InferResponse, nika_kernel_ai::provider::ProviderError>
 impl<TraitVariantBlanketType> nika_kernel_ai::provider::ProviderStream for nika_providers::registry::ResolvedProvider<H> where TraitVariantBlanketType: nika_kernel_ai::provider::ProviderStreamDyn
 pub async fn nika_providers::registry::ResolvedProvider<H>::infer_stream(&self, request: nika_kernel_ai::provider::InferRequest) -> core::result::Result<core::pin::Pin<alloc::boxed::Box<(dyn futures_core::stream::Stream<Item = core::result::Result<nika_kernel_ai::provider::InferEvent, nika_kernel_ai::provider::ProviderError>> + core::marker::Send)>>, nika_kernel_ai::provider::ProviderError>
+#[non_exhaustive] pub struct nika_providers::SeatFact
+pub nika_providers::SeatFact::adapter_present: bool
+pub nika_providers::SeatFact::id: alloc::string::String
+pub nika_providers::SeatFact::product_present: bool
+pub nika_providers::SeatFact::serves: alloc::vec::Vec<alloc::string::String>
+pub nika_providers::SeatFact::signed_in: bool
+impl nika_providers::census::SeatFact
+pub fn nika_providers::census::SeatFact::as_path(&self) -> nika_providers::census::AccessPath
+pub fn nika_providers::census::SeatFact::new(id: impl core::convert::Into<alloc::string::String>, serves: alloc::vec::Vec<alloc::string::String>, product_present: bool, adapter_present: bool, signed_in: bool) -> Self
+pub const fn nika_providers::census::SeatFact::ready(&self) -> bool
+impl core::clone::Clone for nika_providers::census::SeatFact
+pub fn nika_providers::census::SeatFact::clone(&self) -> nika_providers::census::SeatFact
+impl core::cmp::Eq for nika_providers::census::SeatFact
+impl core::cmp::PartialEq for nika_providers::census::SeatFact
+pub fn nika_providers::census::SeatFact::eq(&self, other: &nika_providers::census::SeatFact) -> bool
+impl core::fmt::Debug for nika_providers::census::SeatFact
+pub fn nika_providers::census::SeatFact::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for nika_providers::census::SeatFact
+impl<D> owo_colors::OwoColorize for nika_providers::census::SeatFact
+impl<T, U> core::convert::Into<U> for nika_providers::census::SeatFact where U: core::convert::From<T>
+pub fn nika_providers::census::SeatFact::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_providers::census::SeatFact where U: core::convert::Into<T>
+pub type nika_providers::census::SeatFact::Error = core::convert::Infallible
+pub fn nika_providers::census::SeatFact::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_providers::census::SeatFact where U: core::convert::TryFrom<T>
+pub type nika_providers::census::SeatFact::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_providers::census::SeatFact::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_providers::census::SeatFact where T: core::clone::Clone
+pub type nika_providers::census::SeatFact::Owned = T
+pub fn nika_providers::census::SeatFact::clone_into(&self, target: &mut T)
+pub fn nika_providers::census::SeatFact::to_owned(&self) -> T
+impl<T> core::any::Any for nika_providers::census::SeatFact where T: 'static + ?core::marker::Sized
+pub fn nika_providers::census::SeatFact::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_providers::census::SeatFact where T: ?core::marker::Sized
+pub fn nika_providers::census::SeatFact::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_providers::census::SeatFact where T: ?core::marker::Sized
+pub fn nika_providers::census::SeatFact::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_providers::census::SeatFact where T: core::clone::Clone
+pub unsafe fn nika_providers::census::SeatFact::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_providers::census::SeatFact
+pub fn nika_providers::census::SeatFact::from(t: T) -> T
+impl<T> nika_error::traits::AsAny for nika_providers::census::SeatFact where T: 'static
+pub fn nika_providers::census::SeatFact::as_any(&self) -> &(dyn core::any::Any + 'static)
 pub const nika_providers::CANONICAL_IDS: [&str; 16]
 pub const nika_providers::PREFIX_REFUSAL_CODE: &str
 pub fn nika_providers::access_plan_map(models: &[alloc::string::String], probes: &[nika_providers::probe::ProviderProbe], pin: core::option::Option<&str>) -> alloc::collections::btree::map::BTreeMap<alloc::string::String, nika_types::access::AccessPlan>

--- a/crates/nika-providers/src/census.rs
+++ b/crates/nika-providers/src/census.rs
@@ -92,6 +92,12 @@ impl SeatFact {
 
     /// A run can START on this seat: signed in AND the adapter a
     /// session spawns is on PATH (the first screen's « ready »).
+    /// `product_present` is deliberately NOT a leg: the session spawns
+    /// the ADAPTER, never the product bin — for a native-ACP seat the
+    /// two are one binary (`adapter_present` covers it), and for the
+    /// wrapper class the adapter plus the sign-in witness (the home
+    /// file the product once wrote) is enough to start. The product's
+    /// absence only changes the FIX line (`as_path`), never readiness.
     #[must_use]
     pub const fn ready(&self) -> bool {
         self.signed_in && self.adapter_present

--- a/crates/nika-providers/src/census.rs
+++ b/crates/nika-providers/src/census.rs
@@ -1,0 +1,442 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The ACCESS CENSUS — the ONE enumeration of every inference path this
+//! machine offers (R4 root-cause: welcome, doctor and the refusal chain
+//! each read a DIFFERENT source of access truth, so a signed-in harness
+//! seat could run inference while the first screen said « installed · no
+//! inference path »). One collector, one type; every surface READS it,
+//! none recomputes its own detection.
+//!
+//! Sovereignty invariants (the [`crate::probe`] precedent): key checks
+//! are PRESENT-NOT-PRINTED, seat detection is PATH + auth-surface
+//! presence only (never a credential read, never a spawn, never the
+//! network) — a census is cheap enough for the greeting.
+
+use nika_types::access::{AccessClass, HarnessRuntime};
+
+use crate::probe::ProviderProbe;
+use crate::{ProviderRegistry, ProvidersConfig};
+
+/// One way this machine can serve inference — the census row every
+/// surface reads (doctor's machine lane · the adoption ladder · the
+/// refusal tail).
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct AccessPath {
+    /// The path's class (`api` · `local` · `harness` · …).
+    pub class: AccessClass,
+    /// The path id — a provider id (`anthropic`) or, for the harness
+    /// class, the seat's PIN token (`claude-code` — never the retired
+    /// ACP wrapper id).
+    pub id: String,
+    /// The path can serve as configured TODAY (key present · seat
+    /// signed in with its adapter). Keyless local seeds are always
+    /// « configured » — presence is not detection, so they never win
+    /// [`AccessCensus::best`].
+    pub configured: bool,
+    /// WHERE the credential lives — the env var NAME for a keyed
+    /// `api`/`oauth` row (`ANTHROPIC_API_KEY`); `None` for keyless and
+    /// seat rows (a seat's custody is the harness's own login, never an
+    /// env var nika reads). Custody is DERIVED from the row, never a
+    /// value probe.
+    pub custody: Option<String>,
+    /// The printed fix when the path is not usable (never run). A seat
+    /// row names its `--access` pin and the gesture (install · sign
+    /// in), never the ACP wrapper id — the wrapper is not a pin
+    /// (NIKA-1802).
+    pub fix_line: Option<String>,
+}
+
+/// One harness seat's facts (feature `access-harness`) — the triple the
+/// first screen needs: the APP is here · the ACP ADAPTER a session
+/// spawns is here · the sign-in witness the admission gate reads. A
+/// signed-in app without its adapter is « detected, not ready » — the
+/// two halves are never conflated (the gauntlet's P1/P4 lesson).
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct SeatFact {
+    /// The pin token (`claude-code` · `codex` · …).
+    pub id: String,
+    /// The provider ids this seat fronts.
+    pub serves: Vec<String>,
+    /// The product CLI is on PATH (`claude`).
+    pub product_present: bool,
+    /// The ACP speaker is on PATH (`claude-agent-acp` — the binary a
+    /// session spawns; for native-ACP seats this IS the product bin).
+    pub adapter_present: bool,
+    /// The admission auth witness (the registry's auth surface — a
+    /// home-file presence, or ACP-on-PATH for the command-auth class
+    /// whose session is the sign-in witness).
+    pub signed_in: bool,
+}
+
+impl SeatFact {
+    /// Construct (INV-019).
+    #[must_use]
+    pub fn new(
+        id: impl Into<String>,
+        serves: Vec<String>,
+        product_present: bool,
+        adapter_present: bool,
+        signed_in: bool,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            serves,
+            product_present,
+            adapter_present,
+            signed_in,
+        }
+    }
+
+    /// A run can START on this seat: signed in AND the adapter a
+    /// session spawns is on PATH (the first screen's « ready »).
+    #[must_use]
+    pub const fn ready(&self) -> bool {
+        self.signed_in && self.adapter_present
+    }
+
+    /// The seat as a census path — `configured` mirrors the resolver's
+    /// candidate (`signed_in`: the sign-in witness), the fix line names
+    /// the PIN and the gesture, never the ACP wrapper id.
+    #[must_use]
+    pub fn as_path(&self) -> AccessPath {
+        let rt = HarnessRuntime::lookup(&self.id);
+        let display = rt.map_or(self.id.as_str(), |r| r.display);
+        let fix_line = if self.ready() {
+            None
+        } else if !self.product_present && !self.adapter_present {
+            Some(format!(
+                "install {display} itself · then `--access {}`",
+                self.id
+            ))
+        } else if !self.adapter_present {
+            Some(format!(
+                "install its ACP speaker (`nika doctor` has the line) · then `--access {}`",
+                self.id
+            ))
+        } else {
+            Some(format!(
+                "sign in to {display} itself · then `--access {}`",
+                self.id
+            ))
+        };
+        AccessPath {
+            class: AccessClass::Harness,
+            id: self.id.clone(),
+            configured: self.signed_in,
+            custody: None,
+            fix_line,
+        }
+    }
+}
+
+/// The whole machine, one read: every access path (provider rows + the
+/// harness seats joined in — the join the probe rows alone never did),
+/// the seats a run can start on, and the strongest configured path.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct AccessCensus {
+    /// Every path, provider rows then seats (census order is stable).
+    pub paths: Vec<AccessPath>,
+    /// The harness seats (empty when built without `access-harness`).
+    pub seats: Vec<SeatFact>,
+    /// Seat pin tokens a run can start on, in the ratified G-3 order.
+    pub seats_ready: Vec<String>,
+    /// The strongest CONFIGURED non-seed path: a ready seat outranks a
+    /// metered key (the sovereign order — the operator's own plan
+    /// first); a keyless local seed is a CATALOG fact, never a win.
+    pub best: Option<AccessPath>,
+}
+
+impl AccessCensus {
+    /// The pure fold — provider probe rows + seat facts in, census out.
+    /// Zero I/O: tests drive this half.
+    #[must_use]
+    pub fn from_parts(probes: &[ProviderProbe], seats: Vec<SeatFact>) -> Self {
+        let mut paths: Vec<AccessPath> = probes.iter().map(path_from_probe).collect();
+        paths.extend(seats.iter().map(SeatFact::as_path));
+        let seats_ready = seats_ready(&seats);
+        let best = seats_ready
+            .first()
+            .and_then(|id| {
+                paths
+                    .iter()
+                    .find(|p| p.class == AccessClass::Harness && &p.id == id)
+            })
+            .or_else(|| {
+                paths.iter().find(|p| {
+                    p.configured && matches!(p.class, AccessClass::Api | AccessClass::Oauth)
+                })
+            })
+            .cloned();
+        Self {
+            paths,
+            seats,
+            seats_ready,
+            best,
+        }
+    }
+
+    /// The collector (the I/O lives here, [`crate::probe`]'s precedent):
+    /// the SAME env composition a run uses, presence-only.
+    #[must_use]
+    pub fn collect(config: ProvidersConfig) -> Self {
+        let registry = ProviderRegistry::without_http(config);
+        let probes = crate::probe::collect_provider_probes(&registry);
+        Self::from_parts(&probes, collect_seats())
+    }
+
+    /// The seat-escape line an auth-class refusal teaches when THIS
+    /// machine has a signed-in seat (R4) — census-derived, so it is
+    /// printed only when it is TRUE, and it names the LIVE pin token.
+    #[must_use]
+    pub fn seat_escape(&self) -> Option<String> {
+        self.seats_ready
+            .first()
+            .map(|seat| format!("or use a signed-in seat: `--access {seat}`"))
+    }
+}
+
+/// The seats half of the collector — PATH + auth-surface presence only
+/// (the admission probe's own cheap pass, never a handshake spawn).
+#[must_use]
+pub fn collect_seats() -> Vec<SeatFact> {
+    #[cfg(feature = "access-harness")]
+    {
+        match nika_harness::registry() {
+            Ok(rows) => nika_harness::presence_facts(rows)
+                .into_iter()
+                .map(|fact| {
+                    SeatFact::new(
+                        fact.id,
+                        fact.serves,
+                        fact.product_present,
+                        fact.acp_present,
+                        fact.configured,
+                    )
+                })
+                .collect(),
+            // A broken registry offers nothing (fail-closed — the
+            // `harness_provider_rows` precedent).
+            Err(_) => Vec::new(),
+        }
+    }
+    #[cfg(not(feature = "access-harness"))]
+    {
+        Vec::new()
+    }
+}
+
+/// A provider probe row as a census path. Custody is the conventional
+/// env var NAME the row already carries (the fix surface's `fix_var`) —
+/// derived, never a value read.
+fn path_from_probe(p: &ProviderProbe) -> AccessPath {
+    AccessPath {
+        class: p.readiness.access,
+        id: p.id.clone(),
+        configured: p.readiness.configured,
+        custody: p.requires_key.then(|| p.fix_var.clone()),
+        fix_line: (!p.readiness.configured && p.requires_key)
+            .then(|| format!("export {}=…", p.fix_var)),
+    }
+}
+
+/// The seats a run can start on, ordered by the ratified runtime order
+/// (G-3) so two reads never disagree; an id outside the vocabulary
+/// ranks last, codepoint-stable.
+fn seats_ready(seats: &[SeatFact]) -> Vec<String> {
+    let mut ready: Vec<&SeatFact> = seats.iter().filter(|s| s.ready()).collect();
+    ready.sort_by_key(|s| {
+        HarnessRuntime::ALL
+            .iter()
+            .position(|rt| rt.id == s.id)
+            .unwrap_or(usize::MAX)
+    });
+    ready.into_iter().map(|s| s.id.clone()).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::probe::{ExecutionLocus, ProviderReadiness};
+
+    fn api_row(id: &str, key_present: bool, fix_var: &str) -> ProviderProbe {
+        ProviderProbe::new(
+            id,
+            true,
+            key_present,
+            fix_var,
+            true,
+            ProviderReadiness::new(
+                true,
+                key_present,
+                None,
+                None,
+                true,
+                ExecutionLocus::Cloud,
+                AccessClass::Api,
+            ),
+            "https://api.example.test",
+        )
+    }
+
+    fn local_row(id: &str) -> ProviderProbe {
+        ProviderProbe::new(
+            id,
+            false,
+            false,
+            "",
+            false,
+            ProviderReadiness::new(
+                true,
+                true,
+                None,
+                None,
+                false,
+                ExecutionLocus::Loopback,
+                AccessClass::Local,
+            ),
+            "http://127.0.0.1:11434",
+        )
+    }
+
+    fn seat(id: &str, product: bool, adapter: bool, signed_in: bool) -> SeatFact {
+        SeatFact::new(
+            id,
+            vec!["anthropic".to_owned()],
+            product,
+            adapter,
+            signed_in,
+        )
+    }
+
+    #[test]
+    fn a_signed_in_seat_with_its_adapter_is_a_ready_path() {
+        let census = AccessCensus::from_parts(
+            &[local_row("ollama")],
+            vec![seat("claude-code", true, true, true)],
+        );
+        assert_eq!(census.seats_ready, ["claude-code"]);
+        let best = census.best.as_ref().expect("a ready seat wins best");
+        assert_eq!(best.id, "claude-code");
+        assert_eq!(best.class, AccessClass::Harness);
+        assert_eq!(
+            census.seat_escape().as_deref(),
+            Some("or use a signed-in seat: `--access claude-code`")
+        );
+    }
+
+    /// Mutation pin for [`SeatFact::ready`]: inverting either leg
+    /// (`signed_in` · `adapter_present`) must flip the census.
+    #[test]
+    fn a_seat_missing_either_half_is_never_ready() {
+        for fact in [
+            seat("claude-code", true, false, true), // signed in, no adapter
+            seat("claude-code", true, true, false), // adapter, no sign-in
+            seat("claude-code", false, false, false),
+        ] {
+            let census = AccessCensus::from_parts(&[], vec![fact]);
+            assert!(census.seats_ready.is_empty(), "{:?}", census.seats);
+            assert_eq!(census.seat_escape(), None, "no truth, no tail");
+        }
+    }
+
+    #[test]
+    fn custody_names_the_env_var_never_a_value() {
+        let census = AccessCensus::from_parts(
+            &[
+                api_row("anthropic", false, "ANTHROPIC_API_KEY"),
+                local_row("ollama"),
+            ],
+            vec![],
+        );
+        let anthropic = census
+            .paths
+            .iter()
+            .find(|p| p.id == "anthropic")
+            .expect("the row");
+        assert!(!anthropic.configured);
+        assert_eq!(anthropic.custody.as_deref(), Some("ANTHROPIC_API_KEY"));
+        assert_eq!(
+            anthropic.fix_line.as_deref(),
+            Some("export ANTHROPIC_API_KEY=…")
+        );
+        // A keyless local seed carries no custody and never wins `best`.
+        let ollama = census.paths.iter().find(|p| p.id == "ollama").expect("row");
+        assert_eq!(ollama.custody, None);
+        assert_eq!(ollama.fix_line, None);
+        assert_eq!(census.best, None, "a keyless seed is not detection");
+    }
+
+    /// The sovereign order inside `best`: a ready seat outranks the
+    /// metered key even when the key is configured.
+    #[test]
+    fn best_prefers_the_operators_own_plan_over_the_metered_key() {
+        let census = AccessCensus::from_parts(
+            &[api_row("anthropic", true, "ANTHROPIC_API_KEY")],
+            vec![seat("claude-code", true, true, true)],
+        );
+        assert_eq!(
+            census.best.as_ref().map(|p| p.id.as_str()),
+            Some("claude-code")
+        );
+        // Without the seat the configured key is the best path.
+        let keyed =
+            AccessCensus::from_parts(&[api_row("anthropic", true, "ANTHROPIC_API_KEY")], vec![]);
+        assert_eq!(
+            keyed.best.as_ref().map(|p| p.id.as_str()),
+            Some("anthropic")
+        );
+    }
+
+    #[test]
+    fn the_seat_fix_line_names_the_pin_never_the_wrapper() {
+        let missing = seat("claude-code", false, false, false).as_path();
+        let fix = missing.fix_line.expect("a fix");
+        assert!(fix.contains("--access claude-code"), "{fix}");
+        assert!(
+            !fix.contains("claude-agent-acp"),
+            "the wrapper id is not a pin (NIKA-1802): {fix}"
+        );
+        let no_adapter = seat("claude-code", true, false, true).as_path();
+        let fix = no_adapter.fix_line.expect("a fix");
+        assert!(fix.contains("--access claude-code"), "{fix}");
+        assert!(!fix.contains("claude-agent-acp"), "{fix}");
+        let unsigned = seat("codex", true, true, false).as_path();
+        let fix = unsigned.fix_line.expect("a fix");
+        assert!(
+            fix.contains("sign in") && fix.contains("--access codex"),
+            "{fix}"
+        );
+        // A ready seat teaches nothing.
+        assert_eq!(seat("codex", true, true, true).as_path().fix_line, None);
+    }
+
+    /// `seats_ready` follows the ratified G-3 order, never the
+    /// enumeration order (mutation pin for the sort).
+    #[test]
+    fn seats_ready_ride_the_ratified_order() {
+        let census = AccessCensus::from_parts(
+            &[],
+            vec![
+                seat("claude-code", true, true, true),
+                seat("gemini-cli", true, true, true),
+                seat("codex", true, true, true),
+            ],
+        );
+        assert_eq!(census.seats_ready, ["gemini-cli", "codex", "claude-code"]);
+    }
+
+    #[test]
+    fn the_collector_never_binds_a_value() {
+        // The I/O half observes presence only: paths carry ids, custody
+        // NAMES and booleans — no field can hold a secret by
+        // construction.
+        let census = AccessCensus::collect(ProvidersConfig::new());
+        assert!(
+            census.paths.iter().all(|p| !p.id.is_empty()),
+            "rows are ids, not values"
+        );
+    }
+}

--- a/crates/nika-providers/src/lib.rs
+++ b/crates/nika-providers/src/lib.rs
@@ -39,6 +39,7 @@
 
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used, clippy::panic))]
 
+pub mod census;
 #[cfg(test)]
 mod parity_tests;
 pub mod probe;
@@ -50,6 +51,7 @@ mod sse;
 mod test_support;
 pub mod wire;
 
+pub use census::{AccessCensus, AccessPath, SeatFact};
 pub use profile::{
     CANONICAL_IDS, PREFIX_REFUSAL_CODE, Profile, ResolveRefusal, WireFormat, catalog_warning,
     resolve_refusal, seed, server_backed_local,

--- a/crates/nika-providers/src/resolve_access.rs
+++ b/crates/nika-providers/src/resolve_access.rs
@@ -178,9 +178,13 @@ fn judge(
                     str::to_owned,
                 )
         } else {
+            // Custody is NAMED (R4 · « key present » used to render
+            // without ever saying WHERE the key lives): keys are
+            // env-only, so the witness says the var is unset IN THE
+            // PROCESS ENV — derivable, never a value probe.
             candidate.fix_var.as_ref().map_or_else(
                 || String::from("no credential configured"),
-                |var| format!("{var} unset"),
+                |var| format!("{var} unset in process env"),
             )
         };
         return Some(AccessRejection::new(


### PR DESCRIPTION
## What

The R4 access-census branch: `welcome` and `doctor --json` classified a machine with a signed-in harness seat as `installed · no inference path` (the probe filled from provider rows only, the seat rows one call away and never joined in); the doctor per-seat fix taught the retired wrapper id (NIKA-1802); the NIKA-1800/INFER-001 witnesses never named the seat escape hatch. The census (`nika_providers::census::AccessCensus`) joins provider rows and harness seats in ONE read.

## R6 review → fix mapping

- **doctor exit-3 false red** — the ONE Fail driving exit 3 read provider rows alone: no cloud key + no local server = "no inference provider" even with a signed-in seat ready → the lane now reads `probe.census.seats_ready`, and the detail/fix name the seat door (`2f7a31000` rebased).
- **`SeatFact::ready()` and `product_present`** — documented at the definition: the session spawns the ADAPTER, never the product bin; for a native-ACP seat the two are one binary, for the wrapper class adapter + sign-in witness is enough. The product's absence changes the fix line, never readiness (`9515c1655`).
- **Dead `harness_names` rows** — the census looks a seat up by its live pin token ONLY; `claude`/`gemini`/`kimi` were never keys (measured: one consumer, pin-keyed) → dropped, comment corrected (`d06049269`).

## Ratchet repairs (pre-push gate catches)

- `cli_fix_hint` grew past the 100-line fn cap on the R4 seat-escape arm → the DECIDE pair moved to `decide_fix_hint` (the `run_decl_fix_hint` precedent), plus comment trims to keep nika-cli under the 15k crate wall.
- The `access-census-one-truth.fixed.md` fragment opened with a stray `---` → line 1 is the bullet again.

## Test plan

- [x] `cargo test -p nika-cli-host -p nika-providers -p nika-cli --lib` green
- [x] pre-push gate green (tests · clippy · hygiene · ratchets)
- [ ] Diamond CI