### PR TITLE
fix(ci): the next-tag projector anchors proven_by like the issue-proof reader

### DIFF
--- a/scripts/ci/next-tag-project.sh
+++ b/scripts/ci/next-tag-project.sh
@@ -97,8 +97,12 @@ if [ -f "$LEDGER" ]; then
       grab && $0 ~ /^[[:space:]]+-[[:space:]]*id:[[:space:]]*/ {
         sub(/.*id:[[:space:]]*/, ""); gsub(/["\047]/, ""); id=$0
       }
-      grab && $0 ~ /proven_by:[[:space:]]*/ {
-        sub(/.*proven_by:[[:space:]]*/, ""); gsub(/["\047]/, "")
+      # A YAML value starts its line; a comment that names the key does
+      # not (the #1218 class — the issue-proof ledger reader already
+      # anchors; this one read proven_by inside a comment and judged a
+      # markdown-wrapped code span as a job that is in no workflow).
+      grab && $0 ~ /^[[:space:]]*proven_by:[[:space:]]*/ {
+        sub(/^[[:space:]]*proven_by:[[:space:]]*/, ""); gsub(/["\047]/, "")
         job=$0
         if (job == "" || job == "null") print id "\t"
         else print id "\t" job


### PR DESCRIPTION
## What

`next-tag-project.sh --check` (the anti-08-08 gate, RELEASING.md step 4) refused the 0.115.0 tag on a phantom: its wiring.yaml capabilities reader matched `proven_by:` ANYWHERE in the line, so the `gate.issue-proof.judges-every-close` row's own comment — which explains WHY the ledger carries the row — was judged as a second declaration naming a nonsense job "in no workflow".

The issue-proof ledger reader already anchors line-initial for exactly this class (#1218 · "A YAML value starts its line; a comment that names the key does not"). The projector's reader learns the same anchor.

Measured: `--check` goes from UNPROVEN 1 (phantom) to "UNPROVEN none · every ledger row names a live job" (47 rows).

## Test plan

- [x] `bash scripts/ci/next-tag-project.sh --check` green on the real tree
- [x] shellcheck clean
- [x] pre-push gate green
- [ ] Diamond CI
