### PR TITLE
fix(ci): install bubblewrap before release smoke exec

### DIFF
--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -123,6 +123,15 @@ jobs:
             exit 1
           fi
 
+      - name: Install bubblewrap (Ubuntu exec path stays confined)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          set -euo pipefail
+          sudo timeout 300 apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 update
+          sudo timeout 300 apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 install -y --no-install-recommends bubblewrap
+          sudo apparmor_parser -R /etc/apparmor.d/bwrap-userns-restrict 2>/dev/null || true
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+
       # ──────────────────────────────────────────────────────────────────
       # 4. exec path (offline) — check + run a single exec task
       # ──────────────────────────────────────────────────────────────────

--- a/estate.yaml
+++ b/estate.yaml
@@ -193,7 +193,7 @@ patterns:
 - glob: ".github/workflows/**"
   class: authored
   match_count: 22
-  aggregate_sha256: e6c5a9b61491df55887679c0aa4e4e8b7645138a2574d6a286ad436108dcf817
+  aggregate_sha256: b190fd9eb1dd50a4819dd65ec72559032ff191d9476f6945de9543293f60b298
   evidence: "hand-written CI rails, comments narrate design decisions; the heal lanes here rewrite OTHER files (spec-pin-heal.yml → SPEC_PIN + pack · changelog-cliff.yml → CHANGELOG.md), nothing rewrites the workflows themselves"
 - glob: ".github/**"
   class: authored


### PR DESCRIPTION
## What

Install and configure Bubblewrap on the Ubuntu release-artifact smoke lane before the first real `exec` workflow. This preserves Nika’s fail-closed sandbox contract instead of weakening it with `NIKA_SANDBOX=off`.

## Evidence

- Failing published-artifact run: https://github.com/supernovae-st/nika/actions/runs/33369125443
- macOS passed; Ubuntu failed with NIKA-1710 because the runner had no Bubblewrap
- Uses the same bounded AppArmor/userns setup already proven by Diamond CI
- Local pre-push: all 11 ratchets, workspace `cargo test --workspace --lib`, hygiene green (yellow advisory only)

## Post-merge proof

Manually dispatch `e2e-smoke.yml` against the already-published v0.116.0 artifacts and require both macOS and Ubuntu green.

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>
Signed-off-by: Thibaut Melen <thibaut@supernovae.studio>
Signed-off-by: Nika 🦋 <nika@supernovae.studio>