### PR TITLE
fix(serve): join scheduler before store shutdown

### DIFF
--- a/crates/nika-serve/src/server/mod.rs
+++ b/crates/nika-serve/src/server/mod.rs
@@ -607,12 +607,8 @@ where
     if !schedule_done {
         let _ = schedule_stop.send(true);
     }
-    let authority_result = finish_authority(authority, executions, fatal).await;
-    if schedule_done {
-        authority_result
-    } else {
-        combine_schedule_result(authority_result, schedule_task.await)
-    }
+    let schedule_task = (!schedule_done).then_some(schedule_task);
+    finish_authority(authority, executions, fatal, schedule_task).await
 }
 
 async fn run_authority_with_http<F>(
@@ -685,12 +681,8 @@ where
     if !schedule_done {
         let _ = schedule_stop.send(true);
     }
-    let authority_result = finish_authority(authority, executions, fatal).await;
-    if schedule_done {
-        authority_result
-    } else {
-        combine_schedule_result(authority_result, schedule_task.await)
-    }
+    let schedule_task = (!schedule_done).then_some(schedule_task);
+    finish_authority(authority, executions, fatal, schedule_task).await
 }
 
 fn schedule_failure(
@@ -716,6 +708,7 @@ async fn finish_authority(
     mut authority: ResidentAuthority,
     mut executions: JoinSet<Result<(), ServerError>>,
     fatal: Option<ServerError>,
+    schedule_task: Option<tokio::task::JoinHandle<Result<(), ServerError>>>,
 ) -> Result<(), ServerError> {
     authority.jobs.close();
     if fatal.is_some() {
@@ -747,13 +740,21 @@ async fn finish_authority(
             Err(settlement) => Err(settlement),
         }
     };
+    let schedule_result = match schedule_task {
+        Some(task) => Some(task.await),
+        None => None,
+    };
     let actor_shutdown = match authority.store_actor.take() {
         Some(actor) => actor.shutdown().await,
         None => Err(ServerError::BlockingTask),
     };
-    match result {
+    let authority_result = match result {
         Err(error) => Err(error),
         Ok(()) => actor_shutdown,
+    };
+    match schedule_result {
+        Some(schedule) => combine_schedule_result(authority_result, schedule),
+        None => authority_result,
     }
 }
 

--- a/crates/nika-serve/src/server/mod.rs
+++ b/crates/nika-serve/src/server/mod.rs
@@ -741,7 +741,15 @@ async fn finish_authority(
         }
     };
     let schedule_result = match schedule_task {
-        Some(task) => Some(task.await),
+        Some(task) => {
+            #[cfg(test)]
+            authority
+                .state
+                .store
+                .shutdown_test_probe()
+                .mark_phase(store::ShutdownPhase::SchedulerJoin);
+            Some(task.await)
+        }
         None => None,
     };
     let actor_shutdown = match authority.store_actor.take() {

--- a/crates/nika-serve/src/server/schedule_tests.rs
+++ b/crates/nika-serve/src/server/schedule_tests.rs
@@ -231,11 +231,12 @@ fn body_at(workflow: &str, cost: f64, at: &str) -> String {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn live_once_wakes_executes_persists_and_does_not_rearm_after_restart() {
     let world = TestWorld::new();
-    let backend = Arc::new(CountingBackend::default());
+    let backend = Arc::new(CountingBackend::gated());
     let clock = Arc::new(ManualClock::new("2026-09-01T08:00:00Z[UTC]"));
     let server = world
         .start_with_clock(backend.clone(), limits(), clock.clone())
         .await;
+    let settlement_probe = server.shutdown_probe();
     let at = "2026-09-01T09:00:00Z";
     let created = server
         .request(&put_request(
@@ -279,6 +280,13 @@ async fn live_once_wakes_executes_persists_and_does_not_rearm_after_restart() {
         )
         .is_some()
     );
+    backend.release();
+    tokio::time::timeout(
+        Duration::from_secs(5),
+        settlement_probe.wait_terminal_settled(),
+    )
+    .await
+    .expect("durable terminal settlement");
     let terminal = server
         .request(&get_request(&format!("/v1/jobs/{run_id}")))
         .await;

--- a/crates/nika-serve/src/server/schedule_tests.rs
+++ b/crates/nika-serve/src/server/schedule_tests.rs
@@ -27,6 +27,7 @@ impl ExecutionBackend for NoopBackend {
 struct CountingBackend {
     calls: AtomicUsize,
     called: tokio::sync::Notify,
+    gate: Option<tokio::sync::Semaphore>,
     max_cost_usd: Mutex<Option<f64>>,
     root_bytes: Mutex<Option<Vec<u8>>>,
 }
@@ -94,6 +95,13 @@ impl super::ResidentClock for ManualClock {
 }
 
 impl CountingBackend {
+    fn gated() -> Self {
+        Self {
+            gate: Some(tokio::sync::Semaphore::new(0)),
+            ..Self::default()
+        }
+    }
+
     fn calls(&self) -> usize {
         self.calls.load(Ordering::SeqCst)
     }
@@ -119,6 +127,10 @@ impl CountingBackend {
         .await
         .expect("scheduled backend call");
     }
+
+    fn release(&self) {
+        self.gate.as_ref().expect("gated backend").add_permits(1);
+    }
 }
 
 impl ExecutionBackend for CountingBackend {
@@ -133,6 +145,10 @@ impl ExecutionBackend for CountingBackend {
         Box::pin(async move {
             self.calls.fetch_add(1, Ordering::SeqCst);
             self.called.notify_waiters();
+            if let Some(gate) = &self.gate {
+                let permit = gate.acquire().await.expect("backend gate");
+                permit.forget();
+            }
             ExecutionDisposition::Succeeded.into()
         })
     }
@@ -145,6 +161,36 @@ impl ExecutionBackend for CountingBackend {
         *self.max_cost_usd.lock().expect("record max cost") = max_cost_usd;
         self.execute(context)
     }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn shutdown_keeps_store_alive_until_scheduled_observation_finishes() {
+    let world = TestWorld::new();
+    let backend = Arc::new(CountingBackend::gated());
+    let clock = Arc::new(ManualClock::new("2026-09-01T08:00:00Z[UTC]"));
+    let server = world
+        .start_with_clock(backend.clone(), limits(), clock.clone())
+        .await;
+    let created = server
+        .request(&put_request(
+            "shutdown-once",
+            &body_at("root.nika.yaml", 0.25, "2026-09-01T09:00:00Z"),
+            "If-None-Match: *\r\n",
+            true,
+        ))
+        .await;
+    assert_eq!(created.status, 200, "{}", created.body);
+    clock.wait_for_sleeps(2).await;
+    clock.advance_to("2026-09-01T09:00:00Z[UTC]");
+    backend.wait_for_call().await;
+
+    let stopped = server.signal_stop();
+    backend.release();
+
+    stopped
+        .await
+        .expect("server join")
+        .expect("scheduled observation finishes before store shutdown");
 }
 
 fn body(workflow: &str, cost: f64) -> String {

--- a/crates/nika-serve/src/server/schedule_tests.rs
+++ b/crates/nika-serve/src/server/schedule_tests.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 
 use serde_json::json;
 
+use super::store::ShutdownPhase;
 use super::tests::{TestWorld, auth_header, get_request, limits};
 use super::{ExecutionBackend, ExecutionDisposition, ExecutionOutcome};
 
@@ -171,6 +172,8 @@ async fn shutdown_keeps_store_alive_until_scheduled_observation_finishes() {
     let server = world
         .start_with_clock(backend.clone(), limits(), clock.clone())
         .await;
+    let shutdown_probe = server.shutdown_probe();
+    shutdown_probe.gate_observation();
     let created = server
         .request(&put_request(
             "shutdown-once",
@@ -183,14 +186,29 @@ async fn shutdown_keeps_store_alive_until_scheduled_observation_finishes() {
     clock.wait_for_sleeps(2).await;
     clock.advance_to("2026-09-01T09:00:00Z[UTC]");
     backend.wait_for_call().await;
+    shutdown_probe.wait_observation_blocked().await;
 
     let stopped = server.signal_stop();
+    shutdown_probe.wait_shutdown_loop_observed().await;
     backend.release();
 
-    stopped
+    shutdown_probe.wait_terminal_settled().await;
+    let first_phase = shutdown_probe.wait_first_phase().await;
+    shutdown_probe.release_observation();
+
+    let stop_result = tokio::time::timeout(Duration::from_secs(5), stopped)
         .await
-        .expect("server join")
-        .expect("scheduled observation finishes before store shutdown");
+        .expect("bounded server join")
+        .expect("server join");
+    if first_phase == ShutdownPhase::StoreShutdown {
+        assert!(matches!(stop_result, Err(super::ServerError::BlockingTask)));
+    }
+    assert_eq!(
+        first_phase,
+        ShutdownPhase::SchedulerJoin,
+        "store shutdown started before the scheduler join"
+    );
+    stop_result.expect("scheduled observation finishes before store shutdown");
 }
 
 fn body(workflow: &str, cost: f64) -> String {

--- a/crates/nika-serve/src/server/store.rs
+++ b/crates/nika-serve/src/server/store.rs
@@ -5,6 +5,9 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::thread::JoinHandle;
 
+#[cfg(test)]
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+
 use serde_json::Value;
 use tokio::sync::{Notify, oneshot};
 
@@ -21,6 +24,124 @@ pub(super) struct EventPage {
     pub events: Vec<JobEvent>,
     pub record: JobRecord,
     pub terminal_sequence: Option<u64>,
+}
+
+#[cfg(test)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum ShutdownPhase {
+    SchedulerJoin = 1,
+    StoreShutdown = 2,
+}
+
+#[cfg(test)]
+#[derive(Debug, Default)]
+pub(super) struct ShutdownTestProbe {
+    gate_observation: AtomicBool,
+    observation_blocked: AtomicBool,
+    observation_release: std::sync::Mutex<bool>,
+    observation_gate: std::sync::Condvar,
+    observation_notify: Notify,
+    shutdown_loop_observed: AtomicBool,
+    shutdown_loop_notify: Notify,
+    terminal_settled: AtomicBool,
+    terminal_settled_notify: Notify,
+    first_phase: AtomicU8,
+    phase_notify: Notify,
+}
+
+#[cfg(test)]
+impl ShutdownTestProbe {
+    pub(super) fn gate_observation(&self) {
+        self.gate_observation.store(true, Ordering::SeqCst);
+    }
+
+    fn hold_observation(&self) {
+        if !self.gate_observation.load(Ordering::SeqCst) {
+            return;
+        }
+        self.observation_blocked.store(true, Ordering::SeqCst);
+        self.observation_notify.notify_waiters();
+        let mut released = self
+            .observation_release
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        while !*released {
+            released = self
+                .observation_gate
+                .wait(released)
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+        }
+    }
+
+    pub(super) async fn wait_observation_blocked(&self) {
+        loop {
+            let notified = self.observation_notify.notified();
+            if self.observation_blocked.load(Ordering::SeqCst) {
+                return;
+            }
+            notified.await;
+        }
+    }
+
+    pub(super) fn release_observation(&self) {
+        let mut released = self
+            .observation_release
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        *released = true;
+        self.observation_gate.notify_all();
+    }
+
+    pub(super) fn mark_shutdown_loop_observed(&self) {
+        self.shutdown_loop_observed.store(true, Ordering::SeqCst);
+        self.shutdown_loop_notify.notify_waiters();
+    }
+
+    pub(super) async fn wait_shutdown_loop_observed(&self) {
+        loop {
+            let notified = self.shutdown_loop_notify.notified();
+            if self.shutdown_loop_observed.load(Ordering::SeqCst) {
+                return;
+            }
+            notified.await;
+        }
+    }
+
+    fn mark_terminal_settled(&self) {
+        self.terminal_settled.store(true, Ordering::SeqCst);
+        self.terminal_settled_notify.notify_waiters();
+    }
+
+    pub(super) async fn wait_terminal_settled(&self) {
+        loop {
+            let notified = self.terminal_settled_notify.notified();
+            if self.terminal_settled.load(Ordering::SeqCst) {
+                return;
+            }
+            notified.await;
+        }
+    }
+
+    pub(super) fn mark_phase(&self, phase: ShutdownPhase) {
+        if self
+            .first_phase
+            .compare_exchange(0, phase as u8, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok()
+        {
+            self.phase_notify.notify_waiters();
+        }
+    }
+
+    pub(super) async fn wait_first_phase(&self) -> ShutdownPhase {
+        loop {
+            let notified = self.phase_notify.notified();
+            match self.first_phase.load(Ordering::SeqCst) {
+                1 => return ShutdownPhase::SchedulerJoin,
+                2 => return ShutdownPhase::StoreShutdown,
+                _ => notified.await,
+            }
+        }
+    }
 }
 
 enum RequestCommand {
@@ -99,6 +220,8 @@ pub(super) struct StoreHandle {
     requests: std::sync::mpsc::SyncSender<RequestCommand>,
     controls: std::sync::mpsc::SyncSender<ControlCommand>,
     events: Arc<Notify>,
+    #[cfg(test)]
+    shutdown_probe: Arc<ShutdownTestProbe>,
 }
 
 impl StoreHandle {
@@ -192,6 +315,8 @@ impl StoreHandle {
     }
 
     pub(super) fn get_blocking(&self, id: JobId) -> Result<Option<JobRecord>, ServerError> {
+        #[cfg(test)]
+        self.shutdown_probe.hold_observation();
         let (reply, answer) = oneshot::channel();
         self.send_request(RequestCommand::Get { id, reply })?;
         receive_blocking(answer)
@@ -215,6 +340,11 @@ impl StoreHandle {
 
     pub(super) fn event_notify(&self) -> Arc<Notify> {
         Arc::clone(&self.events)
+    }
+
+    #[cfg(test)]
+    pub(super) fn shutdown_test_probe(&self) -> Arc<ShutdownTestProbe> {
+        Arc::clone(&self.shutdown_probe)
     }
 
     pub(super) async fn transition_with_events(
@@ -252,7 +382,12 @@ impl StoreHandle {
             receipt: receipt.map(Box::new),
             reply,
         })?;
-        receive(answer).await
+        let result = receive(answer).await;
+        #[cfg(test)]
+        if result.is_ok() {
+            self.shutdown_probe.mark_terminal_settled();
+        }
+        result
     }
 
     pub(super) fn settle_with_result_blocking(
@@ -345,6 +480,8 @@ impl StoreActor {
         let (requests, request_receiver) = std::sync::mpsc::sync_channel(request_capacity);
         let (controls, control_receiver) = std::sync::mpsc::sync_channel(control_capacity);
         let events = Arc::new(Notify::new());
+        #[cfg(test)]
+        let shutdown_probe = Arc::new(ShutdownTestProbe::default());
         let thread_events = Arc::clone(&events);
         let thread = std::thread::Builder::new()
             .name("nika-serve-store".to_owned())
@@ -363,6 +500,8 @@ impl StoreActor {
                 requests,
                 controls,
                 events,
+                #[cfg(test)]
+                shutdown_probe,
             },
             thread: Some(thread),
         })
@@ -380,10 +519,15 @@ impl StoreActor {
             .map_err(|_| ServerError::BlockingTask)?;
         answer.await.map_err(|_| ServerError::BlockingTask)?;
         let thread = self.thread.take().ok_or(ServerError::BlockingTask)?;
-        tokio::task::spawn_blocking(move || thread.join())
+        let result = tokio::task::spawn_blocking(move || thread.join())
             .await
             .map_err(|_| ServerError::BlockingTask)?
-            .map_err(|_| ServerError::BlockingTask)
+            .map_err(|_| ServerError::BlockingTask);
+        #[cfg(test)]
+        self.handle
+            .shutdown_probe
+            .mark_phase(ShutdownPhase::StoreShutdown);
+        result
     }
 }
 

--- a/crates/nika-serve/src/server/tests.rs
+++ b/crates/nika-serve/src/server/tests.rs
@@ -130,6 +130,11 @@ impl TestServer {
         self.shutdown.take().expect("shutdown sender").send(()).ok();
         self.join.await.expect("server join")
     }
+
+    pub(super) fn signal_stop(mut self) -> tokio::task::JoinHandle<Result<(), ServerError>> {
+        self.shutdown.take().expect("shutdown sender").send(()).ok();
+        self.join
+    }
 }
 
 #[derive(Debug)]

--- a/crates/nika-serve/src/server/tests.rs
+++ b/crates/nika-serve/src/server/tests.rs
@@ -103,14 +103,18 @@ impl TestWorld {
         );
         let bound = BoundServer::attach(config, &authority).await.expect("bind");
         let address = bound.local_addr().expect("local address");
+        let shutdown_probe = authority.state.store.shutdown_test_probe();
+        let shutdown_observer = Arc::clone(&shutdown_probe);
         let (shutdown, receiver) = oneshot::channel();
         let join = tokio::spawn(authority.serve_with_http(bound, async move {
             let _result = receiver.await;
+            shutdown_observer.mark_shutdown_loop_observed();
         }));
         TestServer {
             address,
             shutdown: Some(shutdown),
             join,
+            shutdown_probe,
         }
     }
 }
@@ -119,6 +123,7 @@ pub(super) struct TestServer {
     address: SocketAddr,
     shutdown: Option<oneshot::Sender<()>>,
     join: tokio::task::JoinHandle<Result<(), ServerError>>,
+    shutdown_probe: Arc<super::store::ShutdownTestProbe>,
 }
 
 impl TestServer {
@@ -129,6 +134,10 @@ impl TestServer {
     pub(super) async fn stop(mut self) -> Result<(), ServerError> {
         self.shutdown.take().expect("shutdown sender").send(()).ok();
         self.join.await.expect("server join")
+    }
+
+    pub(super) fn shutdown_probe(&self) -> Arc<super::store::ShutdownTestProbe> {
+        Arc::clone(&self.shutdown_probe)
     }
 
     pub(super) fn signal_stop(mut self) -> tokio::task::JoinHandle<Result<(), ServerError>> {


### PR DESCRIPTION
## Outcome

Keeps `StoreActor` alive while the resident scheduler drains prepared runs and observes terminal receipts. Shutdown now joins the scheduler before closing the store on both resident runners.

Main Diamond run 33375229993 exposed the race as `BlockingTask` in `live_once_wakes_executes_persists_and_does_not_rearm_after_restart`: store shutdown sometimes won against the final scheduled-run observation.

## Proof

- deterministic semaphore-gated regression, no sleeps
- original CI test: 100/100
- new gated test: 100/100
- nika-serve: 146/146 library tests
- strict nika-serve clippy: green
- fmt + precommit hooks: green

The pre-push full gate passed while the same worktree also held the uncommitted 0.116.1 metadata sweep; this PR CI is the exact-ref proof. This PR contains no version bump or release mutation.