### PR TITLE
fix(engine): restore full-tree pre-push gates

### DIFF
--- a/crates/nika-cli/src/verbs/serve.rs
+++ b/crates/nika-cli/src/verbs/serve.rs
@@ -1048,6 +1048,7 @@ mod tests {
 
     #[test]
     fn a_short_token_file_teaches_the_mint_and_does_not_echo_the_secret() {
+        let _cwd = crate::cwd::hold();
         let tmp = tempfile::tempdir().expect("tmp");
         let workflows = tmp.path().join("wf");
         std::fs::create_dir(&workflows).expect("wf");
@@ -1074,6 +1075,7 @@ mod tests {
     #[test]
     fn a_world_readable_token_file_teaches_the_mint_and_does_not_echo_the_secret() {
         use std::os::unix::fs::PermissionsExt as _;
+        let _cwd = crate::cwd::hold();
         let tmp = tempfile::tempdir().expect("tmp");
         let workflows = tmp.path().join("wf");
         std::fs::create_dir(&workflows).expect("wf");
@@ -1096,6 +1098,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn a_symlink_token_file_teaches_regular_file_and_does_not_echo_the_secret() {
+        let _cwd = crate::cwd::hold();
         let tmp = tempfile::tempdir().expect("tmp");
         let workflows = tmp.path().join("wf");
         std::fs::create_dir(&workflows).expect("wf");
@@ -1122,6 +1125,7 @@ mod tests {
 
     #[test]
     fn a_missing_token_file_teaches_unreadable_and_the_mint() {
+        let _cwd = crate::cwd::hold();
         let tmp = tempfile::tempdir().expect("tmp");
         let workflows = tmp.path().join("wf");
         std::fs::create_dir(&workflows).expect("wf");

--- a/crates/nika-runtime/src/admit.rs
+++ b/crates/nika-runtime/src/admit.rs
@@ -63,8 +63,8 @@ pub(crate) fn gates(
 /// mid-run NIKA-1704 abort is the spend-then-apologise this gate closes.
 ///
 /// B20 R1 / issue 1297: a `--var` that resolves an envelope or task
-/// `model:` CEL is not on the static report. [`gates`] passes those
-/// bindings so the live id is judged here; this 4-arg form (the CLI
+/// `model:` CEL is not on the static report. The internal `gates` path
+/// passes those bindings so the live id is judged here; this 4-arg form (the CLI
 /// preflight) still prices `--model` and the file.
 #[must_use]
 pub fn budget_floor_refusal(

--- a/docs/crate-specs/nika-http.md
+++ b/docs/crate-specs/nika-http.md
@@ -120,7 +120,7 @@ defeats layer 2. Narrowed, not eliminated; per-request IP pinning is a
 |---|---|---|
 | 1 SPEC | ✅ | this file |
 | 2 TDD | ✅ | `tests/http_contract.rs` + ssrf unit/property authored first · RED (todo! skeleton) → GREEN · 36 contract + 27 lib/unit (incl 4 proptest) |
-| 3 IMPL | ✅ | ~1903 LOC src (post permits.net.http runtime boundary + resolver-enforced SSRF + cred-strip + loopback e2e · live · `scripts/crate-metrics.sh nika-http`) · zero unwrap/expect in src |
+| 3 IMPL | ✅ | ~2278 LOC src (post permits.net.http runtime boundary + resolver-enforced SSRF + cred-strip + loopback e2e · live · `scripts/crate-metrics.sh nika-http`) · zero unwrap/expect in src |
 | 4 CLIPPY 0 | ✅ | `cargo clippy --workspace --all-targets -- -D warnings` GREEN |
 | 5 MUTATION ≥90% | ✅ | `cargo mutants -p nika-http` · **92 mutants · 72 caught / 72 viable = 100%** (20 unviable). Every pre-review survivor (303/301/307/308 demotion branches · masked v6 embedded-v4 arm · cap boundary · resolve-layer) killed by the post-review tests: `classify_resolved` unit set · demotion method-recording fixtures · exact-cap boundary · trailing-dot + v6 proptest |
 | 6 PROPERTY | ✅ | MANDATORY (security): private-v4-range→SsrfBlocked (256 cases) · public-v4→allowed · v4↔mapped-v6 verdict equivalence · foreign-scheme→blocked |


### PR DESCRIPTION
## Why

main@ee5d1deb carried two full-tree hygiene REDs: a stale measured nika-http LOC anchor and a public rustdoc link to private nika-runtime::gates. The same tree also exposed a parallel-CWD race in four persistent token-file tests.

The pre-push hook validates the complete tree. A baseline-only branch was blocked by the CWD race, while a race-only branch was blocked by the two baseline REDs. This bootstrap PR therefore keeps the fixes as two ordered, reviewable commits without bypassing hooks.

## Commits

1. 50e4e97b — refresh the projector-backed HTTP LOC anchor and remove the public-to-private rustdoc link without widening the API.
2. ee813688 — hold the process-wide CWD lease in the four token-file tests; production code is unchanged.

## Evidence

- check-crate-specs.sh: green; HTTP live LOC moved from 2246 to 2278 after #1320.
- check-doc-private-items.sh: green across 70 library crates.
- Token-file tests: 4/4 green.
- Workspace cargo test --workspace --lib: green; nika-cli 333/333.
- Workspace clippy --all-targets -D warnings: green.
- cargo fmt --all -- --check: green.
- Full pre-push: green in 305.67s; 11 CI ratchets passed; no RED hygiene vector.

The mutant tree without the CWD lease reproduced a_missing_token_file_teaches_unreadable_and_the_mint as a parallel-only failure before this PR.