### PR TITLE
fix: gauntlet debt after 1320 (pause card, explain clean, --fix exec)

### DIFF
--- a/changelog.d/explain-file-clean.fixed.md
+++ b/changelog.d/explain-file-clean.fixed.md
@@ -1,0 +1,3 @@
+- **`nika explain FILE` no longer says checks clean on a red check.**
+  The human line and the JSON `clean` flag follow `CheckReport::is_clean`
+  (PERMITS-red files say `check red` / `"clean": false`).

--- a/changelog.d/fix-bare-exec.fixed.md
+++ b/changelog.d/fix-bare-exec.fixed.md
@@ -1,0 +1,4 @@
+- **`nika check --fix` wraps a bare `exec:` scalar into live dialect.**
+  Inert tokens become `command: ["prog", …]`; shell metacharacters
+  become `shell: "…"`. The 0.102 `command:` + `shell: true` pair is
+  gone (it PARSE-019'd).

--- a/changelog.d/gha-run-false-friend.fixed.md
+++ b/changelog.d/gha-run-false-friend.fixed.md
@@ -1,0 +1,3 @@
+A task-level `run:` (the GitHub Actions shell step) now names `exec:`
+instead of hoisting to envelope `run:` `{entropy, clock}`. `params:`
+names live `args:`.

--- a/changelog.d/gha-run-false-friend.fixed.md
+++ b/changelog.d/gha-run-false-friend.fixed.md
@@ -1,3 +1,2 @@
-A task-level `run:` (the GitHub Actions shell step) now names `exec:`
-instead of hoisting to envelope `run:` `{entropy, clock}`. `params:`
-names live `args:`.
+- **A task-level GitHub Actions `run:` names `exec:`.** Envelope `run:`
+  stays `{entropy, clock}` at column 0. `params:` names live `args:`.

--- a/changelog.d/pause-card-input.fixed.md
+++ b/changelog.d/pause-card-input.fixed.md
@@ -1,0 +1,4 @@
+- **Pause card teaches a string on `mode: input`.** Confirm still
+  shows `=true` (boolean, not yes). Input/choice show
+  `--answer task="your answer"`, so the loud `answer:` line matches
+  the resume line instead of burning the ticket.

--- a/crates/nika-cli/src/verbs/explain_file.rs
+++ b/crates/nika-cli/src/verbs/explain_file.rs
@@ -413,9 +413,14 @@ fn render_human(
     // The name alone: `description:` died with the envelope nuke
     // (2026-08-12), and the old fallback line taught the dead key.
     let _ = writeln!(s, "{}", doc.workflow);
+    let cleanliness = if report.is_clean() {
+        "checks clean"
+    } else {
+        "check red"
+    };
     let _ = writeln!(
         s,
-        "  {} · {} · checks clean",
+        "  {} · {} · {cleanliness}",
         crate::text::count(doc.nodes.len(), "task"),
         crate::text::count(report.waves.len(), "wave")
     );
@@ -859,7 +864,7 @@ fn render_json(
         "explain_version": 1,
         "file": path,
         "workflow": doc.workflow,
-        "clean": true,
+        "clean": report.is_clean(),
         "tasks": tasks,
         "waves": waves,
         "cost": report.cost,

--- a/crates/nika-cli/src/verbs/explain_file/tests.rs
+++ b/crates/nika-cli/src/verbs/explain_file/tests.rs
@@ -135,6 +135,32 @@ fn a_dirty_file_gets_findings_first_never_a_story() {
     assert!(!out.text.contains("the story"), "{}", out.text);
 }
 
+/// P07 · a PERMITS-red file still has a DAG, so explain narrates — but
+/// it must not print « checks clean » / `"clean": true`.
+#[test]
+fn a_permits_red_file_does_not_claim_clean() {
+    let path = tmp(
+        "sec004",
+        "nika: leak\npermits:\n  fs:\n    read: [\"./**\"]\n  tools: [\"nika:read\"]\ntasks:\n  leak:\n    invoke:\n      tool: nika:read\n      args: { path: /etc/passwd }\n",
+    );
+    let human = run(path.to_str().expect("utf8"), false, false);
+    assert_eq!(human.code, exit::OK, "{}", human.text);
+    assert!(
+        human.text.contains("check red"),
+        "human must not lie: {}",
+        human.text
+    );
+    assert!(
+        !human.text.contains("checks clean"),
+        "the old lie: {}",
+        human.text
+    );
+    let json = run(path.to_str().expect("utf8"), true, false);
+    std::fs::remove_file(&path).ok();
+    let v: serde_json::Value = serde_json::from_str(&json.text).expect("parses");
+    assert_eq!(v["clean"], false, "{}", json.text);
+}
+
 #[test]
 fn traces_glance_finds_the_lexicographically_latest_journal() {
     let dir = std::env::temp_dir().join(format!("nika-explain-traces-{}", std::process::id()));

--- a/crates/nika-cli/src/verbs/fix.rs
+++ b/crates/nika-cli/src/verbs/fix.rs
@@ -133,7 +133,7 @@ fn apply_prepass(source: &mut String, repairs: &mut Vec<Repair>, stop_notes: &mu
         *source = next;
         repairs.push(Repair::applied(
             "bare exec: string",
-            "command: / shell: mapping",
+            "command: argv or shell: mapping",
             "bare-exec",
         ));
     } else if has_bare_exec(source) {
@@ -214,8 +214,27 @@ fn wrap_one_bare_exec(line: &str) -> Option<String> {
         return None;
     }
     let indent = indent_of(line);
+    let unquoted = rest.trim().trim_matches(|c| c == '"' || c == '\'');
+    if unquoted.is_empty() {
+        return None;
+    }
+    // Live dialect: argv for inert tokens, `shell:` for metacharacters.
+    // Writing both `command:` and `shell: true` is the 0.102 form and
+    // PARSE-019s (P08 · C13).
+    if unquoted
+        .chars()
+        .any(|c| matches!(c, '|' | ';' | '&' | '<' | '>' | '`' | '$' | '(' | ')'))
+    {
+        let escaped = unquoted.replace('\\', "\\\\").replace('"', "\\\"");
+        return Some(format!("{indent}exec:\n{indent}  shell: \"{escaped}\""));
+    }
+    let args: Vec<String> = unquoted
+        .split_whitespace()
+        .map(|w| format!("\"{w}\""))
+        .collect();
     Some(format!(
-        "{indent}exec:\n{indent}  command: {rest}\n{indent}  shell: true"
+        "{indent}exec:\n{indent}  command: [{}]",
+        args.join(", ")
     ))
 }
 
@@ -1114,7 +1133,8 @@ mod tests {
     #[test]
     fn bare_exec_string_wraps_into_command_or_names_the_mapping() {
         // C13 · issue 1310: `exec: "echo …"` used to no-op with « must
-        // be a YAML mapping ». Wrap into `command:` so D1 can finish.
+        // be a YAML mapping ». Wrap inert scalars to argv (not the
+        // 0.102 command:+shell:true pair, which PARSE-019s).
         let dir = std::env::temp_dir().join(format!("nika-fix-c13-{}", std::process::id()));
         std::fs::create_dir_all(&dir).expect("tmpdir");
         let path = dir.join("bare-exec.nika.yaml");
@@ -1131,13 +1151,18 @@ mod tests {
         );
         let healed = std::fs::read_to_string(&path).expect("re-read");
         assert!(
-            healed.contains("command:") && healed.contains("shell:"),
-            "C13 writes command: and shell: together: {healed}"
+            healed.contains("command: [\"echo\", \"hello\"]"),
+            "C13 wraps inert scalar to argv: {healed}"
+        );
+        assert!(
+            !healed.contains("shell:"),
+            "inert tokens are not implicit-shell: {healed}"
         );
         assert!(
             !healed.contains("exec: \"echo hello\""),
             "the scalar exec is gone: {healed}"
         );
+        assert_eq!(out.code, exit::OK, "C13 converges green: {}", out.text);
         assert!(
             !healed.contains("workflow:"),
             "C13 must not invent workflow:: {healed}"

--- a/crates/nika-display/src/demo.rs
+++ b/crates/nika-display/src/demo.rs
@@ -202,6 +202,17 @@ pub fn paused() -> Vec<Event> {
     events
 }
 
+/// Same pause, `mode: input` — the card must teach a string, not a boolean.
+#[must_use]
+pub fn paused_input() -> Vec<Event> {
+    let mut events = opening();
+    events.extend([at(30, 4400, EventKind::WorkflowPaused)
+        .with_field(s("task", "approve"))
+        .with_field(s("mode", "input"))
+        .with_field(s("message", "ship it?"))]);
+    events
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/nika-display/src/demo.rs
+++ b/crates/nika-display/src/demo.rs
@@ -203,8 +203,10 @@ pub fn paused() -> Vec<Event> {
 }
 
 /// Same pause, `mode: input` — the card must teach a string, not a boolean.
+/// Test-only: the render goldens consume it; it is not a demo-replay door.
+#[cfg(test)]
 #[must_use]
-pub fn paused_input() -> Vec<Event> {
+pub(crate) fn paused_input() -> Vec<Event> {
     let mut events = opening();
     events.extend([at(30, 4400, EventKind::WorkflowPaused)
         .with_field(s("task", "approve"))

--- a/crates/nika-display/src/render.rs
+++ b/crates/nika-display/src/render.rs
@@ -714,9 +714,20 @@ fn append_paused_card(lines: &mut Vec<String>, view: &RunView, theme: &Theme) {
         crate::vocab::hint(
             *theme,
             "answer",
-            &format!("nika run --answer {task}=true FILE  (boolean true/false, not yes)")
+            &pause_answer_hint(task, view.paused_mode.as_deref())
         )
     ));
+}
+
+/// Confirm (stdlib default) takes a boolean. Input/choice take a string —
+/// teaching `=true` / « not yes » on those modes burns the ticket (P11).
+fn pause_answer_hint(task: &str, mode: Option<&str>) -> String {
+    match mode {
+        Some("input" | "choice") => {
+            format!("nika run --answer {task}=\"your answer\" FILE")
+        }
+        _ => format!("nika run --answer {task}=true FILE  (boolean true/false, not yes)"),
+    }
 }
 
 // `&Theme` (not by-value) to match the `frame`/`verdict_frame` borrow that

--- a/crates/nika-display/src/render_tests.rs
+++ b/crates/nika-display/src/render_tests.rs
@@ -149,7 +149,7 @@ fn golden_paused_frame_names_the_awaiting_gate() {
     );
     assert!(
         joined.contains("nika run --answer summarize=true FILE"),
-        "the paused card teaches the resume door: {joined}"
+        "confirm teaches --answer key=true: {joined}"
     );
     assert!(
         !joined.contains("=yes"),
@@ -165,6 +165,20 @@ fn golden_paused_frame_names_the_awaiting_gate() {
     assert!(
         close.contains("paused · awaiting an answer for `summarize`"),
         "{close}"
+    );
+}
+
+/// P11 · an input gate's card must not teach `=true` / « not yes ».
+#[test]
+fn pause_card_input_mode_teaches_a_string() {
+    let joined = frame(&fold(&demo::paused_input()), &UNICODE, 0).join("\n");
+    assert!(
+        joined.contains("nika run --answer approve=\"your answer\" FILE"),
+        "input teaches a string: {joined}"
+    );
+    assert!(
+        !joined.contains("=true") && !joined.contains("not yes"),
+        "confirm copy must not ride an input gate: {joined}"
     );
 }
 

--- a/crates/nika-display/src/state.rs
+++ b/crates/nika-display/src/state.rs
@@ -142,6 +142,10 @@ pub struct RunView {
     /// run ended AWAITING, neither verdict applies (the paused card's
     /// key · `None` on every other run).
     pub paused_task: Option<String>,
+    /// The paused prompt's `mode:` (`confirm` · `input` · `choice`) —
+    /// the card's `--answer` shape. `None` when the frame omitted it
+    /// (stdlib default is confirm).
+    pub(crate) paused_mode: Option<String>,
     /// A WORKFLOW-level failure reason carried on `workflow_failed` (e.g. a
     /// run-end NIKA-VAR-009 typed-output breach) — not tied to a task row.
     pub workflow_detail: Option<String>,
@@ -333,6 +337,7 @@ impl RunView {
                 self.workflow_detail = Some(format!("paused · awaiting an answer for `{task}`"));
                 self.touch(event, TaskState::Paused);
                 self.paused_task = Some(task);
+                self.paused_mode = str_field(event, "mode").map(str::to_owned);
             }
             // Dispatch + checkpoint + cost/stream/permit kinds carry no
             // row state today. `#[non_exhaustive]` future kinds render

--- a/crates/nika-schema/src/parser/retired.rs
+++ b/crates/nika-schema/src/parser/retired.rs
@@ -122,6 +122,17 @@ pub(super) fn foreign(key: &str) -> Option<&'static str> {
              another workflow, called with `invoke: { workflow: ./child.nika.yaml }` \
              (spec 14 §composition)",
         ),
+        "run" => Some(
+            "GitHub Actions `run:` is a shell step — here the verb is `exec:` \
+             (`exec: { command: \"echo hi\" }` plus `permits.exec`). Envelope \
+             `run:` (`entropy` · `clock`) belongs at column 0 beside `tasks:`, \
+             never inside a task",
+        ),
+        "params" => Some(
+            "`invoke:` takes `args:` (a map), not `params:` — the live dialect \
+             is `invoke: { tool: nika:fetch, args: { url: \"https://example.com\" } }` \
+             (spec 03 §invoke)",
+        ),
         _ => None,
     }
 }
@@ -163,16 +174,23 @@ mod tests {
                 .to_string()
         };
 
-        // `run:` is a REAL envelope key. Inside a task it read as nonsense
-        // to the author who typed it, and the message said only "unknown".
-        let run = sees("    run:\n      x: 1\n");
+        // GitHub Actions `run:` is the false friend (P02/P08 2026-08-31).
+        // Envelope `run:` {entropy, clock} is real at column 0; inside a
+        // task the author meant a shell step. Name `exec:`, not a hoist.
+        let run = sees("    run: echo hi\n");
         assert!(
-            run.contains("ENVELOPE") && run.contains("column 0"),
-            "an envelope key at task level names the depth · {run}"
+            run.contains("exec:") && run.contains("GitHub Actions"),
+            "task-level `run:` names the GHA false friend and `exec:` · {run}"
         );
         assert!(
-            run.contains("infer") && run.contains("invoke"),
-            "and names what a task body actually is · {run}"
+            run.contains("column 0") && run.contains("entropy"),
+            "and still points envelope `run:` at column 0 · {run}"
+        );
+
+        let params = sees("    params: { url: u }\n    exec: { command: [\"true\"] }\n");
+        assert!(
+            params.contains("`args:`") && params.contains("params:"),
+            "task-level `params:` routes to live `args:` · {params}"
         );
 
         // The GitHub Actions spelling of a concept that already has a


### PR DESCRIPTION
Post-1320 re-measure (`ee5d1deb1`) closed the P0 host-escape / cost-wrong-seat set. Remaining confirmed debt, three of four:

1. **Pause card** taught `approve=true` (boolean, not yes) on `mode: input`. Following that line burns the ticket without settling. Confirm still teaches boolean; input/choice teach a string.
2. **`nika explain FILE`** printed `checks clean` / `"clean": true` on PERMITS-red files. It now follows `CheckReport::is_clean`.
3. **`nika check --fix`** wrapped a bare `exec:` scalar as `command:` + `shell: true` (0.102) which PARSE-019'd. Inert tokens become argv; metacharacters become `shell:`.

The GHA `run:` / project-mode abandon (debt #3) is not in this PR.

Refs: `dx/state/gauntlet/2026-08-31-post-1320/WAVE.md` P11 P07 P08 P12.

Do not retag 0.116.0.