### PR TITLE
fix(security): stop secret-bearing test diagnostics

### DIFF
--- a/crates/nika-check-analyzer/src/native_first.rs
+++ b/crates/nika-check-analyzer/src/native_first.rs
@@ -380,7 +380,7 @@ fn command_segments(command: &RawCommand) -> Vec<CommandSegment> {
             clippy::unreachable,
             reason = "non_exhaustive future variant — enum and checker ship together; fail loud beats silently-wrong output"
         )]
-        other => unreachable!("unknown exec command form: {other:?}"),
+        _ => unreachable!("unsupported exec command form"),
     }
 }
 
@@ -671,7 +671,12 @@ mod tests {
     use nika_schema::source::FileId;
 
     fn hints_of(yaml: &str) -> Vec<Hint> {
-        scan(&parse(yaml, FileId::new(0), ParseMode::Strict).expect("parse"))
+        let parsed = parse(yaml, FileId::new(0), ParseMode::Strict);
+        assert!(parsed.is_ok(), "fixture must parse");
+        let Some(wf) = parsed.ok() else {
+            return Vec::new();
+        };
+        scan(&wf)
     }
 
     /// Every utility with a 1:1 builtin NAMES it, and names the argument
@@ -700,11 +705,11 @@ mod tests {
             let advice = &hints.first().expect("a utility fires 006").advice;
             assert!(
                 advice.starts_with("native-first/006"),
-                "{argv} is rule 006 · {advice}"
+                "utility must be classified as rule 006"
             );
             assert!(
                 advice.contains(builtin),
-                "{argv} names {builtin} · {advice}"
+                "utility advice must name its builtin"
             );
         }
 
@@ -730,7 +735,10 @@ mod tests {
         ] {
             let hints = hints_of(&exec_wf(argv));
             let advice = &hints.first().expect("a known family fires").advice;
-            assert!(advice.starts_with(rule), "{argv} stays {rule} · {advice}");
+            assert!(
+                advice.starts_with(rule),
+                "specific native-first rule must outrank utility rule"
+            );
         }
 
         // A PATHED head is the author's own tool that merely shares a
@@ -762,7 +770,7 @@ mod tests {
     fn sole_native_hint(yaml: &str) -> Hint {
         let hints = hints_of(yaml);
         let native: Vec<&Hint> = hints.iter().filter(|h| h.kind == "native-first").collect();
-        assert_eq!(native.len(), 1, "exactly one per task: {hints:?}");
+        assert_eq!(native.len(), 1, "exactly one native hint per task");
         native[0].clone()
     }
 
@@ -772,8 +780,8 @@ mod tests {
             "\"curl -s https://api.test/items -H 'x-api-key: k'\"",
         ));
         assert_eq!(h.task, "t");
-        assert!(h.advice.contains("native-first/001"), "{h:?}");
-        assert!(h.advice.contains("nika:fetch"), "{h:?}");
+        assert!(h.advice.contains("native-first/001"));
+        assert!(h.advice.contains("nika:fetch"));
     }
 
     #[test]
@@ -788,12 +796,12 @@ mod tests {
             let hints = hints_of(&exec_wf(command));
             assert!(
                 !hints.iter().any(|h| h.kind == "native-first"),
-                "{command} must stay silent: {hints:?}"
+                "pathed program must stay silent"
             );
         }
         // …but a pathed INTERPRETER + script is still the helper class.
         let h = sole_native_hint(&exec_wf("[\"/usr/bin/python3\", \"scripts/upload.py\"]"));
-        assert!(h.advice.contains("native-first/005"), "{h:?}");
+        assert!(h.advice.contains("native-first/005"));
     }
 
     #[test]
@@ -801,7 +809,7 @@ mod tests {
         let h = sole_native_hint(&exec_wf(
             "\"python3 -c 'import requests; requests.get(\\\"https://x.test\\\")'\"",
         ));
-        assert!(h.advice.contains("native-first/001"), "{h:?}");
+        assert!(h.advice.contains("native-first/001"));
     }
 
     #[test]
@@ -811,12 +819,12 @@ mod tests {
         let h = sole_native_hint(&exec_wf(
             "[\"node\", \"workflows/site/bin/crawl-and-upload.mjs\", \"--url\", \"${{ inputs.site }}\"]",
         ));
-        assert!(h.advice.contains("native-first/005"), "{h:?}");
-        assert!(h.advice.contains("exec ledger"), "{h:?}");
+        assert!(h.advice.contains("native-first/005"));
+        assert!(h.advice.contains("exec ledger"));
         // #475 · the parse lane is IN the inventory: the single most
         // common reason a helper survives it is "my input is YAML/CSV/
         // TOML" — a hole here becomes an exec in a user's boundary.
-        assert!(h.advice.contains("nika:convert"), "{h:?}");
+        assert!(h.advice.contains("nika:convert"));
     }
 
     #[test]
@@ -824,7 +832,7 @@ mod tests {
         let h = sole_native_hint(&exec_wf(
             "\"python3 -c 'import urllib; fetch(\\\"https://x.test\\\")'\"",
         ));
-        assert!(h.advice.contains("native-first/001"), "{h:?}");
+        assert!(h.advice.contains("native-first/001"));
     }
 
     #[test]
@@ -841,7 +849,7 @@ mod tests {
             let hints = hints_of(&exec_wf(command));
             assert!(
                 !hints.iter().any(|h| h.advice.contains("native-first/004")),
-                "pathed head must not fire media 004: {hints:?}"
+                "pathed head must not fire media 004"
             );
         }
     }
@@ -851,22 +859,22 @@ mod tests {
         let h = sole_native_hint(&exec_wf(
             "\"curl -X POST https://api.openai.com/v1/images/generations -d @body.json\"",
         ));
-        assert!(h.advice.contains("native-first/004"), "{h:?}");
-        assert!(h.advice.contains("nika:image_generate"), "{h:?}");
+        assert!(h.advice.contains("native-first/004"));
+        assert!(h.advice.contains("nika:image_generate"));
     }
 
     #[test]
     fn fires_on_file_and_data_programs() {
         let file = sole_native_hint(&exec_wf("\"cat out/manifest.json\""));
-        assert!(file.advice.contains("native-first/002"), "{file:?}");
+        assert!(file.advice.contains("native-first/002"));
         let data = sole_native_hint(&exec_wf(
             "\"jq '.items | map(.name)' out/crawl.json > out/names.json\"",
         ));
-        assert!(data.advice.contains("native-first/003"), "{data:?}");
+        assert!(data.advice.contains("native-first/003"));
         let env_prefixed = sole_native_hint(&exec_wf("\"LC_ALL=C sed s/a/b/ in.txt\""));
         assert!(
             env_prefixed.advice.contains("native-first/003"),
-            "assignments are skipped to the real head: {env_prefixed:?}"
+            "assignments must be skipped to the real head"
         );
     }
 
@@ -883,7 +891,7 @@ mod tests {
             let hints = hints_of(&exec_wf(command));
             assert!(
                 !hints.iter().any(|h| h.kind == "native-first"),
-                "{command} must stay silent: {hints:?}"
+                "genuine subprocess must stay silent"
             );
         }
     }
@@ -892,7 +900,7 @@ mod tests {
     fn silent_on_interpreter_without_script_or_http() {
         // A bare interpreter computation is a legitimate subprocess.
         let hints = hints_of(&exec_wf("\"python3 -c 'print(6*7)'\""));
-        assert!(!hints.iter().any(|h| h.kind == "native-first"), "{hints:?}");
+        assert!(!hints.iter().any(|h| h.kind == "native-first"));
     }
 
     #[test]
@@ -937,7 +945,7 @@ tasks:
                 ("render_background", "native-first/004"),
                 ("write_manifest", "native-first/003"),
             ],
-            "{hints:?}"
+            "the regression fixture must yield the expected hints"
         );
     }
 
@@ -956,7 +964,7 @@ tasks:
                 Some("native-first/003"),
                 Some("native-first/002"),
             ],
-            "the head must not hide later pipeline segments: {hints:?}"
+            "the head must not hide later pipeline segments"
         );
     }
 
@@ -973,7 +981,7 @@ tasks:
         assert_eq!(
             codes,
             vec![Some("native-first/003")],
-            "quoted/escaped separators and pathed utility heads stay literal: {hints:?}"
+            "quoted/escaped separators and pathed utility heads must stay literal"
         );
     }
 
@@ -988,7 +996,7 @@ tasks:
                 .filter(|h| h.code == Some("native-first/006"))
                 .count(),
             5,
-            "each deterministic native path gets its own site: {hints:?}"
+            "each deterministic native path must get its own site"
         );
         for builtin in ["date", "hash"] {
             assert!(
@@ -996,10 +1004,10 @@ tasks:
                 "a hint target must resolve in the real builtin catalog: nika:{builtin}"
             );
         }
-        assert!(hints[0].advice.contains("nika:date"), "{:?}", hints[0]);
+        assert!(hints[0].advice.contains("nika:date"));
         assert!(
             hints[1..].iter().all(|h| h.advice.contains("nika:hash")),
-            "{hints:?}"
+            "every digest hint must name nika:hash"
         );
     }
 
@@ -1008,7 +1016,7 @@ tasks:
         let hints = hints_of(&exec_wf("\"echo ok # ignored ; jq '.'; date\""));
         assert!(
             hints.iter().all(|h| h.kind != "native-first"),
-            "comment text is never executable syntax: {hints:?}"
+            "comment text must never become executable syntax"
         );
     }
 
@@ -1027,7 +1035,7 @@ tasks:
             assert_eq!(
                 hints.iter().filter(|h| h.kind == "native-first").count(),
                 expected,
-                "{command}: {hints:?}"
+                "compound prefix case has unexpected native hint count"
             );
         }
     }
@@ -1048,7 +1056,7 @@ tasks:
             assert_eq!(
                 hints.iter().filter(|h| h.kind == "native-first").count(),
                 expected,
-                "{command}: {hints:?}"
+                "conditional case has unexpected native hint count"
             );
         }
     }
@@ -1059,20 +1067,20 @@ tasks:
         assert_eq!(
             comment.iter().filter(|h| h.kind == "native-first").count(),
             1,
-            "comment payload stays inert while the next line is judged: {comment:?}"
+            "comment payload must stay inert while the next line is judged"
         );
 
         let heredoc = hints_of(&exec_wf("\"if cat <<EOF\\njq '.'\\nEOF\\nthen date\\nfi\""));
         assert!(
             heredoc.iter().all(|h| h.kind != "native-first"),
-            "the conservative heredoc backoff still owns the whole shell: {heredoc:?}"
+            "the conservative heredoc backoff must own the whole shell"
         );
 
         let crlf = hints_of(&exec_wf("\"if jq '.' input.json; then\\r\\ndate\\r\\nfi\""));
         assert_eq!(
             crlf.iter().filter(|h| h.kind == "native-first").count(),
             2,
-            "CRLF keeps the same command boundaries: {crlf:?}"
+            "CRLF must keep the same command boundaries"
         );
     }
 
@@ -1089,7 +1097,10 @@ tasks:
         for (command, expected) in cases {
             let hints = hints_of(&exec_wf(command));
             let count = hints.iter().filter(|h| h.kind == "native-first").count();
-            assert_eq!(count, expected, "{command}: {hints:?}");
+            assert_eq!(
+                count, expected,
+                "prefix case has unexpected native hint count"
+            );
             total += count;
         }
         assert_eq!(total, 8, "the hostile prefix matrix keeps all eight sites");
@@ -1108,7 +1119,7 @@ tasks:
         let pathed = hints_of(&exec_wf("\"/usr/bin/jq /tmp/input\""));
         assert!(
             pathed.iter().all(|h| h.kind != "native-first"),
-            "a pathed head remains author-owned: {pathed:?}"
+            "a pathed head must remain author-owned"
         );
     }
 
@@ -1117,7 +1128,7 @@ tasks:
         let hints = hints_of(&exec_wf("\"cat <<EOF\\njq '.'\\nEOF\""));
         assert!(
             hints.iter().all(|h| h.code != Some("native-first/003")),
-            "the deliberately small segmenter backs off on heredocs: {hints:?}"
+            "the deliberately small segmenter must back off on heredocs"
         );
     }
 }

--- a/crates/nika-check/src/tools.rs
+++ b/crates/nika-check/src/tools.rs
@@ -75,7 +75,7 @@ fn collect(site: &str, action: &RawAction, out: &mut Vec<UnknownTool>) {
             clippy::unreachable,
             reason = "non_exhaustive future variant — enum and checker ship together; fail loud beats silently-wrong output"
         )]
-        other => unreachable!("unknown action: {other:?}"),
+        _ => unreachable!("unsupported action"),
     }
 }
 
@@ -355,7 +355,7 @@ fn collect_mcp(site: &str, action: &RawAction, out: &mut Vec<(String, String)>) 
             clippy::unreachable,
             reason = "non_exhaustive future variant — enum and checker ship together; fail loud beats silently-wrong output"
         )]
-        other => unreachable!("unknown action: {other:?}"),
+        _ => unreachable!("unsupported action"),
     }
 }
 
@@ -394,7 +394,12 @@ mod tests {
     use nika_schema::source::FileId;
 
     fn findings_of(yaml: &str) -> Vec<UnknownTool> {
-        scan_unknown_tools(&parse(yaml, FileId::new(0), ParseMode::Strict).expect("parse"))
+        let parsed = parse(yaml, FileId::new(0), ParseMode::Strict);
+        assert!(parsed.is_ok(), "fixture must parse");
+        let Some(wf) = parsed.ok() else {
+            return Vec::new();
+        };
+        scan_unknown_tools(&wf)
     }
 
     #[test]
@@ -412,7 +417,7 @@ mod tests {
         let f = findings_of(
             "nika: w\ntasks:\n  a:\n    invoke: { tool: \"nika:read\", args: { path: \"./x\" } }\n  b:\n    invoke: { tool: \"nika:json_merge_patch\", args: { target: {}, patch: {} } }\n",
         );
-        assert!(f.is_empty(), "{f:?}");
+        assert!(f.is_empty());
     }
 
     #[test]
@@ -428,7 +433,7 @@ mod tests {
         let f = findings_of(
             "nika: w\ntasks:\n  t:\n    agent:\n      prompt: \"go\"\n      tools: [\"nika:*\", \"nika:fetc\", \"mcp:browser/*\"]\n",
         );
-        assert_eq!(f.len(), 1, "only the concrete typo flags: {f:?}");
+        assert_eq!(f.len(), 1, "only the concrete typo must flag");
         assert_eq!(f[0].suggestion.as_deref(), Some("nika:fetch"));
     }
 
@@ -441,7 +446,7 @@ mod tests {
         let f = findings_of(
             "nika: w\ntasks:\n  t:\n    agent:\n      prompt: \"go\"\n      tools: [\"nika:done\", \"nika:compose\"]\n",
         );
-        assert!(f.is_empty(), "loop-only builtins are catalogued: {f:?}");
+        assert!(f.is_empty(), "loop-only builtins must be catalogued");
     }
 
     #[test]
@@ -456,7 +461,12 @@ mod tests {
     // ── Finding #6 · unknown builtin arg keys ───────────────────────────
 
     fn arg_findings_of(yaml: &str) -> Vec<UnknownArg> {
-        scan_unknown_args(&parse(yaml, FileId::new(0), ParseMode::Strict).expect("parse"))
+        let parsed = parse(yaml, FileId::new(0), ParseMode::Strict);
+        assert!(parsed.is_ok(), "fixture must parse");
+        let Some(wf) = parsed.ok() else {
+            return Vec::new();
+        };
+        scan_unknown_args(&wf)
     }
 
     #[test]
@@ -467,7 +477,7 @@ mod tests {
         let f = arg_findings_of(
             "nika: w\ntasks:\n  t:\n    invoke: { tool: \"nika:jq\", args: { expression: \".\", data: { a: 1 } } }\n",
         );
-        assert_eq!(f.len(), 1, "{f:?}");
+        assert_eq!(f.len(), 1);
         assert_eq!(f[0].tool, "nika:jq");
         assert_eq!(f[0].arg, "data");
         assert_eq!(f[0].task, "t");
@@ -479,7 +489,7 @@ mod tests {
         let f = arg_findings_of(
             "nika: w\ntasks:\n  t:\n    invoke: { tool: \"nika:jq\", args: { expression: \".\", inpit: 1 } }\n",
         );
-        assert_eq!(f.len(), 1, "{f:?}");
+        assert_eq!(f.len(), 1);
         assert_eq!(f[0].arg, "inpit");
         assert_eq!(f[0].suggestion.as_deref(), Some("input"));
     }
@@ -492,7 +502,7 @@ mod tests {
         let f = arg_findings_of(
             "nika: w\ntasks:\n  t:\n    invoke: { tool: \"nika:jq\", args: { expr: \".\", input: 1 } }\n",
         );
-        assert_eq!(f.len(), 1, "{f:?}");
+        assert_eq!(f.len(), 1);
         assert_eq!(f[0].arg, "expr");
         assert_eq!(f[0].suggestion.as_deref(), Some("expression"));
     }
@@ -505,13 +515,12 @@ mod tests {
         let f = arg_findings_of(
             "nika: w\ntasks:\n  t:\n    invoke: { tool: \"nika:json_diff\", args: { left: { a: 1 }, right: { a: 2 } } }\n",
         );
-        assert_eq!(f.len(), 2, "{f:?}");
+        assert_eq!(f.len(), 2);
         for u in &f {
             assert_eq!(u.suggestion, None, "no honest guess for {}", u.arg);
             assert!(
                 u.declared.iter().any(|d| d == "before") && u.declared.iter().any(|d| d == "after"),
-                "declared vocabulary teaches the real keys: {:?}",
-                u.declared
+                "declared vocabulary must teach the real keys"
             );
         }
     }
@@ -535,7 +544,7 @@ mod tests {
         let f = arg_findings_of(
             "nika: w\ntasks:\n  t:\n    invoke: { tool: \"nika:jq\", args: { expression: \".\", input: { a: 1 } } }\n",
         );
-        assert!(f.is_empty(), "every key is declared: {f:?}");
+        assert!(f.is_empty(), "every key must be declared");
     }
 
     #[test]
@@ -567,13 +576,18 @@ mod tests {
         let f = arg_findings_of(
             "nika: w\ntasks:\n  t:\n    invoke: { tool: \"nika:raed\", args: { wat: 1 } }\n",
         );
-        assert!(f.is_empty(), "unknown builtin owns its finding: {f:?}");
+        assert!(f.is_empty(), "unknown builtin must own its finding");
     }
 
     // ── F5 · missing required args (extends the 5/22 static check) ───────
 
     fn missing_of(yaml: &str) -> Vec<MissingArg> {
-        scan_missing_args(&parse(yaml, FileId::new(0), ParseMode::Strict).expect("parse"))
+        let parsed = parse(yaml, FileId::new(0), ParseMode::Strict);
+        assert!(parsed.is_ok(), "fixture must parse");
+        let Some(wf) = parsed.ok() else {
+            return Vec::new();
+        };
+        scan_missing_args(&wf)
     }
 
     #[test]
@@ -612,7 +626,7 @@ mod tests {
         let f = missing_of(
             "nika: w\ntasks:\n  t:\n    invoke: { tool: \"nika:write\", args: { path: \"./o\" } }\n",
         );
-        assert_eq!(f.len(), 1, "{f:?}");
+        assert_eq!(f.len(), 1);
         assert_eq!(f[0].arg, "content");
         assert_eq!(f[0].tool, "nika:write");
     }
@@ -622,7 +636,7 @@ mod tests {
         let f = missing_of(
             "nika: w\ntasks:\n  t:\n    invoke: { tool: \"nika:convert\", args: { input: \"x\", from: \"csv\", to: \"json\" } }\n",
         );
-        assert!(f.is_empty(), "every required arg present: {f:?}");
+        assert!(f.is_empty(), "every required arg must be present");
     }
 
     #[test]
@@ -652,6 +666,6 @@ mod tests {
         // A typo'd builtin is scan_unknown_tools' finding — the
         // missing-required scan can't know its vocabulary, stays silent.
         let f = missing_of("nika: w\ntasks:\n  t:\n    invoke: { tool: \"nika:hsah\" }\n");
-        assert!(f.is_empty(), "unknown builtin owns its finding: {f:?}");
+        assert!(f.is_empty(), "unknown builtin must own its finding");
     }
 }

--- a/crates/nika-cli-host/src/choice/tests.rs
+++ b/crates/nika-cli-host/src/choice/tests.rs
@@ -299,18 +299,15 @@ fn skeletons_name_only_the_cascade_alias_or_are_stamped() {
             .lines()
             .find(|l| l.starts_with("model: "))
             .map(|l| l.trim_start_matches("model: ").trim().trim_matches('\''));
-        assert_eq!(
-            model,
-            Some(want.as_str()),
-            "{} kept a model the cascade did not stamp",
-            path.display()
+        assert!(
+            model == Some(want.as_str()),
+            "a skeleton kept a model the cascade did not stamp"
         );
         assert!(
             !stamped
                 .lines()
                 .any(|l| l.starts_with("model: ") && l.contains("unsloth/")),
-            "{} stamped a Hub id: {stamped}",
-            path.display()
+            "a stamped skeleton must not use a Hub id as its model"
         );
     }
     assert!(scanned >= 8, "scanned {scanned} skeletons");
@@ -359,17 +356,14 @@ fn tty_and_pipe_project_the_same_product() {
 fn assert_parses(yaml: &str) {
     assert!(
         yaml.contains("\n  greet:\n") || yaml.contains("\n  reply:\n"),
-        "a hello task must be indented under tasks: — a `\\` continuation ate the YAML:\n{yaml}"
+        "a hello task must be indented under tasks: — a `\\` continuation ate the YAML"
     );
     let parsed = nika_schema::parse(
         yaml,
         nika_schema::FileId::new(0),
         nika_schema::ParseMode::Strict,
     );
-    assert!(
-        parsed.is_ok(),
-        "first-wow yaml must parse: {parsed:?}\n{yaml}"
-    );
+    assert!(parsed.is_ok(), "first-wow yaml must parse");
 }
 
 fn assert_hello_is_mock_echo(yaml: &str) {
@@ -377,16 +371,50 @@ fn assert_hello_is_mock_echo(yaml: &str) {
         .lines()
         .find(|l| l.starts_with("model: "))
         .expect("hello carries model:");
-    assert!(
-        model.contains("mock/echo"),
-        "hello stays mock/echo, got {model}\n{yaml}"
-    );
+    assert!(model.contains("mock/echo"), "hello stays on the mock model");
     assert!(
         !model.contains("openai") && !model.contains("anthropic") && !model.contains("gpt-"),
-        "a present vendor key must not switch hello onto a billed seat: {model}\n{yaml}"
+        "a present vendor key must not switch hello onto a billed seat"
     );
-    assert!(yaml.contains("infer:"), "{yaml}");
-    assert!(!yaml.contains("agent:"), "{yaml}");
+    assert!(yaml.contains("infer:"), "hello must use infer");
+    assert!(!yaml.contains("agent:"), "hello must not use agent");
+}
+
+#[test]
+fn parse_failure_diagnostic_does_not_expose_workflow_body() {
+    const SENTINEL: &str = "nika-test-secret-do-not-log";
+    let yaml =
+        format!("nika: test\nsecrets:\n  token: {SENTINEL}\ntasks:\n  greet:\n    infer: [\n");
+
+    let result = std::panic::catch_unwind(|| assert_parses(&yaml));
+    assert!(
+        result.is_err(),
+        "invalid workflow must fail the parse assertion"
+    );
+    let payload = match result {
+        Ok(()) => return,
+        Err(payload) => payload,
+    };
+    let message = payload
+        .downcast_ref::<String>()
+        .map(String::as_str)
+        .or_else(|| payload.downcast_ref::<&str>().copied());
+    assert!(
+        message.is_some(),
+        "parse assertion must carry a string diagnostic"
+    );
+    let Some(message) = message else {
+        return;
+    };
+
+    assert!(
+        message == "first-wow yaml must parse",
+        "parse assertion must use its static diagnostic"
+    );
+    assert!(
+        !message.contains(SENTINEL),
+        "parse diagnostics must not expose workflow secrets"
+    );
 }
 
 #[test]
@@ -435,10 +463,16 @@ fn harness_first_wow_is_infer_mock_so_the_printed_next_runs() {
     assert_eq!(choice.arrow, "harness");
     let yaml = first_wow_yaml(&choice);
     assert_hello_is_mock_echo(&yaml);
-    assert!(!yaml.contains("ollama/"), "{yaml}");
-    assert!(!yaml.contains("xai/grok-4"), "{yaml}");
-    assert!(!yaml.contains("harness/claude"), "{yaml}");
-    assert!(yaml.contains("yaml-language-server"), "{yaml}");
+    assert!(!yaml.contains("ollama/"), "hello must not select Ollama");
+    assert!(!yaml.contains("xai/grok-4"), "hello must not select Grok");
+    assert!(
+        !yaml.contains("harness/claude"),
+        "hello must not select a harness seat"
+    );
+    assert!(
+        yaml.contains("yaml-language-server"),
+        "hello must retain the language-server directive"
+    );
     assert_parses(&yaml);
 }
 
@@ -465,7 +499,7 @@ fn local_unready_first_wow_runs_on_mock_echo() {
         !yaml
             .lines()
             .any(|l| l.starts_with("model: ") && l.contains("unsloth/")),
-        "Hub ids are pull targets, not model: values:\n{yaml}"
+        "Hub ids are pull targets, not model values"
     );
     assert_parses(&yaml);
     let dir = tempfile::tempdir().expect("tmp");
@@ -479,12 +513,17 @@ fn local_unready_first_wow_runs_on_mock_echo() {
 fn write_first_wow_refuses_without_force() {
     let dir = tempfile::tempdir().expect("tmp");
     let dest = dir.path().join("hello.nika.yaml");
-    std::fs::write(&dest, "stale\n").expect("seed");
+    let existing = "secrets:\n  token: nika-test-secret-do-not-log\n";
+    std::fs::write(&dest, existing).expect("seed");
     let choice = collect_from(&machine(Some(18), vec![], false, &[], true));
     let out = write_first_wow_from(&dest, false, &choice);
     assert_ne!(out.code, 0);
     assert!(out.text.contains("--force"), "{}", out.text);
-    assert_eq!(std::fs::read_to_string(&dest).expect("kept"), "stale\n");
+    let kept = std::fs::read_to_string(&dest).expect("kept");
+    assert!(
+        kept == existing,
+        "refusal must preserve the existing workflow"
+    );
 }
 
 #[test]

--- a/crates/nika-onboard/src/guided/tests.rs
+++ b/crates/nika-onboard/src/guided/tests.rs
@@ -46,8 +46,8 @@ fn dest(tag: &str) -> String {
 fn exact_template_name_stays_the_fast_path() {
     let d = dest("exact");
     let out = run("chain", Some(&d), true);
-    assert_eq!(out.code, codes::OK, "{}", out.text);
-    assert!(!out.text.contains("routed"), "{}", out.text);
+    assert_eq!(out.code, codes::OK);
+    assert!(!out.text.contains("routed"));
     std::fs::remove_file(&d).ok();
 }
 
@@ -64,29 +64,29 @@ fn example_sources_land_verbatim_through_new() {
     let dest_s = dest.to_string_lossy().into_owned();
 
     let out = run("01-hello", Some(&dest_s), false);
-    assert_eq!(out.code, codes::OK, "{}", out.text);
-    assert!(out.text.contains("example `01-hello`"), "{}", out.text);
-    assert!(out.text.contains("nika check"), "{}", out.text);
+    assert_eq!(out.code, codes::OK);
+    assert!(out.text.contains("example `01-hello`"));
+    assert!(out.text.contains("nika check"));
     // Verbatim MINUS the pack's self-referential path: the `# Run ·`
     // comment inside the OWNED copy must name the owned file — pasting
     // the pack path exited 3 in the user's workspace (gauntlet 08-01).
     let landed = std::fs::read_to_string(&dest).expect("written");
     // B01 stamps hello / 01-hello onto mock/echo (the pack lesson still
     // names ollama). Self-referential pack path still re-points.
-    assert_eq!(
-        landed,
-        stamp(
-            &nika_pack::example("01-hello")
-                .expect("embedded")
-                .replace("examples/01-hello.nika.yaml", &dest_s),
-            "hello",
-            Some("mock/echo"),
-        ),
+    assert!(
+        landed
+            == stamp(
+                &nika_pack::example("01-hello")
+                    .expect("embedded")
+                    .replace("examples/01-hello.nika.yaml", &dest_s),
+                "hello",
+                Some("mock/echo"),
+            ),
         "B01 rehearsal take, self-reference re-pointed to the owned dest"
     );
     assert!(
         !landed.contains("examples/01-hello.nika.yaml"),
-        "no taught command may name the pack-only path: {landed}"
+        "no taught command may name the pack-only path"
     );
     // Filename form resolves too; overwrite refuses. FLIP
     // (2026-07-31): this used to probe `showcase/t1-price-watch` —
@@ -101,12 +101,12 @@ fn example_sources_land_verbatim_through_new() {
     );
     assert_eq!(run("01-hello", Some(&dest_s), false).code, codes::ENV);
     let show = run("price-watch", Some(&dest_s), true);
-    assert_eq!(show.code, codes::OK, "{}", show.text);
-    assert_eq!(
-        std::fs::read_to_string(&dest).expect("written"),
-        nika_pack::example("price-watch")
-            .expect("embedded")
-            .replace("examples/price-watch.nika.yaml", &dest_s),
+    assert_eq!(show.code, codes::OK);
+    assert!(
+        std::fs::read_to_string(&dest).expect("written")
+            == nika_pack::example("price-watch")
+                .expect("embedded")
+                .replace("examples/price-watch.nika.yaml", &dest_s),
         "verbatim, self-reference re-pointed — a flat-corpus example"
     );
 
@@ -131,16 +131,14 @@ fn a_routed_cadence_intent_carries_the_schedule_note() {
         Some(&dest_s),
         false,
     );
-    assert_eq!(out.code, codes::OK, "{}", out.text);
+    assert_eq!(out.code, codes::OK);
     assert!(
         out.text.contains("is a schedule") && out.text.contains("chaque lundi"),
-        "the dropped cadence half is named: {}",
-        out.text
+        "the dropped cadence half must be named"
     );
     assert!(
         out.text.contains("cron"),
-        "the note points at the trigger owner: {}",
-        out.text
+        "the note must point at the trigger owner"
     );
 
     // No cadence — no note (the note never becomes noise).
@@ -150,8 +148,8 @@ fn a_routed_cadence_intent_carries_the_schedule_note() {
         Some(&dest2.to_string_lossy()),
         false,
     );
-    assert_eq!(out.code, codes::OK, "{}", out.text);
-    assert!(!out.text.contains("is a schedule"), "{}", out.text);
+    assert_eq!(out.code, codes::OK);
+    assert!(!out.text.contains("is a schedule"));
 
     let _ = std::fs::remove_dir_all(&dir);
 }
@@ -164,21 +162,19 @@ fn a_routed_cadence_intent_carries_the_schedule_note() {
 #[test]
 fn discovery_query_lists_the_set_without_a_dest() {
     let out = run("?", None, false);
-    assert_eq!(out.code, codes::OK, "{}", out.text);
-    assert!(out.text.contains("embedded set:"), "{}", out.text);
+    assert_eq!(out.code, codes::OK);
+    assert!(out.text.contains("embedded set:"));
     assert!(
         out.text
             .contains("routes across jobs · lessons · skeletons"),
-        "the discovery surface must name the whole intent-routing corpus: {}",
-        out.text
+        "the discovery surface must name the whole intent-routing corpus"
     );
     assert!(
         !out.text.contains("closest skeleton"),
-        "the router is broader than the skeleton set: {}",
-        out.text
+        "the router must be broader than the skeleton set"
     );
     for name in nika_pack::template_names() {
-        assert!(out.text.contains(&name), "lists `{name}`: {}", out.text);
+        assert!(out.text.contains(&name), "must list `{name}`");
     }
 }
 
@@ -200,29 +196,30 @@ fn discovery_taglines_come_from_the_bodies() {
 #[test]
 fn known_template_without_dest_asks_for_a_path() {
     let out = run("chain", None, false);
-    assert_eq!(out.code, codes::ENV, "{}", out.text);
-    assert!(out.text.contains("pass a destination"), "{}", out.text);
+    assert_eq!(out.code, codes::ENV);
+    assert!(out.text.contains("pass a destination"));
 }
 
 #[test]
 fn parallel_intent_routes_to_fanout() {
     let d = dest("par");
     let out = run("summarize every item in parallel", Some(&d), true);
-    assert_eq!(out.code, codes::OK, "{}", out.text);
+    assert_eq!(out.code, codes::OK);
     assert!(
         out.text.contains("routed intent → template `fanout`"),
-        "{}",
-        out.text
+        "must name the routed fanout template"
     );
     assert!(
         !out.text.contains("is a schedule"),
-        "per-item fan-out must not be described as cadence: {}",
-        out.text
+        "per-item fan-out must not be described as cadence"
     );
     // Own-corpus by construction: the instantiated file IS the
     // embedded template verbatim.
     let written = std::fs::read_to_string(&d).expect("file written");
-    assert_eq!(Some(written.as_str()), nika_pack::template("fanout"));
+    assert!(
+        Some(written.as_str()) == nika_pack::template("fanout"),
+        "written workflow must match the fanout template"
+    );
     std::fs::remove_file(&d).ok();
 }
 
@@ -240,8 +237,8 @@ fn an_agentic_research_intent_routes_to_the_job_then_the_skeleton() {
         Some(&d),
         true,
     );
-    assert_eq!(out.code, codes::OK, "{}", out.text);
-    assert!(out.text.contains("deep-research-brief"), "{}", out.text);
+    assert_eq!(out.code, codes::OK);
+    assert!(out.text.contains("deep-research-brief"));
     assert!(
         matches!(
             crate::intent::route_skeletons("an autonomous budgeted agent that researches a topic"),
@@ -260,11 +257,10 @@ fn approval_intent_routes_to_a_gated_template() {
         Some(&d),
         true,
     );
-    assert_eq!(out.code, codes::OK, "{}", out.text);
+    assert_eq!(out.code, codes::OK);
     assert!(
         out.text.contains("`human-gated-ship`") || out.text.contains("`gate-and-act`"),
-        "a gated template must win: {}",
-        out.text
+        "a gated template must win"
     );
     std::fs::remove_file(&d).ok();
 }
@@ -274,8 +270,8 @@ fn zero_evidence_intent_keeps_the_wire_contract_error() {
     // Gibberish shares no term with any template — the honest unknown
     // (exit 2) still names the set on the `embedded set:` wire line.
     let out = run("zzzz qqqq xxxx", Some(&dest("zero")), true);
-    assert_eq!(out.code, codes::FILE, "{}", out.text);
-    assert!(out.text.contains("embedded set:"), "{}", out.text);
+    assert_eq!(out.code, codes::FILE);
+    assert!(out.text.contains("embedded set:"));
 }
 
 // NOTE · the bare-`nika new`-in-a-pipe contract (fail fast naming
@@ -287,7 +283,7 @@ fn zero_evidence_intent_keeps_the_wire_contract_error() {
 fn dispatch_with_a_template_is_the_flag_path_unchanged() {
     let d = dest("dispatch");
     let out = dispatch(Some("chain"), Some(&d), true, PLAIN, &stub_audit);
-    assert_eq!(out.code, codes::OK, "{}", out.text);
+    assert_eq!(out.code, codes::OK);
     std::fs::remove_file(&d).ok();
 }
 
@@ -311,7 +307,7 @@ fn resolve_template_covers_the_four_rungs() {
         _ => None,
     }
     .expect("zero evidence is the said fallback, not a silent chain");
-    assert!(candidates.is_empty(), "{candidates:?}");
+    assert!(candidates.is_empty());
     // Below the margin → the fallback NAMES the coin-flip pair.
     let candidates =
         match resolve_template("Chaque lundi compare three competitors and write a French brief") {
@@ -321,7 +317,7 @@ fn resolve_template_covers_the_four_rungs() {
         .expect("a coin-flip falls back, said");
     assert!(
         candidates.contains(&"media-asset-pack".to_owned()),
-        "{candidates:?}"
+        "fallback candidates must include media-asset-pack"
     );
 }
 
@@ -332,11 +328,11 @@ fn the_ollama_note_drops_local_under_an_endpoint_override() {
     // point the engine at a LAN box.
     assert!(ollama_note_for(false).contains("local"));
     let overridden = ollama_note_for(true);
-    assert!(!overridden.contains("local"), "{overridden}");
-    assert!(overridden.contains("custom endpoint"), "{overridden}");
+    assert!(!overridden.contains("local"));
+    assert!(overridden.contains("custom endpoint"));
     assert!(
         overridden.contains("zero key"),
-        "the protocol truth stays: {overridden}"
+        "the protocol truth must stay"
     );
 }
 
@@ -346,11 +342,11 @@ fn the_model_menu_derives_from_the_catalog_local_first() {
     assert!(menu.len() >= 2, "catalog carries the menu providers");
     assert!(
         menu[0].0.starts_with("ollama/"),
-        "local first (presentation order): {menu:?}"
+        "local must be first in presentation order"
     );
-    assert!(menu[1].0.starts_with("mock/"), "offline second: {menu:?}");
+    assert!(menu[1].0.starts_with("mock/"), "offline must be second");
     // Every entry is a full provider/model wire id from the catalog.
-    assert!(menu.iter().all(|(m, _)| m.contains('/')), "{menu:?}");
+    assert!(menu.iter().all(|(m, _)| m.contains('/')));
 }
 
 /// P0-8 · a non-empty pick that is neither a menu number nor a
@@ -365,10 +361,14 @@ fn ask_model_reasks_an_unrecognized_pick() {
         .expect("not cancelled");
     assert!(
         model.starts_with("mock/"),
-        "Enter after the re-ask: {model}"
+        "Enter after the re-ask must select mock"
     );
-    let shown = String::from_utf8(out).expect("utf8");
-    assert!(shown.contains("unrecognized"), "the typo is said: {shown}");
+    let shown = String::from_utf8(out);
+    assert!(shown.is_ok(), "wizard output must be UTF-8");
+    let Some(shown) = shown.ok() else {
+        return;
+    };
+    assert!(shown.contains("unrecognized"), "the typo must be said");
 }
 
 #[test]
@@ -438,10 +438,12 @@ fn stamped_file_survives_a_hostile_model_string() {
             nika_schema::FileId::new(0),
             nika_schema::ParseMode::Strict,
         );
-        assert!(parsed.is_ok(), "model={model:?} must parse: {parsed:?}");
+        assert!(parsed.is_ok(), "catalog model must parse");
         // The check ladder must not choke either (a dirty audit is
         // fine; a PARSE error at this point is the bug).
-        let wf = parsed.expect("asserted ok above");
+        let Some(wf) = parsed.ok() else {
+            return;
+        };
         let _ = nika_check::check(&wf);
     }
 }
@@ -478,8 +480,10 @@ fn every_embedded_template_audits_clean_or_is_a_documented_gap() {
             nika_schema::FileId::new(0),
             nika_schema::ParseMode::Strict,
         );
-        assert!(parsed.is_ok(), "{name}: template must parse: {parsed:?}");
-        let wf = parsed.expect("asserted ok above");
+        assert!(parsed.is_ok(), "{name}: template must parse");
+        let Some(wf) = parsed.ok() else {
+            return;
+        };
         let is_gap = KNOWN_GAP.contains(&name.as_str());
         let report = nika_check::check(&wf);
         // #1066 amended the own-corpus law rather than retiring it. A
@@ -555,12 +559,14 @@ fn recovered_try_examples_parse_and_check() {
             nika_schema::FileId::new(0),
             nika_schema::ParseMode::Strict,
         );
-        assert!(parsed.is_ok(), "{slug} must parse: {parsed:?}");
-        let wf = parsed.expect("asserted ok");
+        assert!(parsed.is_ok(), "{slug} must parse");
+        let Some(wf) = parsed.ok() else {
+            return;
+        };
         let report = nika_check::check(&wf);
         assert!(
             report.is_clean() || report.findings.iter().all(|f| f.kind == "slot"),
-            "{slug}: recovered example fails check: {report:?}"
+            "{slug}: recovered example fails check"
         );
     }
 }
@@ -578,13 +584,12 @@ fn new_hello_equals_new_01_hello_and_rehearses_on_mock_echo() {
     let b_s = b.to_string_lossy().into_owned();
     let out_a = run("hello", Some(&a_s), true);
     let out_b = run("01-hello", Some(&b_s), true);
-    assert_eq!(out_a.code, codes::OK, "{}", out_a.text);
-    assert_eq!(out_b.code, codes::OK, "{}", out_b.text);
+    assert_eq!(out_a.code, codes::OK);
+    assert_eq!(out_b.code, codes::OK);
     let body_a = std::fs::read_to_string(&a).expect("a");
     let body_b = std::fs::read_to_string(&b).expect("b");
-    assert_eq!(
-        body_a.replace(&a_s, "<dest>"),
-        body_b.replace(&b_s, "<dest>"),
+    assert!(
+        body_a.replace(&a_s, "<dest>") == body_b.replace(&b_s, "<dest>"),
         "hello and 01-hello must land the same file"
     );
     let model = body_a
@@ -593,10 +598,10 @@ fn new_hello_equals_new_01_hello_and_rehearses_on_mock_echo() {
         .expect("model");
     assert!(
         model.contains("mock/echo"),
-        "the one hello is mock/echo: {model}"
+        "the one hello must use mock/echo"
     );
-    assert!(!model.to_ascii_lowercase().contains("local"), "{model}");
-    assert!(!body_a.contains("gpt-4o-mini"), "{body_a}");
+    assert!(!model.to_ascii_lowercase().contains("local"));
+    assert!(!body_a.contains("gpt-4o-mini"));
     let _ = std::fs::remove_dir_all(&dir);
 }
 
@@ -610,16 +615,14 @@ fn weekend_summary_of_three_urls_writes_or_names_fetch_chain() {
         let body = std::fs::read_to_string(&dest).expect("written");
         assert!(
             body.contains("nika: fetch-chain") || out.text.contains("05-fetch-chain"),
-            "wrote something else: {}\n{body}",
-            out.text
+            "must write or name fetch-chain"
         );
         std::fs::remove_file(&dest).ok();
     } else {
-        assert_eq!(out.code, codes::FILE, "{}", out.text);
+        assert_eq!(out.code, codes::FILE);
         assert!(
             out.text.contains("05-fetch-chain"),
-            "must name the closest slug: {}",
-            out.text
+            "must name the closest slug"
         );
         assert!(
             !std::path::Path::new(&dest).exists(),
@@ -637,20 +640,20 @@ fn stamp_comments_match_the_model_field() {
         .lines()
         .find(|l| l.starts_with("model: "))
         .expect("model line");
-    assert!(model.contains("openai/gpt-5.2"), "{model}");
+    assert!(model.contains("openai/gpt-5.2"));
     assert!(
         !model.to_ascii_lowercase().contains("local"),
-        "no « local » while openai: {model}"
+        "openai must not be described as local"
     );
     let mock = stamp(body, "hello", Some("mock/echo"));
     let mock_line = mock
         .lines()
         .find(|l| l.starts_with("model: "))
         .expect("model line");
-    assert!(mock_line.contains("mock/echo"), "{mock_line}");
+    assert!(mock_line.contains("mock/echo"));
     assert!(
         !mock_line.to_ascii_lowercase().contains("local"),
-        "no « local » while mock/echo: {mock_line}"
+        "mock must not be described as local"
     );
 }
 
@@ -673,9 +676,13 @@ fn read_wizard_three_enters_is_the_golden_path() {
     assert_eq!(w.template, "chain");
     assert_eq!(w.dest, "my-first.nika.yaml");
     assert!(w.model.as_deref().is_some_and(|m| m.starts_with("mock/")));
-    let shown = String::from_utf8(out).expect("utf8");
-    assert!(shown.contains("template `chain`"), "{shown}");
-    assert!(shown.contains("ollama/"), "menu shows local first: {shown}");
+    let shown = String::from_utf8(out);
+    assert!(shown.is_ok(), "wizard output must be UTF-8");
+    let Some(shown) = shown.ok() else {
+        return;
+    };
+    assert!(shown.contains("template `chain`"));
+    assert!(shown.contains("ollama/"), "menu must show local first");
     std::fs::remove_dir_all(&base).ok();
 }
 
@@ -699,14 +706,15 @@ fn read_wizard_skips_the_model_question_when_the_template_takes_none() {
     .expect("not cancelled");
     assert_eq!(w.template, "gate-and-act");
     assert_eq!(w.model, None, "no model harvested");
-    let shown = String::from_utf8(out).expect("utf8");
-    assert!(
-        shown.contains("models are per-task in this skeleton"),
-        "{shown}"
-    );
+    let shown = String::from_utf8(out);
+    assert!(shown.is_ok(), "wizard output must be UTF-8");
+    let Some(shown) = shown.ok() else {
+        return;
+    };
+    assert!(shown.contains("models are per-task in this skeleton"));
     assert!(
         !shown.contains("a number, or any provider/model"),
-        "the question must not fire: {shown}"
+        "the question must not fire"
     );
     std::fs::remove_dir_all(&base).ok();
 }
@@ -796,16 +804,11 @@ fn wizard_io_refuses_a_typed_existing_dest_and_force_overrides() {
         &mut out,
         &stub_audit,
     );
-    assert_eq!(v.code, codes::ENV, "{}", v.text);
+    assert_eq!(v.code, codes::ENV);
+    assert!(v.text.contains("--force"), "must teach the override");
     assert!(
-        v.text.contains("--force"),
-        "teaches the override: {}",
-        v.text
-    );
-    assert_eq!(
-        std::fs::read_to_string(base.join("my-first.nika.yaml")).expect("read"),
-        "taken",
-        "refused = untouched"
+        std::fs::read_to_string(base.join("my-first.nika.yaml")).expect("read") == "taken",
+        "refused destination must stay untouched"
     );
 
     let mut input2 = std::io::Cursor::new(b"\nmy-first\n\n".to_vec());
@@ -819,7 +822,7 @@ fn wizard_io_refuses_a_typed_existing_dest_and_force_overrides() {
         &mut out2,
         &stub_audit,
     );
-    assert_eq!(v2.code, codes::OK, "{}", v2.text);
+    assert_eq!(v2.code, codes::OK);
     assert!(
         std::fs::read_to_string(base.join("my-first.nika.yaml"))
             .expect("read")
@@ -845,11 +848,11 @@ fn wizard_io_materializes_a_stamped_file() {
         &mut out,
         &stub_audit,
     );
-    assert_eq!(v.code, codes::OK, "{}", v.text);
-    assert!(v.text.contains("scriptable form"), "{}", v.text);
+    assert_eq!(v.code, codes::OK);
+    assert!(v.text.contains("scriptable form"));
     // The wow contract: the wizard SHOWS the audit ladder — the file
     // arrives already checked, not with a suggestion to check.
-    assert!(v.text.contains("audited"), "the ladder ran: {}", v.text);
+    assert!(v.text.contains("audited"), "the ladder must run");
     let written = std::fs::read_to_string(dir.join("first.nika.yaml")).expect("file written");
     assert!(written.contains("nika: first"));
     std::fs::remove_dir_all(&dir).ok();
@@ -870,8 +873,7 @@ fn boilerplate_and_stopwords_do_not_route() {
     ] {
         assert!(
             !matches!(crate::intent::route(garbage), RoutingOutcome::Routed { .. }),
-            "`{garbage}` must not route · got {:?}",
-            crate::intent::route(garbage)
+            "`{garbage}` must not route"
         );
     }
     // …but a real intent still routes on its signal terms.
@@ -895,10 +897,10 @@ fn a_below_the_bar_intent_writes_nothing_and_names_the_candidates() {
         Some(&d),
         true,
     );
-    assert_eq!(out.code, codes::FILE, "{}", out.text);
+    assert_eq!(out.code, codes::FILE);
     assert!(!Path::new(&d).exists(), "below the bar = no write");
-    assert!(out.text.contains("competitor-radar"), "{}", out.text);
-    assert!(out.text.contains("website-brief"), "{}", out.text);
+    assert!(out.text.contains("competitor-radar"));
+    assert!(out.text.contains("website-brief"));
 }
 
 /// P0-10 · the routed file is a DRAFT: the message says so, never
@@ -907,11 +909,11 @@ fn a_below_the_bar_intent_writes_nothing_and_names_the_candidates() {
 fn a_confident_route_lands_a_draft_that_hands_over_to_check() {
     let d = dest("draft");
     let out = run("summarize every item in parallel", Some(&d), true);
-    assert_eq!(out.code, codes::OK, "{}", out.text);
+    assert_eq!(out.code, codes::OK);
     let lower = out.text.to_ascii_lowercase();
-    assert!(lower.contains("draft"), "{}", out.text);
-    assert!(!lower.contains("ready"), "{}", out.text);
-    assert!(out.text.contains("nika check"), "{}", out.text);
+    assert!(lower.contains("draft"));
+    assert!(!lower.contains("ready"));
+    assert!(out.text.contains("nika check"));
     std::fs::remove_file(&d).ok();
 }
 
@@ -927,7 +929,7 @@ fn taught_lines_survive_the_paste_back() {
         None,
         false,
     );
-    assert_eq!(out.code, codes::FILE, "{}", out.text);
+    assert_eq!(out.code, codes::FILE);
     let rest = out
         .text
         .split("take one by name (`")
@@ -942,12 +944,12 @@ fn taught_lines_survive_the_paste_back() {
     if nika_pack::template(name).is_some() {
         assert!(
             taught.ends_with("<dest>.nika.yaml"),
-            "a skeleton hint must teach its destination: {taught}"
+            "a skeleton hint must teach its destination"
         );
     } else {
         assert!(
             nika_pack::example(name).is_some(),
-            "the taught name must exist: {taught}"
+            "the taught name must exist"
         );
     }
 
@@ -959,12 +961,11 @@ fn taught_lines_survive_the_paste_back() {
     // probe leans on `docker`, which only the docker-report skeleton
     // carries.
     let out = run("report on my running docker containers", None, false);
-    assert_eq!(out.code, codes::ENV, "{}", out.text);
+    assert_eq!(out.code, codes::ENV);
     assert!(
         out.text
             .contains("nika new 'report on my running docker containers' <dest>.nika.yaml"),
-        "the taught paste-back is ONE shell argument: {}",
-        out.text
+        "the taught paste-back must be one shell argument"
     );
 }
 

--- a/crates/nika-runtime/src/admit.rs
+++ b/crates/nika-runtime/src/admit.rs
@@ -328,7 +328,7 @@ fn static_iterations(task: &RawTask) -> f64 {
             clippy::unreachable,
             reason = "non_exhaustive future variant — enum and runtime ship together"
         )]
-        other => unreachable!("unknown for_each form: {other:?}"),
+        _ => unreachable!("unsupported for_each form"),
     }
 }
 
@@ -522,8 +522,8 @@ fn map_pin_refusal(refusal: PinRefusal) -> RuntimeError {
         PinRefusal::NoPath { message } => RuntimeError::AccessNoPath { message },
         PinRefusal::Unavailable { message } => RuntimeError::AccessUnavailable { message },
         // Future classes fail closed until mapped explicitly.
-        other => RuntimeError::AccessNoPath {
-            message: format!("{other:?}"),
+        _ => RuntimeError::AccessNoPath {
+            message: "access pin refusal could not be classified".to_owned(),
         },
     }
 }
@@ -606,7 +606,7 @@ mod tests {
             nika_schema::FileId::new(0),
             nika_schema::ParseMode::Strict,
         )
-        .expect("fixture parses")
+        .unwrap_or_else(|_| panic!("fixture must parse"))
     }
 
     /// One `exec` task inside its declared boundary (clean report) · the
@@ -626,7 +626,7 @@ mod tests {
         runtime
             .run(wf, &report, &mut stamper, &mut sink)
             .await
-            .expect("run settles")
+            .unwrap_or_else(|_| panic!("run must settle"))
     }
 
     /// A refused run ABORTS at the preflight — the error, for inspection.
@@ -640,11 +640,11 @@ mod tests {
         let err = runtime
             .run(wf, &report, &mut stamper, &mut sink)
             .await
-            .expect_err("an unsatisfied required input never reaches dispatch");
+            .err()
+            .unwrap_or_else(|| panic!("a refused run must never reach dispatch"));
         assert!(
             sink.events().is_empty(),
-            "refused BEFORE any event — not even the prologue: {:?}",
-            sink.events()
+            "refusal must happen before any event, including the prologue"
         );
         err
     }
@@ -656,7 +656,7 @@ mod tests {
         ));
         let err = required_inputs_refusal(&wf, &BTreeMap::new()).expect("two unsatisfied");
         let RuntimeError::MissingRequiredInputs { missing, declared } = &err else {
-            panic!("expected MissingRequiredInputs, got {err:?}");
+            panic!("expected MissingRequiredInputs");
         };
         // Declaration order — the author's own reading order.
         assert_eq!(missing, &["needle", "region"]);
@@ -700,12 +700,14 @@ mod tests {
         let err = run_refused(&runtime, &wf).await;
         assert_eq!(err.spec_code(), "NIKA-1708");
         let msg = err.to_string();
-        assert!(msg.contains("`needle`"), "the input is named: {msg}");
-        assert!(msg.contains("--var needle=<value>"), "the fix rides: {msg}");
+        assert!(msg.contains("`needle`"), "the input must be named");
+        assert!(
+            msg.contains("--var needle=<value>"),
+            "the remediation must ride"
+        );
         assert!(
             probe.executed_commands().is_empty(),
-            "not one task spent: {:?}",
-            probe.executed_commands()
+            "not one task may execute"
         );
     }
 
@@ -767,7 +769,9 @@ mod tests {
         let full = scope_to_task(wf.clone(), "report").expect("report scopes");
         assert_eq!(full.tasks.len(), 4, "the sink's cone is the whole diamond");
 
-        let err = scope_to_task(wf, "nope").expect_err("unknown id refused");
+        let err = scope_to_task(wf, "nope")
+            .err()
+            .unwrap_or_else(|| panic!("unknown task id must be refused"));
         assert!(
             err.contains("nope") && err.contains("discover"),
             "names the id + the available set"
@@ -794,10 +798,10 @@ mod tests {
     #[test]
     fn floor_above_budget_refuses_with_both_numbers() {
         let msg = floor_refusal(0.000_019, 0.000_001).expect("refuses");
-        assert!(msg.contains("$0.000019"), "floor rides: {msg}");
-        assert!(msg.contains("$0.000001"), "budget rides: {msg}");
-        assert!(msg.contains("refusing to start"), "{msg}");
-        assert!(msg.contains("nika check"), "points at the envelope: {msg}");
+        assert!(msg.contains("$0.000019"), "floor must ride");
+        assert!(msg.contains("$0.000001"), "budget must ride");
+        assert!(msg.contains("refusing to start"));
+        assert!(msg.contains("nika check"), "must point at the envelope");
     }
 
     #[test]
@@ -829,10 +833,10 @@ mod tests {
             .expect("a floor above the budget refuses at admission");
         assert!(
             matches!(err, RuntimeError::BudgetFloor { .. }),
-            "the launch-abort variant: {err:?}"
+            "must use the launch-abort variant"
         );
-        assert!(err.to_string().starts_with("NIKA-1709"), "{err}");
-        assert!(err.to_string().contains("refusing to start"), "{err}");
+        assert!(err.to_string().starts_with("NIKA-1709"));
+        assert!(err.to_string().contains("refusing to start"));
         // The sparing arms: no budget · a floor that fits.
         assert!(budget_floor_refusal(&wf, &report, None, None).is_none());
         assert!(budget_floor_refusal(&wf, &report, Some(999.0), None).is_none());
@@ -859,7 +863,7 @@ mod tests {
         );
         assert!(
             matches!(err, Some(RuntimeError::BudgetFloor { .. })),
-            "the overridden (effective) model's floor trips the gate: {err:?}"
+            "the overridden effective model's floor must trip the gate"
         );
 
         let yaml = "nika: m\nmodel: \"anthropic/claude-sonnet-5\"\ntasks:\n  \
@@ -880,10 +884,7 @@ mod tests {
     fn priced_image_builtin_floor_exceeds_a_tiny_cap() {
         let wf = parse(&image_generate_wf("xai"));
         let report = nika_check::check(&wf);
-        assert!(
-            report.is_clean(),
-            "the fixture must check clean: {report:?}"
-        );
+        assert!(report.is_clean(), "the fixture must check clean");
         assert_eq!(
             report.cost.min_path_total_usd, 0.0,
             "check still skips invoke — the hole this gate closes"
@@ -892,12 +893,12 @@ mod tests {
             .expect("a $0.02 builtin floor refuses a $0.001 cap");
         assert_eq!(err.spec_code(), "NIKA-1709");
         let msg = err.to_string();
-        assert!(msg.contains("refusing to start"), "{msg}");
-        assert!(msg.contains("$0.020000"), "catalog floor rides: {msg}");
-        assert!(msg.contains("$0.001000"), "cap rides: {msg}");
+        assert!(msg.contains("refusing to start"));
+        assert!(msg.contains("$0.020000"), "catalog floor must ride");
+        assert!(msg.contains("$0.001000"), "cap must ride");
         assert!(
             !msg.contains("spent $"),
-            "preflight, not the NIKA-1704 spend-then-apologise: {msg}"
+            "preflight must not report post-spend state"
         );
         assert!(budget_floor_refusal(&wf, &report, Some(1.00), None).is_none());
         assert!(budget_floor_refusal(&wf, &report, None, None).is_none());
@@ -917,7 +918,7 @@ mod tests {
         let report = nika_check::check(&wf);
         assert!(
             report.is_clean(),
-            "the canary must check clean so admission owns the refuse: {report:?}"
+            "the canary must check clean so admission owns the refusal"
         );
         let ep = report
             .data_journey
@@ -925,16 +926,16 @@ mod tests {
             .iter()
             .find(|e| e.task == "ping")
             .expect("canary endpoint");
-        assert!(!ep.priced, "canary stays unpriced: {ep:?}");
+        assert!(!ep.priced, "canary must stay unpriced");
         assert_eq!(ep.locus, nika_check::EndpointLocus::Cloud);
         let err = budget_floor_refusal(&wf, &report, Some(0.01), None)
             .expect("unpriced cloud + cap 0.01 must refuse");
         assert_eq!(err.spec_code(), "NIKA-1709");
         let msg = err.to_string();
-        assert!(msg.contains("refusing to start"), "{msg}");
-        assert!(msg.contains("unpriced"), "{msg}");
-        assert!(msg.contains("nika-b20-unpriced-canary"), "{msg}");
-        assert!(msg.contains("0.010000"), "cap rides: {msg}");
+        assert!(msg.contains("refusing to start"));
+        assert!(msg.contains("unpriced"));
+        assert!(msg.contains("nika-b20-unpriced-canary"));
+        assert!(msg.contains("0.010000"), "cap must ride");
         assert!(
             budget_floor_refusal(&wf, &report, None, None).is_none(),
             "no cap → unpriced cloud may still start"
@@ -947,7 +948,7 @@ mod tests {
             "nika: b20-mock\nmodel: mock/echo\npermits: {}\ntasks:\n  ping:\n    infer: { prompt: \"PONG\", max_tokens: 16 }\n",
         );
         let report = nika_check::check(&wf);
-        assert!(report.is_clean(), "mock rehearsal checks clean: {report:?}");
+        assert!(report.is_clean(), "mock rehearsal must check clean");
         assert!(
             budget_floor_refusal(&wf, &report, Some(0.01), None).is_none(),
             "mock is a proven zero — a cap must not refuse the rehearsal"
@@ -967,7 +968,7 @@ mod tests {
             .iter()
             .find(|e| e.task == "ping")
             .expect("local endpoint");
-        assert!(!ep.priced, "local stays unpriced-not-free: {ep:?}");
+        assert!(!ep.priced, "local must stay unpriced-not-free");
         assert_eq!(ep.locus, nika_check::EndpointLocus::Local);
         assert!(
             budget_floor_refusal(&wf, &report, None, None).is_none(),
@@ -991,11 +992,10 @@ mod tests {
             .iter()
             .find(|e| e.task == "ping")
             .expect("flash endpoint");
-        assert!(ep.priced, "flash is the snapshot row: {ep:?}");
+        assert!(ep.priced, "flash must be the snapshot row");
         assert!(
             budget_floor_refusal(&wf, &report, Some(0.20), None).is_none(),
-            "priced flash under $0.20 must start: floor {}",
-            report.cost.min_path_total_usd
+            "priced flash under $0.20 must start"
         );
     }
 
@@ -1006,18 +1006,15 @@ mod tests {
         let err = run_refused(&runtime, &wf).await;
         assert_eq!(err.spec_code(), "NIKA-1709");
         let msg = err.to_string();
-        assert!(msg.contains("refusing to start"), "{msg}");
-        assert!(msg.contains("unpriced"), "{msg}");
+        assert!(msg.contains("refusing to start"));
+        assert!(msg.contains("unpriced"));
     }
 
     #[test]
     fn mock_image_builtin_has_no_static_floor() {
         let wf = parse(&image_generate_wf("mock"));
         let report = nika_check::check(&wf);
-        assert!(
-            report.is_clean(),
-            "mock image fixture checks clean: {report:?}"
-        );
+        assert!(report.is_clean(), "mock image fixture must check clean");
         assert!(
             budget_floor_refusal(&wf, &report, Some(0.001), None).is_none(),
             "mock/local image is unpriced — a tight cap must not refuse the rehearsal"
@@ -1036,12 +1033,11 @@ mod tests {
         assert_eq!(err.spec_code(), "NIKA-1709");
         assert!(
             probe.captured_calls().is_empty(),
-            "no executor call recorded: {:?}",
-            probe.captured_calls()
+            "no executor call may be recorded"
         );
         let msg = err.to_string();
-        assert!(!msg.contains("cost_usd"), "{msg}");
-        assert!(!msg.contains("spent $0.02"), "{msg}");
+        assert!(!msg.contains("cost_usd"));
+        assert!(!msg.contains("spent $0.02"));
     }
 
     #[tokio::test]
@@ -1053,12 +1049,7 @@ mod tests {
         let runtime = runtime.with_max_cost_usd(Some(1.00));
         let outcome = run(&runtime, &wf).await;
         assert!(outcome.ok, "cap 1.00 admits a $0.02 floor");
-        assert_eq!(
-            probe.captured_calls().len(),
-            1,
-            "the stub ran: {:?}",
-            probe.captured_calls()
-        );
+        assert_eq!(probe.captured_calls().len(), 1, "the stub must run once");
         assert_eq!(probe.captured_calls()[0].name, "nika:image_generate");
     }
 
@@ -1083,7 +1074,7 @@ mod tests {
         .expect_err("both gates could fire — the input gate speaks first");
         assert!(
             matches!(err, RuntimeError::MissingRequiredInputs { .. }),
-            "the input gate precedes: {err:?}"
+            "the input gate must precede"
         );
         // With the input satisfied, the budget floor is the word.
         let mut overrides = BTreeMap::new();
@@ -1092,7 +1083,7 @@ mod tests {
             .expect_err("the budget gate fires once inputs are satisfied");
         assert!(
             matches!(err, RuntimeError::BudgetFloor { .. }),
-            "the budget gate then owns the refusal: {err:?}"
+            "the budget gate must then own the refusal"
         );
     }
 
@@ -1154,12 +1145,9 @@ mod tests {
         let (wf, report) = mistral_wf();
         let (pin, probes) = (Some("locale"), &[]);
         let err = access_pin_refusal(&wf, &report, probes, pin, None).expect("typo refused");
-        assert!(
-            matches!(err, RuntimeError::AccessUnknownToken { .. }),
-            "{err:?}"
-        );
-        assert!(err.to_string().contains("locale"), "{err}");
-        assert!(err.to_string().contains("NIKA-1802"), "{err}");
+        assert!(matches!(err, RuntimeError::AccessUnknownToken { .. }));
+        assert!(err.to_string().contains("locale"));
+        assert!(err.to_string().contains("NIKA-1802"));
     }
 
     #[test]
@@ -1175,11 +1163,8 @@ mod tests {
             )],
         );
         let err = access_pin_refusal(&wf, &report, probes, pin, None).expect("pin unsatisfied");
-        assert!(
-            matches!(err, RuntimeError::AccessPinUnsatisfied { .. }),
-            "{err:?}"
-        );
-        assert!(err.to_string().contains("never a substitute"), "{err}");
+        assert!(matches!(err, RuntimeError::AccessPinUnsatisfied { .. }));
+        assert!(err.to_string().contains("never a substitute"));
     }
 
     #[test]
@@ -1187,12 +1172,9 @@ mod tests {
         let (wf, report) = mistral_wf();
         let err = access_pin_refusal(&wf, &report, &[], Some("claude-code"), None)
             .expect("known token refused");
-        assert!(
-            matches!(err, RuntimeError::AccessUnavailable { .. }),
-            "{err:?}"
-        );
-        assert!(err.to_string().contains("NIKA-1803"), "{err}");
-        assert!(!err.to_string().contains("NIKA-1802"), "{err}");
+        assert!(matches!(err, RuntimeError::AccessUnavailable { .. }));
+        assert!(err.to_string().contains("NIKA-1803"));
+        assert!(!err.to_string().contains("NIKA-1802"));
     }
 
     #[cfg(feature = "access-harness")]
@@ -1211,7 +1193,7 @@ mod tests {
         .with_serves(vec!["anthropic".to_owned()]);
         let err = access_pin_refusal(&wf, &report, &[probe], Some("claude-code"), None)
             .expect("ACP alone is not an infer-grade proof");
-        assert!(matches!(err, RuntimeError::AccessNoPath { .. }), "{err:?}");
+        assert!(matches!(err, RuntimeError::AccessNoPath { .. }));
         let witness = err.to_string();
         for term in [
             "claude-code",
@@ -1220,7 +1202,7 @@ mod tests {
             "structured_output",
             "model_identity",
         ] {
-            assert!(witness.contains(term), "missing {term}: {witness}");
+            assert!(witness.contains(term), "missing witness term: {term}");
         }
     }
 
@@ -1251,12 +1233,9 @@ mod tests {
             )],
         );
         let err = access_pin_refusal(&wf, &report, probes, pin, None).expect("no runtime");
-        assert!(
-            matches!(err, RuntimeError::AccessUnavailable { .. }),
-            "{err:?}"
-        );
-        assert!(err.to_string().contains("NIKA-1803"), "{err}");
-        assert!(!err.to_string().contains("API_KEY"), "{err}");
+        assert!(matches!(err, RuntimeError::AccessUnavailable { .. }));
+        assert!(err.to_string().contains("NIKA-1803"));
+        assert!(!err.to_string().contains("API_KEY"));
     }
 
     #[test]
@@ -1272,8 +1251,8 @@ mod tests {
             )],
         );
         let err = access_pin_refusal(&wf, &report, probes, pin, None).expect("path inadmissible");
-        assert!(matches!(err, RuntimeError::AccessNoPath { .. }), "{err:?}");
-        assert!(err.to_string().contains("MISTRAL_API_KEY unset"), "{err}");
+        assert!(matches!(err, RuntimeError::AccessNoPath { .. }));
+        assert!(err.to_string().contains("MISTRAL_API_KEY unset"));
     }
 
     #[test]
@@ -1319,14 +1298,11 @@ mod tests {
         );
         let err = access_pin_refusal(&wf, &report, &[probe], Some("harness"), None)
             .expect("mock must never substitute a live harness");
-        assert!(
-            matches!(err, RuntimeError::AccessPinUnsatisfied { .. }),
-            "{err:?}"
-        );
+        assert!(matches!(err, RuntimeError::AccessPinUnsatisfied { .. }));
         let witness = err.to_string();
-        assert!(witness.contains("mock/echo"), "{witness}");
-        assert!(witness.contains("--access mock"), "{witness}");
-        assert!(witness.contains("never a live substitute"), "{witness}");
+        assert!(witness.contains("mock/echo"));
+        assert!(witness.contains("--access mock"));
+        assert!(witness.contains("never a live substitute"));
     }
 
     #[test]
@@ -1375,14 +1351,14 @@ mod tests {
              a:\n    infer: { prompt: hi, model: \"anthropic/claude-sonnet-5\" }\n  \
              b:\n    infer: { prompt: hi, max_tokens: 100, model: \"ollama/llama3\" }\n",
         );
-        assert!(msg.contains("2 task(s)"), "{msg}");
+        assert!(msg.contains("2 task(s)"));
         assert!(
             msg.contains("1 with no `max_tokens`"),
-            "the priced-unbounded task: {msg}"
+            "the priced-unbounded task must be classified"
         );
         assert!(
             msg.contains("1 on an unpriced model"),
-            "the local task: {msg}"
+            "the local task must be classified"
         );
     }
 
@@ -1402,8 +1378,8 @@ mod tests {
         );
         assert!(
             msg.contains("1 task(s)"),
-            "only the unpriced local task: {msg}"
+            "only the unpriced local task must count"
         );
-        assert!(msg.contains("unpriced model"), "{msg}");
+        assert!(msg.contains("unpriced model"));
     }
 }

--- a/crates/nika-runtime/src/admit_resolved_tests.rs
+++ b/crates/nika-runtime/src/admit_resolved_tests.rs
@@ -37,7 +37,7 @@ fn parse(yaml: &str) -> RawWorkflow {
         nika_schema::FileId::new(0),
         nika_schema::ParseMode::Strict,
     )
-    .expect("fixture parses")
+    .unwrap_or_else(|_| panic!("fixture must parse"))
 }
 
 fn runtime_with(shell: MockShell) -> MockRuntime {
@@ -72,11 +72,11 @@ async fn run_refused(runtime: &MockRuntime, wf: &RawWorkflow) -> RuntimeError {
     let err = runtime
         .run(wf, &report, &mut stamper, &mut sink)
         .await
-        .expect_err("an unpriced cloud seat under a cap never reaches dispatch");
+        .err()
+        .unwrap_or_else(|| panic!("a refused run must never reach dispatch"));
     assert!(
         sink.events().is_empty(),
-        "refused BEFORE any event — not even the prologue: {:?}",
-        sink.events()
+        "refusal must happen before any event, including the prologue"
     );
     err
 }
@@ -103,12 +103,11 @@ fn static_report_misses_a_var_resolved_unpriced_cloud_seat() {
     let report = nika_check::check(&wf);
     assert!(
         report.is_clean(),
-        "unjudged run-time model is not dirty: {report:?}"
+        "unjudged run-time model must not be dirty"
     );
     assert!(
         report.data_journey.model_endpoints.is_empty(),
-        "no default → check cannot name the seat: {:?}",
-        report.data_journey.model_endpoints
+        "without a default, check must not name the seat"
     );
     assert!(
         budget_floor_refusal(&wf, &report, Some(0.20), None).is_none(),
@@ -133,9 +132,9 @@ fn var_resolved_unpriced_cloud_plus_cap_refuses_to_start() {
     .expect_err("resolved gemini canary + $0.20 must NIKA-1709");
     assert_eq!(err.spec_code(), "NIKA-1709");
     let msg = err.to_string();
-    assert!(msg.contains("unpriced"), "{msg}");
-    assert!(msg.contains("nika-b20-unpriced-canary"), "{msg}");
-    assert!(msg.contains("0.200000"), "cap rides: {msg}");
+    assert!(msg.contains("unpriced"));
+    assert!(msg.contains("nika-b20-unpriced-canary"));
+    assert!(msg.contains("0.200000"), "cap must ride");
     assert!(
         gates(&wf, &report, &canary_override(), None, None, None, &[]).is_ok(),
         "no cap → unpriced cloud may still start"
@@ -154,7 +153,7 @@ fn priced_envelope_cel_overridden_to_unpriced_cloud_refuses() {
         .iter()
         .find(|e| e.task == "ping")
         .expect("check sees the priced default");
-    assert!(ep.priced, "static door looks priced: {ep:?}");
+    assert!(ep.priced, "static door must look priced");
     assert!(
         budget_floor_refusal(&wf, &report, Some(0.20), None).is_none(),
         "check JSON looks priced — the static walk admits"
@@ -181,8 +180,7 @@ fn cli_model_override_to_unpriced_cloud_refuses() {
             .model_endpoints
             .iter()
             .any(|e| e.priced && e.model.contains("gemini-2.5-flash")),
-        "file is priced flash: {:?}",
-        report.data_journey.model_endpoints
+        "file must be priced flash"
     );
     let err = budget_floor_refusal(
         &wf,


### PR DESCRIPTION
## Summary

- removes secret-bearing structured values from panic, assertion, and test diagnostics
- closes 16 high-severity `rust/cleartext-logging` annotations discovered after PR #1320 without suppressions or fake sanitizers
- keeps failure predicates and fail-closed behavior intact while replacing only diagnostic payloads with static messages

## CodeQL annotation mapping

- `crates/nika-check-analyzer/src/native_first.rs`: 1 annotation
- `crates/nika-check/src/tools.rs`: 1 annotation
- `crates/nika-cli-host/src/choice/tests.rs`: 1 annotation
- `crates/nika-onboard/src/guided/tests.rs`: 1 annotation
- `crates/nika-runtime/src/admit.rs`: 9 annotations
- `crates/nika-runtime/src/admit_resolved_tests.rs`: 3 annotations

Total: 16/16 source sinks addressed.

## Verification

- `cargo fmt --all -- --check`
- targeted `cargo test --lib` for `nika-check-analyzer`, `nika-check`, `nika-onboard`, and `nika-runtime`: 1,166 passed, 1 ignored
- targeted clippy for the four affected crates with `-D warnings`
- `nika-cli-host`: 266/266 library tests, targeted clippy with `-D warnings`, and two non-vacuous secret-sentinel tests
- `gitleaks stdin --redact=100` over the branch diff
- canonical `scripts/hooks/pre-push-gate.sh`: workspace lib tests green, workspace clippy green, hygiene non-red, all 11 CI ratchets passed
- independent adversarial review found four additional implicit `Debug` sinks during iteration; all were removed, and the final review verdict was `SURVIVED / SHIP`

## Limits

- local policy intentionally runs workspace library tests only; 143 integration files remain covered by CI nextest
- the security claim is not complete until this PR's exact CodeQL run is green
- no release, tag, version bump, or publication action is included
