### PR TITLE
fix: try sandbox host-tool tip + gauntlet proven_by rows

### DIFF
--- a/changelog.d/try-sandbox-host-tip.fixed.md
+++ b/changelog.d/try-sandbox-host-tip.fixed.md
@@ -1,0 +1,3 @@
+- **`nika try` names a missing host tool in the sandbox.**
+  `standup-digest` (git) and `03-exec-pipeline` (cargo) print a recover
+  tip instead of an opaque seatbelt, even under `--model mock/echo`.

--- a/crates/nika-cli/src/verbs/run/example.rs
+++ b/crates/nika-cli/src/verbs/run/example.rs
@@ -268,10 +268,25 @@ fn example_tip(
     override_given: bool,
     model: &str,
 ) -> Option<String> {
-    if verdict.code == exit::OK || override_given {
+    if verdict.code == exit::OK {
         return None;
     }
     let failure = verdict.failure.as_ref()?;
+    // B06/C06: the try sandbox is not a cargo tree and not a git repo.
+    // `--model` cannot conjure either, so this arm fires before the
+    // override short-circuit (a mock rehearsal still hits seatbelt).
+    if failure.code == "NIKA-SEC-001"
+        && let Some(hint) = nika_pack::try_recover_hint(slug)
+    {
+        let slug = slug.strip_suffix(".nika.yaml").unwrap_or(slug);
+        return Some(format!(
+            "tip: try sandbox has no `{}` ({}) · this job is off the first shelf.\n        to own a real workspace: nika new {slug}",
+            hint.missing, hint.recovered_as
+        ));
+    }
+    if override_given {
+        return None;
+    }
     // Infer/provider failures — the "no local model running" case: the
     // offline preview is one flag away (the funnel's highest-intent P0).
     if failure.code.starts_with("NIKA-INFER-") {
@@ -432,5 +447,26 @@ mod tests {
         // breach) carries nothing to key on — silence, not a guess.
         let bare_fail = RunVerdict::bare(exit::WORKFLOW);
         assert!(example_tip("01-hello", &bare_fail, false, "ollama/llama3.1").is_none());
+    }
+
+    /// B06/C06: seatbelt in the try sandbox names cargo/git, even when
+    /// `--model mock/echo` was passed (a model swap cannot conjure them).
+    #[test]
+    fn example_tip_seatbelt_names_the_missing_host_tool() {
+        let belt = failed(
+            "NIKA-SEC-001",
+            "command blocked: seatbelt refused the confined process (status 128)",
+        );
+        let git = example_tip("standup-digest", &belt, true, "mock/echo")
+            .expect("C06 must teach even under --model");
+        assert!(git.contains("`git`"), "{git}");
+        assert!(git.contains("nika new standup-digest"), "{git}");
+        let cargo = example_tip("03-exec-pipeline", &belt, true, "mock/echo")
+            .expect("B06 must teach even under --model");
+        assert!(cargo.contains("`cargo`"), "{cargo}");
+        assert!(
+            example_tip("01-hello", &belt, true, "mock/echo").is_none(),
+            "first-shelf jobs have no recover hint"
+        );
     }
 }

--- a/wiring.yaml
+++ b/wiring.yaml
@@ -337,6 +337,76 @@ capabilities:
     shipped_when: "never — catalog data only, no WireFormat seats it"
     reachable_by: "unreachable by design · nika check refuses at the MODELS rung"
     proven_by: rust
+  - id: gauntlet.b04-host-read
+    kind: operator-teaching
+    declared_at: crates/nika-cap/src/file_plumbing.rs:151
+    shipped_when: "default"
+    reachable_by: "nika check a file that nika:read /etc/passwd under fs.read ./**"
+    proven_by: rust
+    issue: 1294
+  - id: gauntlet.b05-host-exec
+    kind: operator-teaching
+    declared_at: crates/nika-cap/src/file_plumbing.rs:151
+    shipped_when: "default"
+    reachable_by: "nika check a file that exec cat /etc/passwd with permits.exec [cat]"
+    proven_by: rust
+    issue: 1295
+  - id: gauntlet.b18-grok-not-groq
+    kind: operator-teaching
+    declared_at: crates/nika-providers/src/profile.rs:664
+    shipped_when: "default"
+    reachable_by: "nika check a file with model: grok/grok-3"
+    proven_by: rust
+    issue: 1306
+  - id: gauntlet.n01-cel-model-cap
+    kind: operator-teaching
+    declared_at: crates/nika-runtime/src/admit_resolved_tests.rs:233
+    shipped_when: "default"
+    reachable_by: "nika run --max-cost-usd with ${{ inputs['model'] }} an unpriced cloud id"
+    proven_by: rust
+    issue: 1319
+  - id: gauntlet.c01-try-answer
+    kind: cli-flag
+    declared_at: crates/nika-cli/src/try_args.rs:52
+    shipped_when: "default"
+    reachable_by: "nika try --help"
+    proven_by: rust
+    issue: 1298
+  - id: gauntlet.c13-fix-bare-exec
+    kind: operator-teaching
+    declared_at: crates/nika-cli-host/src/fix_ladder.rs:196
+    shipped_when: "default"
+    reachable_by: "nika check --fix a file whose exec: is a YAML string"
+    proven_by: rust
+    issue: 1310
+  - id: gauntlet.ux1-first-shelf
+    kind: operator-teaching
+    declared_at: crates/nika-pack/src/lib.rs:297
+    shipped_when: "default"
+    reachable_by: "nika try  (TTY)"
+    proven_by: rust
+    issue: 1316
+  - id: gauntlet.b24-image-floor
+    kind: operator-teaching
+    declared_at: crates/nika-runtime/src/admit.rs:884
+    shipped_when: "default"
+    reachable_by: "nika run --max-cost-usd 0.001 a nika:image_generate xAI task"
+    proven_by: rust
+    issue: 1296
+  - id: gauntlet.b20-unpriced-cloud
+    kind: operator-teaching
+    declared_at: crates/nika-runtime/src/admit.rs:916
+    shipped_when: "default"
+    reachable_by: "nika run --max-cost-usd 0.01 model: gemini/nika-b20-unpriced-canary"
+    proven_by: rust
+    issue: 1297
+  - id: gauntlet.c06-try-recover-hint
+    kind: operator-teaching
+    declared_at: crates/nika-cli/src/verbs/run/example.rs:271
+    shipped_when: "default"
+    reachable_by: "nika try standup-digest --model mock/echo"
+    proven_by: rust
+    issue: 1307
 
 # A field the parser accepts and the runtime never reads. G6 fires while
 # the runtime needle is absent. Tombstone with a reason and a date to


### PR DESCRIPTION
C06/B06: `nika try standup-digest` / `03-exec-pipeline` print a recover tip
when the try sandbox seatbelts git/cargo, even under `--model mock/echo`.
The jobs stay off the first shelf.

`wiring.yaml` rows (`proven_by: rust` + `issue:`) for the 0.116.1 HOLDS so
issue-proof can keep a close (B04 B05 B18 B20 B24 C01 C13 UX-1 N01 C06).

Do not retag 0.116.1.

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>