### PR TITLE
fix(release): make replays fail closed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,13 @@ on:
 permissions:
   contents: read # least privilege at the top — release job elevates (Scorecard Token-Permissions)
 
+# One tag is one publication lane. A manual replay must queue behind the live
+# train instead of racing it for release assets, the floating image tag, or the
+# Homebrew formula. Never cancel a train after an irreversible registry write.
+concurrency:
+  group: release-${{ github.event.inputs.tag || github.ref_name }}
+  cancel-in-progress: false
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: '0'
@@ -313,13 +320,13 @@ jobs:
           # rendered from CHANGELOG.md; --generate-notes keeps the full PR
           # list appended below it (gh prepends provided notes to generated).
           bash scripts/release/render-notes.sh "$REF_NAME" > "$RUNNER_TEMP/release-notes.md"
-          # idempotent on a workflow_dispatch rebuild (a documented path in
-          # this file): an existing release keeps its body + discussion —
-          # the LINEAGE LAW (never rewrite a live release retroactively) —
-          # and only the assets refresh (--clobber)
+          # Idempotent on a workflow_dispatch rebuild: an existing release
+          # keeps its body + discussion, and every already-published asset
+          # must be byte-identical. A replay may fill a missing asset, never
+          # rewrite one whose public name is already occupied.
           if gh release view "$REF_NAME" --repo "$REPO" > /dev/null 2>&1; then
-            echo "::notice::release ${REF_NAME} already exists — refreshing assets only"
-            gh release upload "$REF_NAME" --repo "$REPO" --clobber \
+            echo "::notice::release ${REF_NAME} already exists — verifying immutable assets"
+            bash scripts/release/upload-assets-immutable.sh "$REF_NAME" "$REPO" \
               artifacts/nika-*.tar.gz artifacts/SHA256SUMS
           else
             gh release create "$REF_NAME" \
@@ -539,9 +546,10 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          # --clobber: a workflow_dispatch rebuild of a tag is a supported
-          # path in this file — a re-run must not go red on its own assets
-          gh release upload "$TAG" --repo "$REPO" --clobber ./*.tgz ./*.tgz.sha256
+          # A replay may heal an absent asset, but a public name is immutable
+          # once occupied. Different bytes fail closed.
+          bash scripts/release/upload-assets-immutable.sh \
+            "$TAG" "$REPO" ./*.tgz ./*.tgz.sha256
       - name: Attest build provenance (the npm tarball · verifiable via `gh attestation verify`)
         uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
@@ -647,3 +655,11 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository }}:latest
             ghcr.io/${{ github.repository }}:${{ needs.release.outputs.version }}
+          labels: |
+            org.opencontainers.image.title=Nika
+            org.opencontainers.image.description=Sovereign AI workflow runtime
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.url=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ needs.release.outputs.sha }}
+            org.opencontainers.image.version=${{ needs.release.outputs.version }}
+            org.opencontainers.image.licenses=AGPL-3.0-or-later

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Existing tag to (re)build, e.g. v0.90.0'
+        description: 'Existing tag to rebuild; dispatch this workflow from main, never from the tag'
         required: true
 
 permissions:
@@ -37,8 +37,25 @@ env:
   CARGO_INCREMENTAL: '0'
 
 jobs:
+  dispatch-ref:
+    name: replay uses current release guards
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Refuse a replay selected from a non-main workflow ref
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          WORKFLOW_REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] \
+            && [ "$WORKFLOW_REF" != "refs/heads/main" ]; then
+            printf 'release replay must select --ref main; got %s\n' "$WORKFLOW_REF" >&2
+            exit 1
+          fi
+
   build:
     name: build ${{ matrix.name }}
+    needs: dispatch-ref
     runs-on: ${{ matrix.os }}
     env:
       # Evaluated once at job start so steps can reference it in `if:` conditions.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,42 +35,6 @@ env:
   CARGO_INCREMENTAL: '0'
 
 jobs:
-  release_state:
-    name: inspect existing release assets
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: read
-    outputs:
-      intoto_exists: ${{ steps.probe.outputs.intoto_exists }}
-    steps:
-      - name: Probe the occupied SLSA asset name
-        id: probe
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          TAG: ${{ github.event.inputs.tag || github.ref_name }}
-        run: |
-          set -euo pipefail
-          response="$RUNNER_TEMP/release.json"
-          error="$RUNNER_TEMP/release.err"
-          if gh api "repos/${REPO}/releases/tags/${TAG}" > "$response" 2> "$error"; then
-            matches="$(jq '[.assets[] | select(.name == "multiple.intoto.jsonl")] | length' "$response")"
-            case "$matches" in
-              0) echo "intoto_exists=false" >> "$GITHUB_OUTPUT" ;;
-              1) echo "intoto_exists=true" >> "$GITHUB_OUTPUT" ;;
-              *)
-                echo "::error::release has duplicate multiple.intoto.jsonl assets"
-                exit 73
-                ;;
-            esac
-          elif grep -q 'HTTP 404' "$error"; then
-            echo "intoto_exists=false" >> "$GITHUB_OUTPUT"
-          else
-            cat "$error" >&2
-            echo "::error::could not determine existing release state"
-            exit 69
-          fi
-
   build:
     name: build ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
@@ -100,16 +64,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.inputs.tag || github.ref_name }}
-      # workflow_dispatch may rebuild a tag older than this helper. Pull the
-      # one first-party script from the exact commit whose workflow is running,
-      # never from the historical release tree and never from a floating ref.
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ github.workflow_sha }}
-          path: .release-tooling
-          persist-credentials: false
-          sparse-checkout: scripts/release/upload-assets-immutable.sh
-          sparse-checkout-cone-mode: false
       - name: Verify tag matches Cargo workspace version
         env:
           REF_NAME: ${{ github.event.inputs.tag || github.ref_name }}
@@ -327,6 +281,16 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.inputs.tag || github.ref_name }}
+      # workflow_dispatch may rebuild a tag older than this helper. Pull the
+      # one first-party script from the exact commit whose workflow is running,
+      # never from the historical release tree and never from a floating ref.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: .release-tooling
+          persist-credentials: false
+          sparse-checkout: scripts/release/upload-assets-immutable.sh
+          sparse-checkout-cone-mode: false
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
@@ -400,11 +364,7 @@ jobs:
     # verifier refuses SHA refs) — the one documented exception to the
     # SHA-pin law; scorecard's Pinned-Dependencies knows this exception.
     name: slsa provenance (intoto asset)
-    needs: [release, release_state]
-    # The upstream generator's release uploader deletes and replaces an
-    # occupied same-name asset. SLSA signatures are run-specific, so a replay
-    # would necessarily rewrite public bytes. Run it only to fill absence.
-    if: needs.release_state.outputs.intoto_exists != 'true'
+    needs: release
     permissions:
       actions: read # read the workflow run for provenance
       id-token: write # sign the provenance (Sigstore OIDC)
@@ -412,8 +372,39 @@ jobs:
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: ${{ needs.release.outputs.hashes }}
-      upload-assets: true
-      upload-tag-name: ${{ needs.release.outputs.tag }}
+      # The upstream release uploader deletes and replaces an occupied
+      # same-name asset. Generate a run artifact only; the first-party
+      # provenance-publish job below performs the fail-closed release upload.
+      upload-assets: false
+
+  provenance-publish:
+    name: publish immutable slsa asset
+    needs: [release, provenance]
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: .release-tooling
+          persist-credentials: false
+          sparse-checkout: scripts/release/upload-assets-immutable.sh
+          sparse-checkout-cone-mode: false
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ needs.provenance.outputs.provenance-name }}
+      - name: Attach SLSA provenance without replacing public bytes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ needs.release.outputs.tag }}
+          PROVENANCE_NAME: ${{ needs.provenance.outputs.provenance-name }}
+        run: |
+          set -euo pipefail
+          test "$PROVENANCE_NAME" = "multiple.intoto.jsonl"
+          bash .release-tooling/scripts/release/upload-assets-immutable.sh \
+            "$TAG" "$REPO" "$PROVENANCE_NAME"
 
   bump-formula:
     name: bump homebrew tap

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -413,7 +413,7 @@ jobs:
             "$TAG" "$REPO" "$PROVENANCE_NAME"
 
   provenance-replay-check:
-    name: preserve tag-true slsa on replay
+    name: preserve existing slsa asset on replay
     needs: release
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-24.04
@@ -433,7 +433,7 @@ jobs:
             echo "::error::manual replay requires exactly one existing multiple.intoto.jsonl; refusing branch-context provenance regeneration"
             exit 73
           fi
-          echo "tag-true SLSA provenance is already present and remains untouched"
+          echo "one SLSA provenance asset is present and remains untouched; cryptographic verification stays a separate release check"
 
   bump-formula:
     name: bump homebrew tap

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,12 +22,14 @@ on:
 permissions:
   contents: read # least privilege at the top — release job elevates (Scorecard Token-Permissions)
 
-# One tag is one publication lane. A manual replay cannot overlap the live
-# train for release assets, the floating image tag, or the Homebrew formula.
-# Never cancel a running train after an irreversible registry write. GitHub's
-# default retains one pending replay and may replace it with a newer one.
+# All version trains share one publication lane. A manual replay cannot overlap
+# another replay or a live train for release assets, the floating image tag, or
+# the Homebrew formula. Never cancel a running train after an irreversible
+# registry write. GitHub retains one pending train and may replace it with a
+# newer one, so the ceremony never queues more than one train behind the active
+# run.
 concurrency:
-  group: release-${{ github.event.inputs.tag || github.ref_name }}
+  group: nika-release-train
   cancel-in-progress: false
 
 env:
@@ -356,7 +358,7 @@ jobs:
 
   provenance:
     # The scorecard-visible provenance: this reusable workflow builds and
-    # UPLOADS `multiple.intoto.jsonl` as a release asset. The native
+    # GENERATES `multiple.intoto.jsonl` as a run artifact. The native
     # attest-build-provenance step above stays (gh attestation verify) but
     # scorecard's Signed-Releases probe only reads release ASSET NAMES
     # (ossf/scorecard#4080) — the .intoto.jsonl asset is what scores.
@@ -373,7 +375,7 @@ jobs:
     permissions:
       actions: read # read the workflow run for provenance
       id-token: write # sign the provenance (Sigstore OIDC)
-      contents: write # upload the .intoto.jsonl asset to the release
+      contents: read # bind the generated statement to this repository
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: ${{ needs.release.outputs.hashes }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -365,6 +365,11 @@ jobs:
     # SHA-pin law; scorecard's Pinned-Dependencies knows this exception.
     name: slsa provenance (intoto asset)
     needs: release
+    # On workflow_dispatch, github.ref/github.sha identify the workflow source
+    # (normally main), not the input tag whose bytes were built. The generic
+    # generator binds those context values into the statement, so only a tag
+    # push can create tag-true provenance. Manual replay must preserve it.
+    if: github.event_name == 'push'
     permissions:
       actions: read # read the workflow run for provenance
       id-token: write # sign the provenance (Sigstore OIDC)
@@ -380,6 +385,7 @@ jobs:
   provenance-publish:
     name: publish immutable slsa asset
     needs: [release, provenance]
+    if: github.event_name == 'push'
     runs-on: ubuntu-24.04
     permissions:
       contents: write
@@ -405,6 +411,29 @@ jobs:
           test "$PROVENANCE_NAME" = "multiple.intoto.jsonl"
           bash .release-tooling/scripts/release/upload-assets-immutable.sh \
             "$TAG" "$REPO" "$PROVENANCE_NAME"
+
+  provenance-replay-check:
+    name: preserve tag-true slsa on replay
+    needs: release
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Refuse provenance regeneration from the workflow branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ needs.release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          matches="$(gh api "repos/${REPO}/releases/tags/${TAG}" \
+            --jq '[.assets[] | select(.name == "multiple.intoto.jsonl")] | length')"
+          if [ "$matches" != "1" ]; then
+            echo "::error::manual replay requires exactly one existing multiple.intoto.jsonl; refusing branch-context provenance regeneration"
+            exit 73
+          fi
+          echo "tag-true SLSA provenance is already present and remains untouched"
 
   bump-formula:
     name: bump homebrew tap

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -516,9 +516,10 @@ jobs:
 
   npm-wasm-publish:
     # The ELEVATED half — runs zero third-party code: download, gh, npm on
-    # a pinned toolchain. The tarball is attached + attested BEFORE the
-    # publish attempt so a credential-less run still ships the exact
-    # publish-ready bytes.
+    # a pinned toolchain, plus the one first-party immutable-upload helper
+    # checked out sparsely at the exact release SHA. The tarball is attached +
+    # attested BEFORE the publish attempt so a credential-less run still ships
+    # the exact publish-ready bytes.
     name: npm publish (nika-check-wasm)
     needs: [release, npm-wasm-pack]
     runs-on: ubuntu-24.04
@@ -527,6 +528,12 @@ jobs:
       id-token: write # npm --provenance (Sigstore OIDC) + build attestation
       attestations: write # publish the tarball's build-provenance attestation
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.release.outputs.sha }}
+          persist-credentials: false
+          sparse-checkout: scripts/release/upload-assets-immutable.sh
+          sparse-checkout-cone-mode: false
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: npm-tarball

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ env:
 
 jobs:
   dispatch-ref:
-    name: replay uses current release guards
+    name: release coordinate uses current guards
     runs-on: ubuntu-24.04
     steps:
       - name: Refuse a replay selected from a non-main workflow ref
@@ -52,6 +52,20 @@ jobs:
             printf 'release replay must select --ref main; got %s\n' "$WORKFLOW_REF" >&2
             exit 1
           fi
+      # Validate with the workflow's own first-party guard before any build or
+      # publication job can start. In particular, `+build` must never reach
+      # `gh release create` and leave a half-published multi-registry train.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: .release-tooling
+          persist-credentials: false
+          sparse-checkout: scripts/release/check-release-tag.sh
+          sparse-checkout-cone-mode: false
+      - name: Validate the publication coordinate before every write
+        env:
+          REF_NAME: ${{ github.event.inputs.tag || github.ref_name }}
+        run: bash .release-tooling/scripts/release/check-release-tag.sh "$REF_NAME"
 
   build:
     name: build ${{ matrix.name }}
@@ -308,7 +322,9 @@ jobs:
           ref: ${{ github.workflow_sha }}
           path: .release-tooling
           persist-credentials: false
-          sparse-checkout: scripts/release/upload-assets-immutable.sh
+          sparse-checkout: |
+            scripts/release/check-release-tag.sh
+            scripts/release/upload-assets-immutable.sh
           sparse-checkout-cone-mode: false
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -414,7 +430,9 @@ jobs:
           ref: ${{ github.workflow_sha }}
           path: .release-tooling
           persist-credentials: false
-          sparse-checkout: scripts/release/upload-assets-immutable.sh
+          sparse-checkout: |
+            scripts/release/check-release-tag.sh
+            scripts/release/upload-assets-immutable.sh
           sparse-checkout-cone-mode: false
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -623,7 +641,9 @@ jobs:
           ref: ${{ github.workflow_sha }}
           path: .release-tooling
           persist-credentials: false
-          sparse-checkout: scripts/release/upload-assets-immutable.sh
+          sparse-checkout: |
+            scripts/release/check-release-tag.sh
+            scripts/release/upload-assets-immutable.sh
           sparse-checkout-cone-mode: false
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,10 @@ on:
 permissions:
   contents: read # least privilege at the top — release job elevates (Scorecard Token-Permissions)
 
-# One tag is one publication lane. A manual replay must queue behind the live
-# train instead of racing it for release assets, the floating image tag, or the
-# Homebrew formula. Never cancel a train after an irreversible registry write.
+# One tag is one publication lane. A manual replay cannot overlap the live
+# train for release assets, the floating image tag, or the Homebrew formula.
+# Never cancel a running train after an irreversible registry write. GitHub's
+# default retains one pending replay and may replace it with a newer one.
 concurrency:
   group: release-${{ github.event.inputs.tag || github.ref_name }}
   cancel-in-progress: false
@@ -34,6 +35,42 @@ env:
   CARGO_INCREMENTAL: '0'
 
 jobs:
+  release_state:
+    name: inspect existing release assets
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    outputs:
+      intoto_exists: ${{ steps.probe.outputs.intoto_exists }}
+    steps:
+      - name: Probe the occupied SLSA asset name
+        id: probe
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ github.event.inputs.tag || github.ref_name }}
+        run: |
+          set -euo pipefail
+          response="$RUNNER_TEMP/release.json"
+          error="$RUNNER_TEMP/release.err"
+          if gh api "repos/${REPO}/releases/tags/${TAG}" > "$response" 2> "$error"; then
+            matches="$(jq '[.assets[] | select(.name == "multiple.intoto.jsonl")] | length' "$response")"
+            case "$matches" in
+              0) echo "intoto_exists=false" >> "$GITHUB_OUTPUT" ;;
+              1) echo "intoto_exists=true" >> "$GITHUB_OUTPUT" ;;
+              *)
+                echo "::error::release has duplicate multiple.intoto.jsonl assets"
+                exit 73
+                ;;
+            esac
+          elif grep -q 'HTTP 404' "$error"; then
+            echo "intoto_exists=false" >> "$GITHUB_OUTPUT"
+          else
+            cat "$error" >&2
+            echo "::error::could not determine existing release state"
+            exit 69
+          fi
+
   build:
     name: build ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
@@ -63,6 +100,16 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.inputs.tag || github.ref_name }}
+      # workflow_dispatch may rebuild a tag older than this helper. Pull the
+      # one first-party script from the exact commit whose workflow is running,
+      # never from the historical release tree and never from a floating ref.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: .release-tooling
+          persist-credentials: false
+          sparse-checkout: scripts/release/upload-assets-immutable.sh
+          sparse-checkout-cone-mode: false
       - name: Verify tag matches Cargo workspace version
         env:
           REF_NAME: ${{ github.event.inputs.tag || github.ref_name }}
@@ -326,7 +373,7 @@ jobs:
           # rewrite one whose public name is already occupied.
           if gh release view "$REF_NAME" --repo "$REPO" > /dev/null 2>&1; then
             echo "::notice::release ${REF_NAME} already exists — verifying immutable assets"
-            bash scripts/release/upload-assets-immutable.sh "$REF_NAME" "$REPO" \
+            bash .release-tooling/scripts/release/upload-assets-immutable.sh "$REF_NAME" "$REPO" \
               artifacts/nika-*.tar.gz artifacts/SHA256SUMS
           else
             gh release create "$REF_NAME" \
@@ -353,7 +400,11 @@ jobs:
     # verifier refuses SHA refs) — the one documented exception to the
     # SHA-pin law; scorecard's Pinned-Dependencies knows this exception.
     name: slsa provenance (intoto asset)
-    needs: release
+    needs: [release, release_state]
+    # The upstream generator's release uploader deletes and replaces an
+    # occupied same-name asset. SLSA signatures are run-specific, so a replay
+    # would necessarily rewrite public bytes. Run it only to fill absence.
+    if: needs.release_state.outputs.intoto_exists != 'true'
     permissions:
       actions: read # read the workflow run for provenance
       id-token: write # sign the provenance (Sigstore OIDC)
@@ -530,7 +581,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.release.outputs.sha }}
+          ref: ${{ github.workflow_sha }}
+          path: .release-tooling
           persist-credentials: false
           sparse-checkout: scripts/release/upload-assets-immutable.sh
           sparse-checkout-cone-mode: false
@@ -555,7 +607,7 @@ jobs:
           set -euo pipefail
           # A replay may heal an absent asset, but a public name is immutable
           # once occupied. Different bytes fail closed.
-          bash scripts/release/upload-assets-immutable.sh \
+          bash .release-tooling/scripts/release/upload-assets-immutable.sh \
             "$TAG" "$REPO" ./*.tgz ./*.tgz.sha256
       - name: Attest build provenance (the npm tarball · verifiable via `gh attestation verify`)
         uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -129,7 +129,9 @@ without an explicit operator decision.
    helper comes from the exact workflow commit, so a historical tag does not
    need to contain future release tooling. Existing SLSA provenance is
    preserved byte-for-byte and a missing statement follows the same guarded
-   replay boundary.
+   replay boundary. SLSA provenance is created only by the original tag-push
+   context. Manual replay requires the tag-true statement to exist exactly
+   once and refuses branch-context regeneration.
 
    The portable Agent Plugins mirror is downstream of this immutable tag.
    After the release assets are green, its release-heal lane runs

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -115,6 +115,12 @@ without an explicit operator decision.
 
 5. **Tag and push.**
 
+   The tag is the shared GitHub/npm/Homebrew/OCI coordinate. It accepts strict
+   SemVer core plus prerelease identifiers (`v1.0.0-rc.1`), but not build
+   metadata (`+build`): SemVer ignores metadata for precedence while the four
+   registries must agree on one spelling. The workflow validates that
+   coordinate in its first job, before builds and before any publication write.
+
    ```sh
    git tag v<NEXT> && git push origin v<NEXT>
    ```

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -119,7 +119,20 @@ without an explicit operator decision.
    git tag v<NEXT> && git push origin v<NEXT>
    ```
 
-   Nothing else. `workflow_dispatch` can replay an existing tag. All live and
+   Nothing else. `workflow_dispatch` can replay an existing tag. Dispatch it
+   from the current workflow on `main`, while the `tag` input identifies the
+   immutable source tag:
+
+   ```sh
+   gh workflow run release.yml --repo supernovae-st/nika --ref main \
+     -f tag=v<NEXT>
+   ```
+
+   Never select the historical tag as the workflow ref: that executes the
+   workflow YAML stored in the tag and can predate the immutable uploader and
+   concurrency guards. This cannot be retrofitted into already-published tags;
+   the operator command and the current workflow's ref guard are both part of
+   the replay boundary. All live and
    replay release trains share one global publication lane because Homebrew and
    the container `latest` tag are cross-version mutable pointers. GitHub retains
    only one pending train and may replace it with a newer one, so never queue

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -119,8 +119,10 @@ without an explicit operator decision.
    git tag v<NEXT> && git push origin v<NEXT>
    ```
 
-   Nothing else. `workflow_dispatch` can rebuild an existing tag; know that
-   re-dispatching an old tag re-points `latest` (docker + release ordering).
+   Nothing else. `workflow_dispatch` can rebuild an existing tag. Runs for the
+   same tag serialize, and replay refuses to replace an occupied release asset
+   with different bytes. Know that re-dispatching an old tag still re-points
+   `latest` (docker + release ordering).
 
    The portable Agent Plugins mirror is downstream of this immutable tag.
    After the release assets are green, its release-heal lane runs

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -130,8 +130,9 @@ without an explicit operator decision.
    need to contain future release tooling. Existing SLSA provenance is
    preserved byte-for-byte and a missing statement follows the same guarded
    replay boundary. SLSA provenance is created only by the original tag-push
-   context. Manual replay requires the tag-true statement to exist exactly
-   once and refuses branch-context regeneration.
+   context. Manual replay requires exactly one existing statement asset and
+   refuses branch-context regeneration; `slsa-verifier` remains the separate
+   cryptographic and source-identity judge.
 
    The portable Agent Plugins mirror is downstream of this immutable tag.
    After the release assets are green, its release-heal lane runs

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -119,14 +119,17 @@ without an explicit operator decision.
    git tag v<NEXT> && git push origin v<NEXT>
    ```
 
-   Nothing else. `workflow_dispatch` can rebuild an existing tag. Runs for the
+   Nothing else. `workflow_dispatch` can replay an existing tag. Runs for the
    same tag never overlap; GitHub retains one pending replay and may replace it
    with a newer one. Replay refuses to replace an occupied release asset with
-   different bytes. Know that re-dispatching an old tag still re-points
-   `latest` (docker + release ordering). The replay helper comes from the exact
-   workflow commit, so a historical tag does not need to contain future
-   release tooling. Existing SLSA provenance is preserved byte-for-byte;
-   absence is healed once.
+   different bytes, so timestamped or otherwise non-reproducible rebuilds stop
+   rather than silently refresh public bytes. A missing asset is filled only
+   after the occupied set compares byte-for-byte. Know that re-dispatching an
+   old tag still re-points `latest` (docker + release ordering). The replay
+   helper comes from the exact workflow commit, so a historical tag does not
+   need to contain future release tooling. Existing SLSA provenance is
+   preserved byte-for-byte and a missing statement follows the same guarded
+   replay boundary.
 
    The portable Agent Plugins mirror is downstream of this immutable tag.
    After the release assets are green, its release-heal lane runs

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -120,9 +120,13 @@ without an explicit operator decision.
    ```
 
    Nothing else. `workflow_dispatch` can rebuild an existing tag. Runs for the
-   same tag serialize, and replay refuses to replace an occupied release asset
-   with different bytes. Know that re-dispatching an old tag still re-points
-   `latest` (docker + release ordering).
+   same tag never overlap; GitHub retains one pending replay and may replace it
+   with a newer one. Replay refuses to replace an occupied release asset with
+   different bytes. Know that re-dispatching an old tag still re-points
+   `latest` (docker + release ordering). The replay helper comes from the exact
+   workflow commit, so a historical tag does not need to contain future
+   release tooling. Existing SLSA provenance is preserved byte-for-byte;
+   absence is healed once.
 
    The portable Agent Plugins mirror is downstream of this immutable tag.
    After the release assets are green, its release-heal lane runs

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -119,13 +119,16 @@ without an explicit operator decision.
    git tag v<NEXT> && git push origin v<NEXT>
    ```
 
-   Nothing else. `workflow_dispatch` can replay an existing tag. Runs for the
-   same tag never overlap; GitHub retains one pending replay and may replace it
-   with a newer one. Replay refuses to replace an occupied release asset with
-   different bytes, so timestamped or otherwise non-reproducible rebuilds stop
-   rather than silently refresh public bytes. A missing asset is filled only
-   after the occupied set compares byte-for-byte. Know that re-dispatching an
-   old tag still re-points `latest` (docker + release ordering). The replay
+   Nothing else. `workflow_dispatch` can replay an existing tag. All live and
+   replay release trains share one global publication lane because Homebrew and
+   the container `latest` tag are cross-version mutable pointers. GitHub retains
+   only one pending train and may replace it with a newer one, so never queue
+   more than one train behind the active run. Replay refuses to replace an
+   occupied release asset with different bytes, so timestamped or otherwise
+   non-reproducible rebuilds stop rather than silently refresh public bytes. A
+   missing asset is filled only after the occupied set compares byte-for-byte.
+   Know that re-dispatching an old tag still re-points `latest` (docker + release
+   ordering). The replay
    helper comes from the exact workflow commit, so a historical tag does not
    need to contain future release tooling. Existing SLSA provenance is
    preserved byte-for-byte and a missing statement follows the same guarded

--- a/changelog.d/1339.fixed.md
+++ b/changelog.d/1339.fixed.md
@@ -1,0 +1,4 @@
+- **Release replays now preserve published bytes.** A global publication lane
+  serializes every version; occupied GitHub Release assets must compare
+  byte-for-byte, SLSA upload authority is isolated, and GHCR images carry exact
+  source, version, and revision labels.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -67,6 +67,20 @@ That tag fires **`.github/workflows/release.yml`**, which:
    bump the formula by hand (§2).
 
 Replay a tag without re-tagging via the **workflow_dispatch** input.
+Always dispatch the current workflow from `main`; the input, not the workflow
+ref, names the immutable tag to rebuild:
+
+```sh
+gh workflow run release.yml --repo supernovae-st/nika --ref main \
+  -f tag=v0.116.2
+```
+
+Never select the historical tag as the workflow ref. GitHub would execute the
+workflow YAML stored in that tag, which can predate the immutable uploader and
+concurrency guards. Already-published tags cannot be retrofitted, so the
+operator command and the current workflow's ref guard are both part of the
+replay boundary.
+
 All live and replay release trains share one global publication lane because
 Homebrew and the container `latest` tag are cross-version mutable pointers.
 GitHub retains only one pending train and may replace it with a newer one, so

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -49,6 +49,12 @@ git tag v0.90.0            # vMAJOR.MINOR.PATCH — must match the workspace ver
 git push origin v0.90.0
 ```
 
+The tag is the one publication coordinate shared by GitHub, npm, Homebrew and
+OCI. Strict SemVer prereleases such as `v1.0.0-rc.1` are accepted; build
+metadata such as `v1.0.0+build` is refused because SemVer ignores it for
+precedence. The workflow's first job checks this before any build or registry
+write, preventing a partially published train.
+
 That tag fires **`.github/workflows/release.yml`**, which:
 
 1. builds `nika` for **macOS arm64/x64** and **Linux arm64/x64** (release · `--locked`),

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -67,6 +67,8 @@ That tag fires **`.github/workflows/release.yml`**, which:
    bump the formula by hand (§2).
 
 Re-run a tag's build without re-tagging via the **workflow_dispatch** input.
+Runs for the same tag serialize; an already-published asset is downloaded and
+compared, and a replay refuses to replace it when the bytes differ.
 
 No CI release pipeline existed before this — a tag did nothing. `scripts/release.sh`
 (monorepo) still only tags + pushes; the binaries come from the workflow.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -74,7 +74,8 @@ timestamped or otherwise non-reproducible rebuild therefore stops; missing
 assets are filled only when the occupied set still compares byte-for-byte.
 The workflow reads replay tooling from its own exact commit, not from the
 historical tag. Existing SLSA provenance is preserved rather than regenerated;
-a missing statement follows the same guarded replay boundary.
+a missing statement makes manual replay fail, because the workflow branch is
+not an honest provenance identity for the historical tag.
 
 No CI release pipeline existed before this — a tag did nothing. `scripts/release.sh`
 (monorepo) still only tags + pushes; the binaries come from the workflow.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -75,7 +75,9 @@ assets are filled only when the occupied set still compares byte-for-byte.
 The workflow reads replay tooling from its own exact commit, not from the
 historical tag. Existing SLSA provenance is preserved rather than regenerated;
 a missing statement makes manual replay fail, because the workflow branch is
-not an honest provenance identity for the historical tag.
+not an honest provenance identity for the historical tag. The replay guard
+checks the unique asset name; the verification commands below still judge its
+signature and source identity.
 
 No CI release pipeline existed before this — a tag did nothing. `scripts/release.sh`
 (monorepo) still only tags + pushes; the binaries come from the workflow.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -67,17 +67,19 @@ That tag fires **`.github/workflows/release.yml`**, which:
    bump the formula by hand (§2).
 
 Replay a tag without re-tagging via the **workflow_dispatch** input.
-Runs for the same tag never overlap. GitHub retains one pending replay and may
-replace it with a newer one; an already-published asset is downloaded and
-compared, and a replay refuses to replace it when the bytes differ. A
-timestamped or otherwise non-reproducible rebuild therefore stops; missing
-assets are filled only when the occupied set still compares byte-for-byte.
-The workflow reads replay tooling from its own exact commit, not from the
-historical tag. Existing SLSA provenance is preserved rather than regenerated;
-a missing statement makes manual replay fail, because the workflow branch is
-not an honest provenance identity for the historical tag. The replay guard
-checks the unique asset name; the verification commands below still judge its
-signature and source identity.
+All live and replay release trains share one global publication lane because
+Homebrew and the container `latest` tag are cross-version mutable pointers.
+GitHub retains only one pending train and may replace it with a newer one, so
+never queue more than one train behind the active run. An already-published
+asset is downloaded and compared, and a replay refuses to replace it when the
+bytes differ. A timestamped or otherwise non-reproducible rebuild therefore
+stops; missing assets are filled only when the occupied set still compares
+byte-for-byte. The workflow reads replay tooling from its own exact commit, not
+from the historical tag. Existing SLSA provenance is preserved rather than
+regenerated; a missing statement makes manual replay fail, because the workflow
+branch is not an honest provenance identity for the historical tag. The replay
+guard checks the unique asset name; the verification commands below still judge
+its signature and source identity.
 
 No CI release pipeline existed before this — a tag did nothing. `scripts/release.sh`
 (monorepo) still only tags + pushes; the binaries come from the workflow.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -67,8 +67,11 @@ That tag fires **`.github/workflows/release.yml`**, which:
    bump the formula by hand (§2).
 
 Re-run a tag's build without re-tagging via the **workflow_dispatch** input.
-Runs for the same tag serialize; an already-published asset is downloaded and
+Runs for the same tag never overlap. GitHub retains one pending replay and may
+replace it with a newer one; an already-published asset is downloaded and
 compared, and a replay refuses to replace it when the bytes differ.
+The workflow reads replay tooling from its own exact commit, not from the
+historical tag. Existing SLSA provenance is preserved rather than regenerated.
 
 No CI release pipeline existed before this — a tag did nothing. `scripts/release.sh`
 (monorepo) still only tags + pushes; the binaries come from the workflow.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -66,12 +66,15 @@ That tag fires **`.github/workflows/release.yml`**, which:
    `TAP_DEPLOY_KEY` secret is set (see §3); otherwise it logs a notice and you
    bump the formula by hand (§2).
 
-Re-run a tag's build without re-tagging via the **workflow_dispatch** input.
+Replay a tag without re-tagging via the **workflow_dispatch** input.
 Runs for the same tag never overlap. GitHub retains one pending replay and may
 replace it with a newer one; an already-published asset is downloaded and
-compared, and a replay refuses to replace it when the bytes differ.
+compared, and a replay refuses to replace it when the bytes differ. A
+timestamped or otherwise non-reproducible rebuild therefore stops; missing
+assets are filled only when the occupied set still compares byte-for-byte.
 The workflow reads replay tooling from its own exact commit, not from the
-historical tag. Existing SLSA provenance is preserved rather than regenerated.
+historical tag. Existing SLSA provenance is preserved rather than regenerated;
+a missing statement follows the same guarded replay boundary.
 
 No CI release pipeline existed before this — a tag did nothing. `scripts/release.sh`
 (monorepo) still only tags + pushes; the binaries come from the workflow.

--- a/estate.yaml
+++ b/estate.yaml
@@ -183,7 +183,7 @@ patterns:
 - glob: "docs/**"
   class: authored
   match_count: 120
-  aggregate_sha256: 7dbe3d045e8bb11d9da9d3b87db5128ed84fa420b173ebb6776eb7c15ad27a5e
+  aggregate_sha256: 09ef777997a29d36bf15de95788d70e2c4ab7a3946c871a16172a5431587d9ef
   evidence: "crate-specs · architecture prose · perf notes — no generation markers at file heads"
 - glob: "scripts/**"
   class: authored
@@ -193,7 +193,7 @@ patterns:
 - glob: ".github/workflows/**"
   class: authored
   match_count: 22
-  aggregate_sha256: 2315d4562f4daf36fb3084332bb1144cc8529f5f0337f00e8ac457d8e53c8a15
+  aggregate_sha256: 41c951554d62d775d7db6a6f7819d599fcf78ca2c4ca731b6a72a88b697b7304
   evidence: "hand-written CI rails, comments narrate design decisions; the heal lanes here rewrite OTHER files (spec-pin-heal.yml → SPEC_PIN + pack · changelog-cliff.yml → CHANGELOG.md), nothing rewrites the workflows themselves"
 - glob: ".github/**"
   class: authored
@@ -249,7 +249,7 @@ patterns:
 - glob: "*"
   class: authored
   match_count: 31
-  aggregate_sha256: 6257d5282076c509fc9bf97bf12adce0b20eedbbe900b66a0292e4687c5fe6a3
+  aggregate_sha256: 191435c68e904bb462a7c060707bf31bb8638ef21cde864fe2671ef665e2f1e8
   evidence: "root prose + config surface (README · DIAMOND · LICENSE · llms.txt · Cargo.toml · deny/clippy/cliff/typos toml · lefthook.yml · flake.nix · Dockerfile) — no generation markers at file heads; CHANGELOG.md · Cargo.lock · SPEC_PIN · ROADMAP.md excepted in files:"
 - glob: "**"
   class: authored

--- a/estate.yaml
+++ b/estate.yaml
@@ -18,11 +18,11 @@ classes:
   testimonial: "captured evidence — fixtures, corpora, traces, receipts: proves behavior; neither shipped source nor regenerable output"
   foreign: "pointer to a third-party sovereign source"
 summary:
-  classified_files: 4753
+  classified_files: 4754
   file_rows: 11
   pattern_rows: 24
   by_class:
-    authored: 1776
+    authored: 1777
     authored-pin: 2
     generated: 125
     pinned-copy: 145
@@ -183,17 +183,17 @@ patterns:
 - glob: "docs/**"
   class: authored
   match_count: 120
-  aggregate_sha256: cfe67450001ad40544ce16ee52097ba1ef99d9b013436861a4e7b1796501801f
+  aggregate_sha256: d980f358b8eb728204c50399487c321898c61d71af12acf75329e00d2b86f899
   evidence: "crate-specs · architecture prose · perf notes — no generation markers at file heads"
 - glob: "scripts/**"
   class: authored
-  match_count: 176
-  aggregate_sha256: 8587e71922319778e94452cafd7bf82d3875074274512473fd06125ba405122d
+  match_count: 177
+  aggregate_sha256: d81b6304fa3c640462fc831018ec0a4063be8804e4d700c24e84e08a52046cfd
   evidence: "hand-written gates · hooks · hygiene vectors · media lanes; the ratchet baselines (scripts/ci/*-baseline.txt · scripts/hygiene/baselines/) are hand-kept monotonic floors ('Never remove a line by hand')"
 - glob: ".github/workflows/**"
   class: authored
   match_count: 22
-  aggregate_sha256: 2e8367d9cd50213aec829f91cad2b353c09b69da44052100183f8aabb2f9e14a
+  aggregate_sha256: 087b1452561dffd0b5f94f64daab0d84ad0fea4ea1ac4031f43537d08e07a829
   evidence: "hand-written CI rails, comments narrate design decisions; the heal lanes here rewrite OTHER files (spec-pin-heal.yml → SPEC_PIN + pack · changelog-cliff.yml → CHANGELOG.md), nothing rewrites the workflows themselves"
 - glob: ".github/**"
   class: authored
@@ -249,7 +249,7 @@ patterns:
 - glob: "*"
   class: authored
   match_count: 31
-  aggregate_sha256: c7f3d7dd49aadf842529c5c8296e1d75ad0d4ce28a4931cb341ab4ef6a1f116a
+  aggregate_sha256: f953c00d94e385a9a6eff50267a096b3dc2ab9419462c8159022af033a98668f
   evidence: "root prose + config surface (README · DIAMOND · LICENSE · llms.txt · Cargo.toml · deny/clippy/cliff/typos toml · lefthook.yml · flake.nix · Dockerfile) — no generation markers at file heads; CHANGELOG.md · Cargo.lock · SPEC_PIN · ROADMAP.md excepted in files:"
 - glob: "**"
   class: authored

--- a/estate.yaml
+++ b/estate.yaml
@@ -183,17 +183,17 @@ patterns:
 - glob: "docs/**"
   class: authored
   match_count: 120
-  aggregate_sha256: 5946d858a57de7076ef219748ed6ee0c8cbc4d7cf45effb4cc85ffa128736e9c
+  aggregate_sha256: cfe67450001ad40544ce16ee52097ba1ef99d9b013436861a4e7b1796501801f
   evidence: "crate-specs · architecture prose · perf notes — no generation markers at file heads"
 - glob: "scripts/**"
   class: authored
   match_count: 176
-  aggregate_sha256: d1909027214c85702a00e75781114c206318684ef1779dfe74bc4731dac37956
+  aggregate_sha256: 23dad9df2bde936c0f40b77be552c9b304ecd8281e8f05148737a342b2651cf4
   evidence: "hand-written gates · hooks · hygiene vectors · media lanes; the ratchet baselines (scripts/ci/*-baseline.txt · scripts/hygiene/baselines/) are hand-kept monotonic floors ('Never remove a line by hand')"
 - glob: ".github/workflows/**"
   class: authored
   match_count: 22
-  aggregate_sha256: cca88eb1b9f0f5a7e52c1335435d3cb5fa03a715ba1ed620aec5d8a1b82072b4
+  aggregate_sha256: 2e8367d9cd50213aec829f91cad2b353c09b69da44052100183f8aabb2f9e14a
   evidence: "hand-written CI rails, comments narrate design decisions; the heal lanes here rewrite OTHER files (spec-pin-heal.yml → SPEC_PIN + pack · changelog-cliff.yml → CHANGELOG.md), nothing rewrites the workflows themselves"
 - glob: ".github/**"
   class: authored
@@ -249,7 +249,7 @@ patterns:
 - glob: "*"
   class: authored
   match_count: 31
-  aggregate_sha256: 06d889ad5870ec51d66bfcfd960fbe71fce7508e4208956942253a1d674407ea
+  aggregate_sha256: c7f3d7dd49aadf842529c5c8296e1d75ad0d4ce28a4931cb341ab4ef6a1f116a
   evidence: "root prose + config surface (README · DIAMOND · LICENSE · llms.txt · Cargo.toml · deny/clippy/cliff/typos toml · lefthook.yml · flake.nix · Dockerfile) — no generation markers at file heads; CHANGELOG.md · Cargo.lock · SPEC_PIN · ROADMAP.md excepted in files:"
 - glob: "**"
   class: authored

--- a/estate.yaml
+++ b/estate.yaml
@@ -18,11 +18,11 @@ classes:
   testimonial: "captured evidence — fixtures, corpora, traces, receipts: proves behavior; neither shipped source nor regenerable output"
   foreign: "pointer to a third-party sovereign source"
 summary:
-  classified_files: 4750
+  classified_files: 4752
   file_rows: 11
   pattern_rows: 24
   by_class:
-    authored: 1773
+    authored: 1775
     authored-pin: 2
     generated: 125
     pinned-copy: 145
@@ -151,8 +151,8 @@ patterns:
     - "cargo-public-api 0.51.0"
 - glob: "crates/**/src/**"
   class: authored
-  match_count: 914
-  aggregate_sha256: fee71ffc2899bfee1546c20f4f2a28d081ebff96c19a9973252e5273480ccfc9
+  match_count: 915
+  aggregate_sha256: 47e27ac22ceffc89abe11ff401326559e90e903ed78e5012055b0a9707644180
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored
@@ -183,17 +183,17 @@ patterns:
 - glob: "docs/**"
   class: authored
   match_count: 120
-  aggregate_sha256: 09ef777997a29d36bf15de95788d70e2c4ab7a3946c871a16172a5431587d9ef
+  aggregate_sha256: 5946d858a57de7076ef219748ed6ee0c8cbc4d7cf45effb4cc85ffa128736e9c
   evidence: "crate-specs · architecture prose · perf notes — no generation markers at file heads"
 - glob: "scripts/**"
   class: authored
   match_count: 176
-  aggregate_sha256: 797d9a10d38834b6a6fb747307d04448698b98af6658a9a5fdf289d152130b61
+  aggregate_sha256: d1909027214c85702a00e75781114c206318684ef1779dfe74bc4731dac37956
   evidence: "hand-written gates · hooks · hygiene vectors · media lanes; the ratchet baselines (scripts/ci/*-baseline.txt · scripts/hygiene/baselines/) are hand-kept monotonic floors ('Never remove a line by hand')"
 - glob: ".github/workflows/**"
   class: authored
   match_count: 22
-  aggregate_sha256: 41c951554d62d775d7db6a6f7819d599fcf78ca2c4ca731b6a72a88b697b7304
+  aggregate_sha256: cca88eb1b9f0f5a7e52c1335435d3cb5fa03a715ba1ed620aec5d8a1b82072b4
   evidence: "hand-written CI rails, comments narrate design decisions; the heal lanes here rewrite OTHER files (spec-pin-heal.yml → SPEC_PIN + pack · changelog-cliff.yml → CHANGELOG.md), nothing rewrites the workflows themselves"
 - glob: ".github/**"
   class: authored
@@ -242,14 +242,14 @@ patterns:
   evidence: "examples/README.md — a pointer README (the runnable examples live in the vendored pack + the spec repo)"
 - glob: "changelog.d/**"
   class: authored
-  match_count: 1
-  aggregate_sha256: 6b53a86aaa149c6719b91ac3e4afb6b688f06035aacf5a34608e8ea089deff36
+  match_count: 2
+  aggregate_sha256: a131e14cdaa1fd0565cdd472bf664df62b933ad71f1bf54fe5fd2c07944f7505
   evidence: "changelog.d/README.md — one hand-written bullet per change, authored by whoever makes the change; scripts/release/changelog-assemble.sh only CONSUMES them (--fold splices and deletes) and never writes one"
   note: "the README is permanent by design: a rule matching nothing is a coverage hole, and every fragment is deleted at fold time"
 - glob: "*"
   class: authored
   match_count: 31
-  aggregate_sha256: 191435c68e904bb462a7c060707bf31bb8638ef21cde864fe2671ef665e2f1e8
+  aggregate_sha256: 06d889ad5870ec51d66bfcfd960fbe71fce7508e4208956942253a1d674407ea
   evidence: "root prose + config surface (README · DIAMOND · LICENSE · llms.txt · Cargo.toml · deny/clippy/cliff/typos toml · lefthook.yml · flake.nix · Dockerfile) — no generation markers at file heads; CHANGELOG.md · Cargo.lock · SPEC_PIN · ROADMAP.md excepted in files:"
 - glob: "**"
   class: authored

--- a/estate.yaml
+++ b/estate.yaml
@@ -183,17 +183,17 @@ patterns:
 - glob: "docs/**"
   class: authored
   match_count: 120
-  aggregate_sha256: bde5aeeba491d21d8f24ca46aa5c649c9163b14cde448eb71177b36c8b0e230e
+  aggregate_sha256: b8661f69c282227885cd39cbebccc036fc653d79c7deada1a59733cc1b25641b
   evidence: "crate-specs · architecture prose · perf notes — no generation markers at file heads"
 - glob: "scripts/**"
   class: authored
   match_count: 176
-  aggregate_sha256: 89482fcb5fcd1c995d26de649dae536de2ad32c043c785f4237150fd93698921
+  aggregate_sha256: 83517952b06b41d485d338362fc15fd3460ddcc823a670068ec4bfe34f5fd532
   evidence: "hand-written gates · hooks · hygiene vectors · media lanes; the ratchet baselines (scripts/ci/*-baseline.txt · scripts/hygiene/baselines/) are hand-kept monotonic floors ('Never remove a line by hand')"
 - glob: ".github/workflows/**"
   class: authored
   match_count: 22
-  aggregate_sha256: f91b7f7a7340b757c3d19154b727b656f3b28eda0028f03b8c6c3f01d9b4a5b7
+  aggregate_sha256: 7818307c03dece4e21b50b093ba471216385e5cbcd02eeea4622fe84d47c4a53
   evidence: "hand-written CI rails, comments narrate design decisions; the heal lanes here rewrite OTHER files (spec-pin-heal.yml → SPEC_PIN + pack · changelog-cliff.yml → CHANGELOG.md), nothing rewrites the workflows themselves"
 - glob: ".github/**"
   class: authored
@@ -249,7 +249,7 @@ patterns:
 - glob: "*"
   class: authored
   match_count: 31
-  aggregate_sha256: e6078c867412a975ea84ffdbfe27021383a31bf140e14ad4cf52d49769343df1
+  aggregate_sha256: f472eb9968dd92e97ae57979552678d1cee166183bcd7fd5d883f861b81ff09a
   evidence: "root prose + config surface (README · DIAMOND · LICENSE · llms.txt · Cargo.toml · deny/clippy/cliff/typos toml · lefthook.yml · flake.nix · Dockerfile) — no generation markers at file heads; CHANGELOG.md · Cargo.lock · SPEC_PIN · ROADMAP.md excepted in files:"
 - glob: "**"
   class: authored

--- a/estate.yaml
+++ b/estate.yaml
@@ -18,11 +18,11 @@ classes:
   testimonial: "captured evidence — fixtures, corpora, traces, receipts: proves behavior; neither shipped source nor regenerable output"
   foreign: "pointer to a third-party sovereign source"
 summary:
-  classified_files: 4748
+  classified_files: 4750
   file_rows: 11
   pattern_rows: 24
   by_class:
-    authored: 1771
+    authored: 1773
     authored-pin: 2
     generated: 125
     pinned-copy: 145
@@ -183,17 +183,17 @@ patterns:
 - glob: "docs/**"
   class: authored
   match_count: 120
-  aggregate_sha256: 05a800d6bb0b5a3208560892700d6df58a8fb80a7478d4d08b3f8a241e436fb4
+  aggregate_sha256: bde5aeeba491d21d8f24ca46aa5c649c9163b14cde448eb71177b36c8b0e230e
   evidence: "crate-specs · architecture prose · perf notes — no generation markers at file heads"
 - glob: "scripts/**"
   class: authored
-  match_count: 174
-  aggregate_sha256: 54eb10f6c4f45e5e7ea2e8db2698613801bc6a702a289416bd568b96aafdd038
+  match_count: 176
+  aggregate_sha256: 17b1aca5f808e5fbadcd181e7e94e0a00864adeec5e2353bdfd5cb5cd49204b1
   evidence: "hand-written gates · hooks · hygiene vectors · media lanes; the ratchet baselines (scripts/ci/*-baseline.txt · scripts/hygiene/baselines/) are hand-kept monotonic floors ('Never remove a line by hand')"
 - glob: ".github/workflows/**"
   class: authored
   match_count: 22
-  aggregate_sha256: b190fd9eb1dd50a4819dd65ec72559032ff191d9476f6945de9543293f60b298
+  aggregate_sha256: 9afacd23e94fd48ca7b81f56ac1753240de7d850c65ed008e0fe7412e891f256
   evidence: "hand-written CI rails, comments narrate design decisions; the heal lanes here rewrite OTHER files (spec-pin-heal.yml → SPEC_PIN + pack · changelog-cliff.yml → CHANGELOG.md), nothing rewrites the workflows themselves"
 - glob: ".github/**"
   class: authored
@@ -249,7 +249,7 @@ patterns:
 - glob: "*"
   class: authored
   match_count: 31
-  aggregate_sha256: 10cf5de19e0f828134a3b7a58ec7b22ebed98fbd5f308e9513da9aab1e4d926b
+  aggregate_sha256: e6078c867412a975ea84ffdbfe27021383a31bf140e14ad4cf52d49769343df1
   evidence: "root prose + config surface (README · DIAMOND · LICENSE · llms.txt · Cargo.toml · deny/clippy/cliff/typos toml · lefthook.yml · flake.nix · Dockerfile) — no generation markers at file heads; CHANGELOG.md · Cargo.lock · SPEC_PIN · ROADMAP.md excepted in files:"
 - glob: "**"
   class: authored

--- a/estate.yaml
+++ b/estate.yaml
@@ -183,17 +183,17 @@ patterns:
 - glob: "docs/**"
   class: authored
   match_count: 120
-  aggregate_sha256: 077904dd0144b11e3abfb64143d2c65a92dc38adab38d716b0aac0c96b571854
+  aggregate_sha256: 7dbe3d045e8bb11d9da9d3b87db5128ed84fa420b173ebb6776eb7c15ad27a5e
   evidence: "crate-specs · architecture prose · perf notes — no generation markers at file heads"
 - glob: "scripts/**"
   class: authored
   match_count: 176
-  aggregate_sha256: 747d90b9760e19d4b92ea892c51b841318257ebe9835f97ef921e3b86f7cc3fa
+  aggregate_sha256: 797d9a10d38834b6a6fb747307d04448698b98af6658a9a5fdf289d152130b61
   evidence: "hand-written gates · hooks · hygiene vectors · media lanes; the ratchet baselines (scripts/ci/*-baseline.txt · scripts/hygiene/baselines/) are hand-kept monotonic floors ('Never remove a line by hand')"
 - glob: ".github/workflows/**"
   class: authored
   match_count: 22
-  aggregate_sha256: d1b4b670f34405b8d56c24fc9bdcf6ab4ad0917791b7fe66c47c5b54d8ac5d77
+  aggregate_sha256: 2315d4562f4daf36fb3084332bb1144cc8529f5f0337f00e8ac457d8e53c8a15
   evidence: "hand-written CI rails, comments narrate design decisions; the heal lanes here rewrite OTHER files (spec-pin-heal.yml → SPEC_PIN + pack · changelog-cliff.yml → CHANGELOG.md), nothing rewrites the workflows themselves"
 - glob: ".github/**"
   class: authored
@@ -249,7 +249,7 @@ patterns:
 - glob: "*"
   class: authored
   match_count: 31
-  aggregate_sha256: b187a8f8836dbbc5c0bf2cca99910f9fca250a20b6f2f99db1eb6e32a9384ede
+  aggregate_sha256: 6257d5282076c509fc9bf97bf12adce0b20eedbbe900b66a0292e4687c5fe6a3
   evidence: "root prose + config surface (README · DIAMOND · LICENSE · llms.txt · Cargo.toml · deny/clippy/cliff/typos toml · lefthook.yml · flake.nix · Dockerfile) — no generation markers at file heads; CHANGELOG.md · Cargo.lock · SPEC_PIN · ROADMAP.md excepted in files:"
 - glob: "**"
   class: authored

--- a/estate.yaml
+++ b/estate.yaml
@@ -188,7 +188,7 @@ patterns:
 - glob: "scripts/**"
   class: authored
   match_count: 176
-  aggregate_sha256: 23dad9df2bde936c0f40b77be552c9b304ecd8281e8f05148737a342b2651cf4
+  aggregate_sha256: 8587e71922319778e94452cafd7bf82d3875074274512473fd06125ba405122d
   evidence: "hand-written gates · hooks · hygiene vectors · media lanes; the ratchet baselines (scripts/ci/*-baseline.txt · scripts/hygiene/baselines/) are hand-kept monotonic floors ('Never remove a line by hand')"
 - glob: ".github/workflows/**"
   class: authored

--- a/estate.yaml
+++ b/estate.yaml
@@ -183,17 +183,17 @@ patterns:
 - glob: "docs/**"
   class: authored
   match_count: 120
-  aggregate_sha256: b8661f69c282227885cd39cbebccc036fc653d79c7deada1a59733cc1b25641b
+  aggregate_sha256: 077904dd0144b11e3abfb64143d2c65a92dc38adab38d716b0aac0c96b571854
   evidence: "crate-specs · architecture prose · perf notes — no generation markers at file heads"
 - glob: "scripts/**"
   class: authored
   match_count: 176
-  aggregate_sha256: 83517952b06b41d485d338362fc15fd3460ddcc823a670068ec4bfe34f5fd532
+  aggregate_sha256: 747d90b9760e19d4b92ea892c51b841318257ebe9835f97ef921e3b86f7cc3fa
   evidence: "hand-written gates · hooks · hygiene vectors · media lanes; the ratchet baselines (scripts/ci/*-baseline.txt · scripts/hygiene/baselines/) are hand-kept monotonic floors ('Never remove a line by hand')"
 - glob: ".github/workflows/**"
   class: authored
   match_count: 22
-  aggregate_sha256: 7818307c03dece4e21b50b093ba471216385e5cbcd02eeea4622fe84d47c4a53
+  aggregate_sha256: d1b4b670f34405b8d56c24fc9bdcf6ab4ad0917791b7fe66c47c5b54d8ac5d77
   evidence: "hand-written CI rails, comments narrate design decisions; the heal lanes here rewrite OTHER files (spec-pin-heal.yml → SPEC_PIN + pack · changelog-cliff.yml → CHANGELOG.md), nothing rewrites the workflows themselves"
 - glob: ".github/**"
   class: authored
@@ -249,7 +249,7 @@ patterns:
 - glob: "*"
   class: authored
   match_count: 31
-  aggregate_sha256: f472eb9968dd92e97ae57979552678d1cee166183bcd7fd5d883f861b81ff09a
+  aggregate_sha256: b187a8f8836dbbc5c0bf2cca99910f9fca250a20b6f2f99db1eb6e32a9384ede
   evidence: "root prose + config surface (README · DIAMOND · LICENSE · llms.txt · Cargo.toml · deny/clippy/cliff/typos toml · lefthook.yml · flake.nix · Dockerfile) — no generation markers at file heads; CHANGELOG.md · Cargo.lock · SPEC_PIN · ROADMAP.md excepted in files:"
 - glob: "**"
   class: authored

--- a/estate.yaml
+++ b/estate.yaml
@@ -18,11 +18,11 @@ classes:
   testimonial: "captured evidence — fixtures, corpora, traces, receipts: proves behavior; neither shipped source nor regenerable output"
   foreign: "pointer to a third-party sovereign source"
 summary:
-  classified_files: 4752
+  classified_files: 4753
   file_rows: 11
   pattern_rows: 24
   by_class:
-    authored: 1775
+    authored: 1776
     authored-pin: 2
     generated: 125
     pinned-copy: 145
@@ -242,8 +242,8 @@ patterns:
   evidence: "examples/README.md — a pointer README (the runnable examples live in the vendored pack + the spec repo)"
 - glob: "changelog.d/**"
   class: authored
-  match_count: 2
-  aggregate_sha256: a131e14cdaa1fd0565cdd472bf664df62b933ad71f1bf54fe5fd2c07944f7505
+  match_count: 3
+  aggregate_sha256: 23050ca7936c4e2e463c7076ed877d6a8bcc42017d7e13a79437d4a00d919d6c
   evidence: "changelog.d/README.md — one hand-written bullet per change, authored by whoever makes the change; scripts/release/changelog-assemble.sh only CONSUMES them (--fold splices and deletes) and never writes one"
   note: "the README is permanent by design: a rule matching nothing is a coverage hole, and every fragment is deleted at fold time"
 - glob: "*"

--- a/estate.yaml
+++ b/estate.yaml
@@ -188,12 +188,12 @@ patterns:
 - glob: "scripts/**"
   class: authored
   match_count: 176
-  aggregate_sha256: 17b1aca5f808e5fbadcd181e7e94e0a00864adeec5e2353bdfd5cb5cd49204b1
+  aggregate_sha256: 89482fcb5fcd1c995d26de649dae536de2ad32c043c785f4237150fd93698921
   evidence: "hand-written gates · hooks · hygiene vectors · media lanes; the ratchet baselines (scripts/ci/*-baseline.txt · scripts/hygiene/baselines/) are hand-kept monotonic floors ('Never remove a line by hand')"
 - glob: ".github/workflows/**"
   class: authored
   match_count: 22
-  aggregate_sha256: 9afacd23e94fd48ca7b81f56ac1753240de7d850c65ed008e0fe7412e891f256
+  aggregate_sha256: f91b7f7a7340b757c3d19154b727b656f3b28eda0028f03b8c6c3f01d9b4a5b7
   evidence: "hand-written CI rails, comments narrate design decisions; the heal lanes here rewrite OTHER files (spec-pin-heal.yml → SPEC_PIN + pack · changelog-cliff.yml → CHANGELOG.md), nothing rewrites the workflows themselves"
 - glob: ".github/**"
   class: authored

--- a/scripts/release/check-release-tag.sh
+++ b/scripts/release/check-release-tag.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Validate the one publication coordinate shared by every release surface.
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: $0 <vMAJOR.MINOR.PATCH[-PRERELEASE]>" >&2
+  exit 64
+fi
+
+tag="$1"
+
+# SemVer 2.0 core + prerelease. Build metadata is deliberately excluded: npm,
+# Homebrew, OCI, and GitHub must share one unambiguous publication coordinate,
+# while SemVer precedence intentionally ignores `+build` identifiers.
+core='(0|[1-9][0-9]*)'
+prerelease_id='(0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)'
+semver_tag="^v${core}\.${core}\.${core}(-${prerelease_id}(\.${prerelease_id})*)?$"
+if [[ ! "$tag" =~ $semver_tag ]]; then
+  echo "release coordinate: invalid canonical semver tag: $tag" >&2
+  exit 64
+fi

--- a/scripts/release/tests/immutable-assets.test.sh
+++ b/scripts/release/tests/immutable-assets.test.sh
@@ -21,7 +21,7 @@ cat >"$FAKE_BIN/gh" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 case "$1 $2" in
-  "api repos/supernovae-st/nika/releases/tags/v9.9.9")
+  api\ repos/supernovae-st/nika/releases/tags/v*)
     find "$REMOTE" -type f -maxdepth 1 -exec basename {} \; | sort
     ;;
   "release download")
@@ -90,10 +90,20 @@ fi
 [ ! -e "$REMOTE/a-missing.tgz" ] \
   || fail 'a missing asset was uploaded before the occupied set was validated'
 
-if PATH="$FAKE_BIN:$PATH" REMOTE="$REMOTE" LOG="$LOG" \
-  bash "$ROOT/scripts/release/upload-assets-immutable.sh" \
-  latest supernovae-st/nika "$LOCAL/new.tgz" >/dev/null 2>&1; then
-  fail 'a non-semver tag reached the release API'
-fi
+printf 'prerelease\n' >"$LOCAL/prerelease.tgz"
+for tag in v1.0.0-rc.1 v0.80.0-alpha.1; do
+  PATH="$FAKE_BIN:$PATH" REMOTE="$REMOTE" LOG="$LOG" \
+    bash "$ROOT/scripts/release/upload-assets-immutable.sh" \
+    "$tag" supernovae-st/nika "$LOCAL/prerelease.tgz" >/dev/null \
+    || fail "canonical prerelease tag $tag was refused"
+done
+
+for tag in latest v1.0.0-rc.01 v1.0.0+build v01.0.0; do
+  if PATH="$FAKE_BIN:$PATH" REMOTE="$REMOTE" LOG="$LOG" \
+    bash "$ROOT/scripts/release/upload-assets-immutable.sh" \
+    "$tag" supernovae-st/nika "$LOCAL/new.tgz" >/dev/null 2>&1; then
+    fail "non-canonical release tag $tag reached the release API"
+  fi
+done
 
 echo 'immutable-assets.test: PASS'

--- a/scripts/release/tests/immutable-assets.test.sh
+++ b/scripts/release/tests/immutable-assets.test.sh
@@ -77,6 +77,19 @@ grep -q 'REFUSED different bytes' "$TEST_ROOT/refusal.out" \
 printf 'alpha\n' | cmp -s - "$REMOTE/new.tgz" \
   || fail 'a refused replay mutated the remote asset'
 
+printf 'occupied\n' >"$REMOTE/z-existing.tgz"
+printf 'different\n' >"$LOCAL/z-existing.tgz"
+printf 'missing\n' >"$LOCAL/a-missing.tgz"
+if PATH="$FAKE_BIN:$PATH" REMOTE="$REMOTE" LOG="$LOG" \
+  bash "$ROOT/scripts/release/upload-assets-immutable.sh" \
+  v9.9.9 supernovae-st/nika \
+  "$LOCAL/a-missing.tgz" "$LOCAL/z-existing.tgz" \
+  >"$TEST_ROOT/two-pass.out" 2>&1; then
+  fail 'a divergent occupied set unexpectedly succeeded'
+fi
+[ ! -e "$REMOTE/a-missing.tgz" ] \
+  || fail 'a missing asset was uploaded before the occupied set was validated'
+
 if PATH="$FAKE_BIN:$PATH" REMOTE="$REMOTE" LOG="$LOG" \
   bash "$ROOT/scripts/release/upload-assets-immutable.sh" \
   latest supernovae-st/nika "$LOCAL/new.tgz" >/dev/null 2>&1; then

--- a/scripts/release/tests/immutable-assets.test.sh
+++ b/scripts/release/tests/immutable-assets.test.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Regression proof: a release replay may heal absence, never replace bytes.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+TEST_ROOT="$(mktemp -d)"
+REMOTE="$TEST_ROOT/remote"
+LOCAL="$TEST_ROOT/local"
+FAKE_BIN="$TEST_ROOT/bin"
+LOG="$TEST_ROOT/gh.log"
+mkdir -p "$REMOTE" "$LOCAL" "$FAKE_BIN"
+trap 'rm -r "$TEST_ROOT"' EXIT
+
+fail() {
+  echo "immutable-assets.test: $1" >&2
+  exit 1
+}
+
+cat >"$FAKE_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+case "$1 $2" in
+  "api repos/supernovae-st/nika/releases/tags/v9.9.9")
+    find "$REMOTE" -type f -maxdepth 1 -exec basename {} \; | sort
+    ;;
+  "release download")
+    pattern=""
+    destination=""
+    shift 2
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --pattern) pattern="$2"; shift 2 ;;
+        --dir) destination="$2"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    cp "$REMOTE/$pattern" "$destination/$pattern"
+    ;;
+  "release upload")
+    asset="${@: -1}"
+    cp "$asset" "$REMOTE/$(basename "$asset")"
+    echo "upload $(basename "$asset")" >>"$LOG"
+    ;;
+  *)
+    echo "unexpected gh invocation: $*" >&2
+    exit 90
+    ;;
+esac
+EOF
+chmod +x "$FAKE_BIN/gh"
+
+printf 'alpha\n' >"$LOCAL/new.tgz"
+PATH="$FAKE_BIN:$PATH" REMOTE="$REMOTE" LOG="$LOG" \
+  bash "$ROOT/scripts/release/upload-assets-immutable.sh" \
+  v9.9.9 supernovae-st/nika "$LOCAL/new.tgz" >/dev/null
+cmp -s "$LOCAL/new.tgz" "$REMOTE/new.tgz" \
+  || fail 'a missing asset was not uploaded'
+[ "$(grep -c '^upload new.tgz$' "$LOG")" -eq 1 ] \
+  || fail 'a missing asset was not uploaded exactly once'
+
+PATH="$FAKE_BIN:$PATH" REMOTE="$REMOTE" LOG="$LOG" \
+  bash "$ROOT/scripts/release/upload-assets-immutable.sh" \
+  v9.9.9 supernovae-st/nika "$LOCAL/new.tgz" >/dev/null
+[ "$(grep -c '^upload new.tgz$' "$LOG")" -eq 1 ] \
+  || fail 'an identical replay uploaded the asset again'
+
+printf 'different\n' >"$LOCAL/new.tgz"
+if PATH="$FAKE_BIN:$PATH" REMOTE="$REMOTE" LOG="$LOG" \
+  bash "$ROOT/scripts/release/upload-assets-immutable.sh" \
+  v9.9.9 supernovae-st/nika "$LOCAL/new.tgz" \
+  >"$TEST_ROOT/refusal.out" 2>&1; then
+  fail 'different bytes replaced an occupied asset name'
+fi
+grep -q 'REFUSED different bytes' "$TEST_ROOT/refusal.out" \
+  || fail 'the mismatch refusal did not name the occupied asset'
+printf 'alpha\n' | cmp -s - "$REMOTE/new.tgz" \
+  || fail 'a refused replay mutated the remote asset'
+
+if PATH="$FAKE_BIN:$PATH" REMOTE="$REMOTE" LOG="$LOG" \
+  bash "$ROOT/scripts/release/upload-assets-immutable.sh" \
+  latest supernovae-st/nika "$LOCAL/new.tgz" >/dev/null 2>&1; then
+  fail 'a non-semver tag reached the release API'
+fi
+
+echo 'immutable-assets.test: PASS'

--- a/scripts/release/tests/release-tooling.test.sh
+++ b/scripts/release/tests/release-tooling.test.sh
@@ -296,10 +296,32 @@ printf '%s\n' "$dispatch_job" | grep -q 'WORKFLOW_REF:.*github.ref' \
   || fail 'manual replay does not inspect the selected workflow ref'
 printf '%s\n' "$dispatch_job" | grep -q 'refs/heads/main' \
   || fail 'manual replay does not require the current main workflow guards'
+printf '%s\n' "$dispatch_job" | grep -q 'REF_NAME:.*github.event.inputs.tag.*github.ref_name' \
+  || fail 'the first release gate does not validate the selected publication tag'
+printf '%s\n' "$dispatch_job" | grep -q 'scripts/release/check-release-tag.sh' \
+  || fail 'the first release gate bypasses the canonical coordinate validator'
+# The GitHub context is matched literally.
+# shellcheck disable=SC2016
+printf '%s\n' "$dispatch_job" | grep -q 'ref: \${{ github.workflow_sha }}' \
+  || fail 'the first release gate does not use the workflow commit validator'
+printf '%s\n' "$dispatch_job" | grep -q 'persist-credentials: false' \
+  || fail 'the read-only release-coordinate checkout persists credentials'
 build_job="$(sed -n '/^  build:/,/^  npm-check:/p' \
   "$ROOT/.github/workflows/release.yml")"
 printf '%s\n' "$build_job" | grep -q '^    needs: dispatch-ref' \
   || fail 'release builds can bypass the replay workflow-ref guard'
+for tag in v1.0.0 v1.0.0-rc.1 v0.80.0-alpha.1; do
+  bash "$ROOT/scripts/release/check-release-tag.sh" "$tag" \
+    || fail "canonical publication coordinate $tag was refused"
+done
+for tag in latest v1.0.0-rc.01 v1.0.0+build v01.0.0; do
+  if bash "$ROOT/scripts/release/check-release-tag.sh" "$tag" \
+    >"$TEST_ROOT/tag-check.out" 2>&1; then
+    fail "non-canonical publication coordinate $tag passed the first gate"
+  fi
+  grep -Fq "invalid canonical semver tag: $tag" "$TEST_ROOT/tag-check.out" \
+    || fail "the first gate did not explain the rejected coordinate $tag"
+done
 grep -q -- '--ref main' "$ROOT/RELEASING.md" \
   || fail 'the canonical replay ceremony does not select current guards'
 grep -q -- '--ref main' "$ROOT/docs/RELEASING.md" \
@@ -326,6 +348,8 @@ printf '%s\n' "$release_job" | grep -q 'ref: \${{ github.workflow_sha }}' \
 printf '%s\n' "$release_job" \
   | grep -q '.release-tooling/scripts/release/upload-assets-immutable.sh' \
   || fail 'the native release job invokes a helper from another job filesystem'
+printf '%s\n' "$release_job" | grep -q 'scripts/release/check-release-tag.sh' \
+  || fail 'the native release checkout omits the uploader coordinate validator'
 npm_publish_job="$(sed -n '/^  npm-wasm-publish:/,/^  docker:/p' \
   "$ROOT/.github/workflows/release.yml")"
 printf '%s\n' "$npm_publish_job" | grep -q 'actions/checkout@' \
@@ -334,8 +358,10 @@ printf '%s\n' "$npm_publish_job" | grep -q 'actions/checkout@' \
 # shellcheck disable=SC2016
 printf '%s\n' "$npm_publish_job" | grep -q 'ref: \${{ github.workflow_sha }}' \
   || fail 'a historical replay reads its helper from the old release tree'
-printf '%s\n' "$npm_publish_job" | grep -q 'sparse-checkout: scripts/release/upload-assets-immutable.sh' \
-  || fail 'the elevated npm publish job checks out more source than its one helper'
+printf '%s\n' "$npm_publish_job" | grep -q 'scripts/release/upload-assets-immutable.sh' \
+  || fail 'the elevated npm publish job omits its immutable-upload helper'
+printf '%s\n' "$npm_publish_job" | grep -q 'scripts/release/check-release-tag.sh' \
+  || fail 'the elevated npm publish job omits the uploader coordinate validator'
 printf '%s\n' "$npm_publish_job" | grep -q 'persist-credentials: false' \
   || fail 'the elevated npm publish checkout persists its write credential'
 provenance_job="$(sed -n '/^  provenance:/,/^  provenance-publish:/p' \
@@ -354,6 +380,8 @@ provenance_publish_job="$(sed -n '/^  provenance-publish:/,/^  bump-formula:/p' 
 printf '%s\n' "$provenance_publish_job" \
   | grep -q '.release-tooling/scripts/release/upload-assets-immutable.sh' \
   || fail 'SLSA provenance bypasses the immutable release uploader'
+printf '%s\n' "$provenance_publish_job" | grep -q 'scripts/release/check-release-tag.sh' \
+  || fail 'the provenance publisher omits the uploader coordinate validator'
 printf '%s\n' "$provenance_publish_job" \
   | grep -q 'needs.provenance.outputs.provenance-name' \
   || fail 'the provenance publisher does not fetch the signed run artifact'

--- a/scripts/release/tests/release-tooling.test.sh
+++ b/scripts/release/tests/release-tooling.test.sh
@@ -300,6 +300,15 @@ fi
 grep -q '.release-tooling/scripts/release/upload-assets-immutable.sh' \
   "$ROOT/.github/workflows/release.yml" \
   || fail 'the release workflow bypasses the immutable asset uploader'
+release_job="$(sed -n '/^  release:/,/^  provenance:/p' \
+  "$ROOT/.github/workflows/release.yml")"
+# The GitHub context is matched literally.
+# shellcheck disable=SC2016
+printf '%s\n' "$release_job" | grep -q 'ref: \${{ github.workflow_sha }}' \
+  || fail 'the native release job cannot access tooling during historical replay'
+printf '%s\n' "$release_job" \
+  | grep -q '.release-tooling/scripts/release/upload-assets-immutable.sh' \
+  || fail 'the native release job invokes a helper from another job filesystem'
 npm_publish_job="$(sed -n '/^  npm-wasm-publish:/,/^  docker:/p' \
   "$ROOT/.github/workflows/release.yml")"
 printf '%s\n' "$npm_publish_job" | grep -q 'actions/checkout@' \
@@ -312,13 +321,18 @@ printf '%s\n' "$npm_publish_job" | grep -q 'sparse-checkout: scripts/release/upl
   || fail 'the elevated npm publish job checks out more source than its one helper'
 printf '%s\n' "$npm_publish_job" | grep -q 'persist-credentials: false' \
   || fail 'the elevated npm publish checkout persists its write credential'
-provenance_job="$(sed -n '/^  provenance:/,/^  bump-formula:/p' \
+provenance_job="$(sed -n '/^  provenance:/,/^  provenance-publish:/p' \
   "$ROOT/.github/workflows/release.yml")"
-printf '%s\n' "$provenance_job" \
-  | grep -q "if: needs.release_state.outputs.intoto_exists != 'true'" \
-  || fail 'a replay can replace the occupied SLSA provenance asset'
-grep -q '^  release_state:' "$ROOT/.github/workflows/release.yml" \
-  || fail 'the workflow never probes whether SLSA provenance is occupied'
+printf '%s\n' "$provenance_job" | grep -q 'upload-assets: false' \
+  || fail 'the upstream SLSA uploader can delete and replace occupied provenance'
+provenance_publish_job="$(sed -n '/^  provenance-publish:/,/^  bump-formula:/p' \
+  "$ROOT/.github/workflows/release.yml")"
+printf '%s\n' "$provenance_publish_job" \
+  | grep -q '.release-tooling/scripts/release/upload-assets-immutable.sh' \
+  || fail 'SLSA provenance bypasses the immutable release uploader'
+printf '%s\n' "$provenance_publish_job" \
+  | grep -q 'needs.provenance.outputs.provenance-name' \
+  || fail 'the provenance publisher does not fetch the signed run artifact'
 bash "$ROOT/scripts/release/tests/immutable-assets.test.sh" >/dev/null \
   || fail 'the immutable asset replay regression failed'
 grep -q 'TAP_DEPLOY_KEY' "$ROOT/docs/RELEASING.md" \

--- a/scripts/release/tests/release-tooling.test.sh
+++ b/scripts/release/tests/release-tooling.test.sh
@@ -290,6 +290,20 @@ if printf '%s\n' "$concurrency_block" \
 fi
 printf '%s\n' "$concurrency_block" | grep -Fqx '  cancel-in-progress: false' \
   || fail 'the release workflow may cancel a train after an irreversible write'
+dispatch_job="$(sed -n '/^  dispatch-ref:/,/^  build:/p' \
+  "$ROOT/.github/workflows/release.yml")"
+printf '%s\n' "$dispatch_job" | grep -q 'WORKFLOW_REF:.*github.ref' \
+  || fail 'manual replay does not inspect the selected workflow ref'
+printf '%s\n' "$dispatch_job" | grep -q 'refs/heads/main' \
+  || fail 'manual replay does not require the current main workflow guards'
+build_job="$(sed -n '/^  build:/,/^  npm-check:/p' \
+  "$ROOT/.github/workflows/release.yml")"
+printf '%s\n' "$build_job" | grep -q '^    needs: dispatch-ref' \
+  || fail 'release builds can bypass the replay workflow-ref guard'
+grep -q -- '--ref main' "$ROOT/RELEASING.md" \
+  || fail 'the canonical replay ceremony does not select current guards'
+grep -q -- '--ref main' "$ROOT/docs/RELEASING.md" \
+  || fail 'the public replay guide does not select current guards'
 for label in \
   org.opencontainers.image.revision \
   org.opencontainers.image.version \

--- a/scripts/release/tests/release-tooling.test.sh
+++ b/scripts/release/tests/release-tooling.test.sh
@@ -280,6 +280,8 @@ grep -q 'crates/nika-acp/Cargo.lock' "$ROOT/RELEASING.md" \
   || fail 'the canonical carrier list omits crates/nika-acp/Cargo.lock'
 grep -q 'before declaring the release complete' "$ROOT/RELEASING.md" \
   || fail 'the ceremony does not say when the timeline record closes the release'
+# The GitHub expression is the literal workflow contract, not shell syntax.
+# shellcheck disable=SC2016
 grep -q 'group: release-${{ github.event.inputs.tag || github.ref_name }}' \
   "$ROOT/.github/workflows/release.yml" \
   || fail 'the release workflow does not serialize runs for the same tag'
@@ -297,6 +299,14 @@ if grep -q -- '--clobber' "$ROOT/.github/workflows/release.yml"; then
 fi
 grep -q 'upload-assets-immutable.sh' "$ROOT/.github/workflows/release.yml" \
   || fail 'the release workflow bypasses the immutable asset uploader'
+npm_publish_job="$(sed -n '/^  npm-wasm-publish:/,/^  docker:/p' \
+  "$ROOT/.github/workflows/release.yml")"
+printf '%s\n' "$npm_publish_job" | grep -q 'actions/checkout@' \
+  || fail 'the isolated npm publish job cannot access the immutable asset helper'
+printf '%s\n' "$npm_publish_job" | grep -q 'sparse-checkout: scripts/release/upload-assets-immutable.sh' \
+  || fail 'the elevated npm publish job checks out more source than its one helper'
+printf '%s\n' "$npm_publish_job" | grep -q 'persist-credentials: false' \
+  || fail 'the elevated npm publish checkout persists its write credential'
 bash "$ROOT/scripts/release/tests/immutable-assets.test.sh" >/dev/null \
   || fail 'the immutable asset replay regression failed'
 grep -q 'TAP_DEPLOY_KEY' "$ROOT/docs/RELEASING.md" \

--- a/scripts/release/tests/release-tooling.test.sh
+++ b/scripts/release/tests/release-tooling.test.sh
@@ -297,16 +297,28 @@ done
 if grep -q -- '--clobber' "$ROOT/.github/workflows/release.yml"; then
   fail 'the release workflow can overwrite bytes under an occupied asset name'
 fi
-grep -q 'upload-assets-immutable.sh' "$ROOT/.github/workflows/release.yml" \
+grep -q '.release-tooling/scripts/release/upload-assets-immutable.sh' \
+  "$ROOT/.github/workflows/release.yml" \
   || fail 'the release workflow bypasses the immutable asset uploader'
 npm_publish_job="$(sed -n '/^  npm-wasm-publish:/,/^  docker:/p' \
   "$ROOT/.github/workflows/release.yml")"
 printf '%s\n' "$npm_publish_job" | grep -q 'actions/checkout@' \
   || fail 'the isolated npm publish job cannot access the immutable asset helper'
+# The GitHub context is matched literally.
+# shellcheck disable=SC2016
+printf '%s\n' "$npm_publish_job" | grep -q 'ref: \${{ github.workflow_sha }}' \
+  || fail 'a historical replay reads its helper from the old release tree'
 printf '%s\n' "$npm_publish_job" | grep -q 'sparse-checkout: scripts/release/upload-assets-immutable.sh' \
   || fail 'the elevated npm publish job checks out more source than its one helper'
 printf '%s\n' "$npm_publish_job" | grep -q 'persist-credentials: false' \
   || fail 'the elevated npm publish checkout persists its write credential'
+provenance_job="$(sed -n '/^  provenance:/,/^  bump-formula:/p' \
+  "$ROOT/.github/workflows/release.yml")"
+printf '%s\n' "$provenance_job" \
+  | grep -q "if: needs.release_state.outputs.intoto_exists != 'true'" \
+  || fail 'a replay can replace the occupied SLSA provenance asset'
+grep -q '^  release_state:' "$ROOT/.github/workflows/release.yml" \
+  || fail 'the workflow never probes whether SLSA provenance is occupied'
 bash "$ROOT/scripts/release/tests/immutable-assets.test.sh" >/dev/null \
   || fail 'the immutable asset replay regression failed'
 grep -q 'TAP_DEPLOY_KEY' "$ROOT/docs/RELEASING.md" \

--- a/scripts/release/tests/release-tooling.test.sh
+++ b/scripts/release/tests/release-tooling.test.sh
@@ -280,12 +280,15 @@ grep -q 'crates/nika-acp/Cargo.lock' "$ROOT/RELEASING.md" \
   || fail 'the canonical carrier list omits crates/nika-acp/Cargo.lock'
 grep -q 'before declaring the release complete' "$ROOT/RELEASING.md" \
   || fail 'the ceremony does not say when the timeline record closes the release'
-# The GitHub expression is the literal workflow contract, not shell syntax.
-# shellcheck disable=SC2016
-grep -q 'group: release-${{ github.event.inputs.tag || github.ref_name }}' \
-  "$ROOT/.github/workflows/release.yml" \
-  || fail 'the release workflow does not serialize runs for the same tag'
-grep -q 'cancel-in-progress: false' "$ROOT/.github/workflows/release.yml" \
+concurrency_block="$(sed -n '/^concurrency:/,/^env:/p' \
+  "$ROOT/.github/workflows/release.yml")"
+printf '%s\n' "$concurrency_block" | grep -Fqx '  group: nika-release-train' \
+  || fail 'live and replay release trains do not share one publication lane'
+if printf '%s\n' "$concurrency_block" \
+  | grep -Eq 'github\.event\.inputs\.tag|github\.ref_name'; then
+  fail 'release concurrency is still partitioned by tag'
+fi
+printf '%s\n' "$concurrency_block" | grep -Fqx '  cancel-in-progress: false' \
   || fail 'the release workflow may cancel a train after an irreversible write'
 for label in \
   org.opencontainers.image.revision \
@@ -325,6 +328,11 @@ provenance_job="$(sed -n '/^  provenance:/,/^  provenance-publish:/p' \
   "$ROOT/.github/workflows/release.yml")"
 printf '%s\n' "$provenance_job" | grep -q 'upload-assets: false' \
   || fail 'the upstream SLSA uploader can delete and replace occupied provenance'
+printf '%s\n' "$provenance_job" | grep -q '^      contents: read' \
+  || fail 'the SLSA generator lacks read-only repository identity access'
+if printf '%s\n' "$provenance_job" | grep -q '^      contents: write'; then
+  fail 'the SLSA generator retains unnecessary release write authority'
+fi
 printf '%s\n' "$provenance_job" | grep -q "if: github.event_name == 'push'" \
   || fail 'manual replay can generate branch-context provenance for an old tag'
 provenance_publish_job="$(sed -n '/^  provenance-publish:/,/^  bump-formula:/p' \

--- a/scripts/release/tests/release-tooling.test.sh
+++ b/scripts/release/tests/release-tooling.test.sh
@@ -325,6 +325,8 @@ provenance_job="$(sed -n '/^  provenance:/,/^  provenance-publish:/p' \
   "$ROOT/.github/workflows/release.yml")"
 printf '%s\n' "$provenance_job" | grep -q 'upload-assets: false' \
   || fail 'the upstream SLSA uploader can delete and replace occupied provenance'
+printf '%s\n' "$provenance_job" | grep -q "if: github.event_name == 'push'" \
+  || fail 'manual replay can generate branch-context provenance for an old tag'
 provenance_publish_job="$(sed -n '/^  provenance-publish:/,/^  bump-formula:/p' \
   "$ROOT/.github/workflows/release.yml")"
 printf '%s\n' "$provenance_publish_job" \
@@ -333,6 +335,14 @@ printf '%s\n' "$provenance_publish_job" \
 printf '%s\n' "$provenance_publish_job" \
   | grep -q 'needs.provenance.outputs.provenance-name' \
   || fail 'the provenance publisher does not fetch the signed run artifact'
+provenance_replay_job="$(sed -n '/^  provenance-replay-check:/,/^  bump-formula:/p' \
+  "$ROOT/.github/workflows/release.yml")"
+printf '%s\n' "$provenance_replay_job" \
+  | grep -q "if: github.event_name == 'workflow_dispatch'" \
+  || fail 'manual replay has no tag-true provenance guard'
+printf '%s\n' "$provenance_replay_job" \
+  | grep -q 'requires exactly one existing multiple.intoto.jsonl' \
+  || fail 'manual replay silently heals provenance from the wrong context'
 bash "$ROOT/scripts/release/tests/immutable-assets.test.sh" >/dev/null \
   || fail 'the immutable asset replay regression failed'
 grep -q 'TAP_DEPLOY_KEY' "$ROOT/docs/RELEASING.md" \

--- a/scripts/release/tests/release-tooling.test.sh
+++ b/scripts/release/tests/release-tooling.test.sh
@@ -280,6 +280,25 @@ grep -q 'crates/nika-acp/Cargo.lock' "$ROOT/RELEASING.md" \
   || fail 'the canonical carrier list omits crates/nika-acp/Cargo.lock'
 grep -q 'before declaring the release complete' "$ROOT/RELEASING.md" \
   || fail 'the ceremony does not say when the timeline record closes the release'
+grep -q 'group: release-${{ github.event.inputs.tag || github.ref_name }}' \
+  "$ROOT/.github/workflows/release.yml" \
+  || fail 'the release workflow does not serialize runs for the same tag'
+grep -q 'cancel-in-progress: false' "$ROOT/.github/workflows/release.yml" \
+  || fail 'the release workflow may cancel a train after an irreversible write'
+for label in \
+  org.opencontainers.image.revision \
+  org.opencontainers.image.version \
+  org.opencontainers.image.source; do
+  grep -q "$label" "$ROOT/.github/workflows/release.yml" \
+    || fail "the release image omits OCI label $label"
+done
+if grep -q -- '--clobber' "$ROOT/.github/workflows/release.yml"; then
+  fail 'the release workflow can overwrite bytes under an occupied asset name'
+fi
+grep -q 'upload-assets-immutable.sh' "$ROOT/.github/workflows/release.yml" \
+  || fail 'the release workflow bypasses the immutable asset uploader'
+bash "$ROOT/scripts/release/tests/immutable-assets.test.sh" >/dev/null \
+  || fail 'the immutable asset replay regression failed'
 grep -q 'TAP_DEPLOY_KEY' "$ROOT/docs/RELEASING.md" \
   || fail 'the operator guide does not name the release workflow deploy key'
 if grep -q 'HOMEBREW_TAP_TOKEN' "$ROOT/docs/RELEASING.md"; then

--- a/scripts/release/upload-assets-immutable.sh
+++ b/scripts/release/upload-assets-immutable.sh
@@ -11,7 +11,13 @@ tag="$1"
 repo="$2"
 shift 2
 
-if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+# SemVer 2.0 core + prerelease. Build metadata is deliberately excluded: npm,
+# Homebrew, OCI, and GitHub must share one unambiguous publication coordinate,
+# while SemVer precedence intentionally ignores `+build` identifiers.
+core='(0|[1-9][0-9]*)'
+prerelease_id='(0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)'
+semver_tag="^v${core}\.${core}\.${core}(-${prerelease_id}(\.${prerelease_id})*)?$"
+if [[ ! "$tag" =~ $semver_tag ]]; then
   echo "release asset upload: invalid semver tag: $tag" >&2
   exit 64
 fi

--- a/scripts/release/upload-assets-immutable.sh
+++ b/scripts/release/upload-assets-immutable.sh
@@ -26,18 +26,23 @@ trap 'rm -r "$scratch"' EXIT
 asset_names="$(gh api "repos/${repo}/releases/tags/${tag}" --paginate \
   --jq '.assets[].name')"
 
+missing_assets=()
+seen_names=""
 for asset in "$@"; do
   [ -f "$asset" ] || {
     echo "release asset upload: missing local asset: $asset" >&2
     exit 66
   }
   name="$(basename "$asset")"
+  if printf '%s\n' "$seen_names" | grep -Fqx -- "$name"; then
+    echo "release asset upload: REFUSED duplicate local asset name ${name}" >&2
+    exit 73
+  fi
+  seen_names="${seen_names}${seen_names:+$'\n'}${name}"
   matches="$(printf '%s\n' "$asset_names" | grep -Fxc -- "$name" || true)"
   case "$matches" in
     0)
-      gh release upload "$tag" --repo "$repo" "$asset"
-      asset_names="${asset_names}${asset_names:+$'\n'}${name}"
-      echo "release asset upload: added ${name}"
+      missing_assets+=("$asset")
       ;;
     1)
       gh release download "$tag" --repo "$repo" --pattern "$name" --dir "$scratch"
@@ -52,4 +57,11 @@ for asset in "$@"; do
       exit 73
       ;;
   esac
+done
+
+# Validate the entire occupied set before mutating the release. If any public
+# byte differs, even earlier missing names remain absent.
+for asset in "${missing_assets[@]}"; do
+  gh release upload "$tag" --repo "$repo" "$asset"
+  echo "release asset upload: added $(basename "$asset")"
 done

--- a/scripts/release/upload-assets-immutable.sh
+++ b/scripts/release/upload-assets-immutable.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Upload release assets without ever replacing bytes under an occupied name.
+set -euo pipefail
+
+if [ "$#" -lt 3 ]; then
+  echo "usage: $0 <tag> <owner/repo> <asset>..." >&2
+  exit 64
+fi
+
+tag="$1"
+repo="$2"
+shift 2
+
+if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "release asset upload: invalid semver tag: $tag" >&2
+  exit 64
+fi
+if [[ ! "$repo" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+  echo "release asset upload: invalid repository: $repo" >&2
+  exit 64
+fi
+
+scratch="$(mktemp -d)"
+trap 'rm -r "$scratch"' EXIT
+
+asset_names="$(gh api "repos/${repo}/releases/tags/${tag}" --paginate \
+  --jq '.assets[].name')"
+
+for asset in "$@"; do
+  [ -f "$asset" ] || {
+    echo "release asset upload: missing local asset: $asset" >&2
+    exit 66
+  }
+  name="$(basename "$asset")"
+  matches="$(printf '%s\n' "$asset_names" | grep -Fxc -- "$name" || true)"
+  case "$matches" in
+    0)
+      gh release upload "$tag" --repo "$repo" "$asset"
+      asset_names="${asset_names}${asset_names:+$'\n'}${name}"
+      echo "release asset upload: added ${name}"
+      ;;
+    1)
+      gh release download "$tag" --repo "$repo" --pattern "$name" --dir "$scratch"
+      if ! cmp -s "$asset" "$scratch/$name"; then
+        echo "release asset upload: REFUSED different bytes for occupied asset ${name}" >&2
+        exit 73
+      fi
+      echo "release asset upload: ${name} already exists with identical bytes"
+      ;;
+    *)
+      echo "release asset upload: REFUSED duplicate public asset name ${name}" >&2
+      exit 73
+      ;;
+  esac
+done

--- a/scripts/release/upload-assets-immutable.sh
+++ b/scripts/release/upload-assets-immutable.sh
@@ -11,16 +11,8 @@ tag="$1"
 repo="$2"
 shift 2
 
-# SemVer 2.0 core + prerelease. Build metadata is deliberately excluded: npm,
-# Homebrew, OCI, and GitHub must share one unambiguous publication coordinate,
-# while SemVer precedence intentionally ignores `+build` identifiers.
-core='(0|[1-9][0-9]*)'
-prerelease_id='(0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)'
-semver_tag="^v${core}\.${core}\.${core}(-${prerelease_id}(\.${prerelease_id})*)?$"
-if [[ ! "$tag" =~ $semver_tag ]]; then
-  echo "release asset upload: invalid semver tag: $tag" >&2
-  exit 64
-fi
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+bash "$here/check-release-tag.sh" "$tag"
 if [[ ! "$repo" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
   echo "release asset upload: invalid repository: $repo" >&2
   exit 64


### PR DESCRIPTION
## Outcome

Hardens future release trains without rewriting v0.116.2:

- serializes every live and replay version through one publication lane so Homebrew and GHCR latest cannot race across tags;
- never cancels an active train after an irreversible registry write and documents the GitHub Actions one-pending-run boundary;
- validates the shared publication coordinate in the first DAG job, before builds or writes: strict SemVer prereleases are accepted, while build metadata and non-canonical tags fail closed;
- requires manual replay through the current main workflow with --ref main while checking out the immutable source tag;
- refuses to replace bytes under an occupied GitHub Release asset name while allowing identical no-op replay and missing-asset healing;
- overrides inherited Ubuntu OCI metadata with exact Nika source, release version, and commit revision labels;
- reduces the third-party SLSA generator from contents: write to contents: read; the first-party immutable publisher retains the only release write authority;
- incorporates the concurrent settlement fix from main and regenerates the combined estate manifest.

## Evidence

- immutable-assets.test.sh: missing, identical, divergent, prerelease, and invalid-coordinate cases
- release-tooling.test.sh: first-DAG coordinate guard, global concurrency, immutable upload, replay context, and SLSA least privilege
- fake-gh adversarial probe: v1.0.0+build exits 64 before any GitHub API invocation
- ShellCheck, canonical shfmt, actionlint, changelog assembly, estate, and gitleaks
- complete pre-push gate: workspace --lib including 153 nika-serve tests, Clippy, hygiene, and 11 CI ratchets
- independent final review CLEAR on exact head f9d4394c6a81aca442ed8d0dba080bd5f38485f5

## Honest boundary

This closes future cross-tag publication overlap, unsupported-coordinate partial publication, GitHub asset byte replacement, OCI label drift, and unnecessary SLSA write authority. Historical tags execute the workflow YAML stored in their own commit when selected as the workflow ref; that cannot be retrofitted, so the documented --ref main operator command and the current workflow ref guard are both part of the boundary. GitHub Actions retains only one pending train and can replace an older pending run, so the operator ceremony never queues more than one train behind the active run. This does not claim transactional atomicity across GitHub Releases, npm, GHCR, and Homebrew; issue #1340 remains open for the separately reviewed completeness barrier.

Signed-off-by: Thibaut Melen <20891897+ThibautMelen@users.noreply.github.com>
Co-Authored-By: Nika 🦋 <nika@supernovae.studio>