### PR TITLE
fix(serve): reserve settlement control capacity

### DIFF
--- a/changelog.d/1341.fixed.md
+++ b/changelog.d/1341.fixed.md
@@ -1,4 +1,4 @@
 - **Concurrent cancellation no longer starves terminal settlement.** The
-  resident store reserves control capacity for every HTTP connection, queued
-  ARM preparation, and active execution, so concurrent lifecycle settlements
-  cannot terminate the server or strand an abandoned preparation as running.
+  resident store keeps HTTP mutation ingress bounded while terminal execution,
+  shutdown, and abandoned ARM-preparation controls use reliable backpressure,
+  so overload cannot terminate the server or strand a run as running.

--- a/changelog.d/1341.fixed.md
+++ b/changelog.d/1341.fixed.md
@@ -1,0 +1,3 @@
+- **Concurrent cancellation no longer starves terminal settlement.** The
+  resident store reserves control capacity for every HTTP connection and
+  active execution, so a cancellation burst cannot terminate the server.

--- a/changelog.d/1341.fixed.md
+++ b/changelog.d/1341.fixed.md
@@ -1,3 +1,4 @@
 - **Concurrent cancellation no longer starves terminal settlement.** The
-  resident store reserves control capacity for every HTTP connection and
-  active execution, so a cancellation burst cannot terminate the server.
+  resident store reserves control capacity for every HTTP connection, queued
+  ARM preparation, and active execution, so concurrent lifecycle settlements
+  cannot terminate the server or strand an abandoned preparation as running.

--- a/crates/nika-serve/src/server/coordinator_tests.rs
+++ b/crates/nika-serve/src/server/coordinator_tests.rs
@@ -504,6 +504,61 @@ async fn losing_claim_aborts_prepared_runs_and_origin_namespaces_do_not_collide(
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn concurrent_prepared_drop_settles_every_reserved_queue_slot() {
+    const QUEUE_CAPACITY: usize = 64;
+    let world = TestWorld::new();
+    let backend = Arc::new(TestBackend::completes(ExecutionDisposition::Succeeded));
+    let bounded_limits = ServerLimits::new(
+        1024,
+        Duration::from_secs(2),
+        Duration::from_secs(2),
+        Duration::from_millis(200),
+        1,
+        QUEUE_CAPACITY,
+        1,
+        32,
+    );
+    let server = world.start(backend.clone(), bounded_limits).await;
+    let mut run_ids = Vec::with_capacity(QUEUE_CAPACITY);
+    let mut prepared_runs = Vec::with_capacity(QUEUE_CAPACITY);
+
+    for index in 0..QUEUE_CAPACITY {
+        let schedule_id = format!("drop-{index}");
+        let prepared = prepare(
+            server.coordinator(),
+            admitted(&world),
+            scheduled_origin(ScheduleOrigin::Project, &schedule_id, 'a'),
+        )
+        .await;
+        run_ids.push(prepared.run_id().clone());
+        prepared_runs.push(prepared);
+    }
+
+    let barrier = Arc::new(std::sync::Barrier::new(QUEUE_CAPACITY));
+    let drops = prepared_runs
+        .into_iter()
+        .map(|prepared| {
+            let barrier = barrier.clone();
+            tokio::task::spawn_blocking(move || {
+                barrier.wait();
+                drop(prepared);
+            })
+        })
+        .collect::<Vec<_>>();
+    for dropped in drops {
+        dropped.await.expect("prepared drop task");
+    }
+
+    for run_id in run_ids {
+        wait_for_status(&server, run_id.as_str(), "failed")
+            .await
+            .expect("every abandoned preparation settles");
+    }
+    assert_eq!(backend.calls(), 0, "a lost ARM claim cannot reach effects");
+    server.stop().await.expect("clean stop");
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn restart_surfaces_running_schedule_as_interrupted_ambiguity() {
     let world = TestWorld::new();
     let backend = Arc::new(TestBackend::completes(ExecutionDisposition::Succeeded));

--- a/crates/nika-serve/src/server/mod.rs
+++ b/crates/nika-serve/src/server/mod.rs
@@ -361,15 +361,9 @@ impl ResidentAuthority {
 }
 
 fn store_control_capacity(limits: ServerLimits) -> usize {
-    // Every live HTTP connection may have one lifecycle mutation queued, every
-    // reserved job slot may abort a prepared ARM run, and every running
-    // execution still needs a terminal settlement slot. One final slot keeps
-    // shutdown/control progress independent of that combined fan-in.
-    limits
-        .max_connections()
-        .saturating_add(limits.queue_capacity())
-        .saturating_add(limits.max_concurrent_jobs())
-        .saturating_add(1)
+    // HTTP mutations remain bounded and may fail fast when this ingress queue
+    // is full. Internal lifecycle controls use reliable backpressure instead.
+    limits.max_connections()
 }
 
 /// Bound authenticated HTTP listener attached to a resident authority.
@@ -885,7 +879,7 @@ async fn start_running(
 ) -> Result<bool, ServerError> {
     match guard
         .store
-        .start_execution(
+        .start_execution_reliable(
             guard.id.clone(),
             admitted.execution_id().to_string(),
             admitted.trace_id().to_string(),
@@ -1026,7 +1020,7 @@ impl RunningGuard {
     ) -> Result<(), ServerError> {
         let result = self
             .store
-            .settle_with_result(self.id.clone(), status, event, outputs, receipt)
+            .settle_with_result_reliable(self.id.clone(), status, event, outputs, receipt)
             .await;
         if let Err(ServerError::JobStore(crate::JobStoreError::IllegalTransition { .. })) = &result
         {

--- a/crates/nika-serve/src/server/mod.rs
+++ b/crates/nika-serve/src/server/mod.rs
@@ -280,15 +280,12 @@ impl ResidentAuthority {
     ) -> Result<Self, ServerError> {
         validate_resident_config(&config)?;
         let prepared = prepare_authority(&config).await?;
+        let control_capacity = store_control_capacity(config.limits());
         let store_actor = StoreActor::start(
             prepared.store,
             prepared.incarnation,
             config.limits().max_connections(),
-            config
-                .limits()
-                .max_concurrent_jobs()
-                .saturating_mul(2)
-                .saturating_add(4),
+            control_capacity,
         )?;
         let (jobs, receiver) = mpsc::channel(config.limits().queue_capacity());
         let recovered = store_actor
@@ -361,6 +358,16 @@ impl ResidentAuthority {
     {
         run_authority_with_http(self, server, shutdown).await
     }
+}
+
+fn store_control_capacity(limits: ServerLimits) -> usize {
+    // Every live HTTP connection may have one lifecycle mutation queued while
+    // each running execution still needs a reserved terminal settlement slot.
+    // One final slot keeps shutdown/control progress independent of that fan-in.
+    limits
+        .max_connections()
+        .saturating_add(limits.max_concurrent_jobs())
+        .saturating_add(1)
 }
 
 /// Bound authenticated HTTP listener attached to a resident authority.

--- a/crates/nika-serve/src/server/mod.rs
+++ b/crates/nika-serve/src/server/mod.rs
@@ -361,11 +361,13 @@ impl ResidentAuthority {
 }
 
 fn store_control_capacity(limits: ServerLimits) -> usize {
-    // Every live HTTP connection may have one lifecycle mutation queued while
-    // each running execution still needs a reserved terminal settlement slot.
-    // One final slot keeps shutdown/control progress independent of that fan-in.
+    // Every live HTTP connection may have one lifecycle mutation queued, every
+    // reserved job slot may abort a prepared ARM run, and every running
+    // execution still needs a terminal settlement slot. One final slot keeps
+    // shutdown/control progress independent of that combined fan-in.
     limits
         .max_connections()
+        .saturating_add(limits.queue_capacity())
         .saturating_add(limits.max_concurrent_jobs())
         .saturating_add(1)
 }

--- a/crates/nika-serve/src/server/store.rs
+++ b/crates/nika-serve/src/server/store.rs
@@ -302,6 +302,27 @@ impl StoreHandle {
         receive(answer).await
     }
 
+    pub(super) async fn start_execution_reliable(
+        &self,
+        id: JobId,
+        execution_id: String,
+        trace_id: String,
+        snapshot_digest: String,
+        event: Value,
+    ) -> Result<JobRecord, ServerError> {
+        let (reply, answer) = oneshot::channel();
+        self.send_control_reliable(ControlCommand::StartExecution {
+            id,
+            execution_id,
+            trace_id,
+            snapshot_digest,
+            event,
+            reply,
+        })
+        .await?;
+        receive(answer).await
+    }
+
     pub(super) async fn queued_jobs(&self) -> Result<Vec<(JobId, String)>, ServerError> {
         let (reply, answer) = oneshot::channel();
         self.send_request(RequestCommand::Queued { reply })?;
@@ -354,14 +375,15 @@ impl StoreHandle {
         event: Value,
     ) -> Result<JobRecord, ServerError> {
         let (reply, answer) = oneshot::channel();
-        self.send_control(ControlCommand::Transition {
+        self.send_control_reliable(ControlCommand::Transition {
             id,
             status,
             event,
             outputs: None,
             receipt: None,
             reply,
-        })?;
+        })
+        .await?;
         receive(answer).await
     }
 
@@ -390,6 +412,32 @@ impl StoreHandle {
         result
     }
 
+    pub(super) async fn settle_with_result_reliable(
+        &self,
+        id: JobId,
+        status: JobStatus,
+        event: Value,
+        outputs: Option<BTreeMap<String, Value>>,
+        receipt: Option<JobReceipt>,
+    ) -> Result<JobRecord, ServerError> {
+        let (reply, answer) = oneshot::channel();
+        self.send_control_reliable(ControlCommand::Transition {
+            id,
+            status,
+            event,
+            outputs,
+            receipt: receipt.map(Box::new),
+            reply,
+        })
+        .await?;
+        let result = receive(answer).await;
+        #[cfg(test)]
+        if result.is_ok() {
+            self.shutdown_probe.mark_terminal_settled();
+        }
+        result
+    }
+
     pub(super) fn settle_with_result_blocking(
         &self,
         id: JobId,
@@ -399,7 +447,7 @@ impl StoreHandle {
         receipt: Option<JobReceipt>,
     ) -> Result<JobRecord, ServerError> {
         let (reply, answer) = oneshot::channel();
-        self.send_control(ControlCommand::Transition {
+        self.send_control_blocking(ControlCommand::Transition {
             id,
             status,
             event,
@@ -412,20 +460,22 @@ impl StoreHandle {
 
     pub(super) async fn interrupt(&self, id: JobId) -> Result<JobRecord, ServerError> {
         let (reply, answer) = oneshot::channel();
-        self.send_control(ControlCommand::Interrupt {
+        self.send_control_reliable(ControlCommand::Interrupt {
             id,
             reply: Some(reply),
-        })?;
+        })
+        .await?;
         receive(answer).await
     }
 
     pub(super) fn interrupt_detached(&self, id: JobId) {
-        let _result = self.send_control(ControlCommand::Interrupt { id, reply: None });
+        let _result = self.send_control_blocking(ControlCommand::Interrupt { id, reply: None });
     }
 
     pub(super) async fn settle_interrupted(&self) -> Result<usize, ServerError> {
         let (reply, answer) = oneshot::channel();
-        self.send_control(ControlCommand::SettleInterrupted { reply })?;
+        self.send_control_reliable(ControlCommand::SettleInterrupted { reply })
+            .await?;
         receive(answer).await
     }
 
@@ -445,6 +495,23 @@ impl StoreHandle {
                 std::sync::mpsc::TrySendError::Full(_) => ServerError::StoreQueueFull,
                 std::sync::mpsc::TrySendError::Disconnected(_) => ServerError::BlockingTask,
             })
+    }
+
+    async fn send_control_reliable(&self, command: ControlCommand) -> Result<(), ServerError> {
+        let controls = self.controls.clone();
+        tokio::task::spawn_blocking(move || {
+            controls
+                .send(command)
+                .map_err(|_| ServerError::BlockingTask)
+        })
+        .await
+        .map_err(|_| ServerError::BlockingTask)?
+    }
+
+    fn send_control_blocking(&self, command: ControlCommand) -> Result<(), ServerError> {
+        self.controls
+            .send(command)
+            .map_err(|_| ServerError::BlockingTask)
     }
 }
 

--- a/crates/nika-serve/src/server/store.rs
+++ b/crates/nika-serve/src/server/store.rs
@@ -311,15 +311,14 @@ impl StoreHandle {
         event: Value,
     ) -> Result<JobRecord, ServerError> {
         let (reply, answer) = oneshot::channel();
-        self.send_control_reliable(ControlCommand::StartExecution {
+        self.send_control_blocking(ControlCommand::StartExecution {
             id,
             execution_id,
             trace_id,
             snapshot_digest,
             event,
             reply,
-        })
-        .await?;
+        })?;
         receive(answer).await
     }
 
@@ -375,15 +374,14 @@ impl StoreHandle {
         event: Value,
     ) -> Result<JobRecord, ServerError> {
         let (reply, answer) = oneshot::channel();
-        self.send_control_reliable(ControlCommand::Transition {
+        self.send_control_blocking(ControlCommand::Transition {
             id,
             status,
             event,
             outputs: None,
             receipt: None,
             reply,
-        })
-        .await?;
+        })?;
         receive(answer).await
     }
 
@@ -421,15 +419,14 @@ impl StoreHandle {
         receipt: Option<JobReceipt>,
     ) -> Result<JobRecord, ServerError> {
         let (reply, answer) = oneshot::channel();
-        self.send_control_reliable(ControlCommand::Transition {
+        self.send_control_blocking(ControlCommand::Transition {
             id,
             status,
             event,
             outputs,
             receipt: receipt.map(Box::new),
             reply,
-        })
-        .await?;
+        })?;
         let result = receive(answer).await;
         #[cfg(test)]
         if result.is_ok() {
@@ -460,11 +457,10 @@ impl StoreHandle {
 
     pub(super) async fn interrupt(&self, id: JobId) -> Result<JobRecord, ServerError> {
         let (reply, answer) = oneshot::channel();
-        self.send_control_reliable(ControlCommand::Interrupt {
+        self.send_control_blocking(ControlCommand::Interrupt {
             id,
             reply: Some(reply),
-        })
-        .await?;
+        })?;
         receive(answer).await
     }
 
@@ -474,8 +470,7 @@ impl StoreHandle {
 
     pub(super) async fn settle_interrupted(&self) -> Result<usize, ServerError> {
         let (reply, answer) = oneshot::channel();
-        self.send_control_reliable(ControlCommand::SettleInterrupted { reply })
-            .await?;
+        self.send_control_blocking(ControlCommand::SettleInterrupted { reply })?;
         receive(answer).await
     }
 
@@ -495,17 +490,6 @@ impl StoreHandle {
                 std::sync::mpsc::TrySendError::Full(_) => ServerError::StoreQueueFull,
                 std::sync::mpsc::TrySendError::Disconnected(_) => ServerError::BlockingTask,
             })
-    }
-
-    async fn send_control_reliable(&self, command: ControlCommand) -> Result<(), ServerError> {
-        let controls = self.controls.clone();
-        tokio::task::spawn_blocking(move || {
-            controls
-                .send(command)
-                .map_err(|_| ServerError::BlockingTask)
-        })
-        .await
-        .map_err(|_| ServerError::BlockingTask)?
     }
 
     fn send_control_blocking(&self, command: ControlCommand) -> Result<(), ServerError> {

--- a/crates/nika-serve/src/server/tests.rs
+++ b/crates/nika-serve/src/server/tests.rs
@@ -260,9 +260,9 @@ pub(super) fn limits() -> ServerLimits {
 }
 
 #[test]
-fn store_control_queue_reserves_settlement_beyond_http_fan_in() {
+fn store_control_queue_tracks_bounded_http_fan_in() {
     let limits = limits();
-    assert_eq!(store_control_capacity(limits), 64 + 16 + 4 + 1);
+    assert_eq!(store_control_capacity(limits), limits.max_connections());
 }
 
 fn short_shutdown_limits() -> ServerLimits {

--- a/crates/nika-serve/src/server/tests.rs
+++ b/crates/nika-serve/src/server/tests.rs
@@ -266,10 +266,8 @@ fn store_control_queue_reserves_settlement_beyond_http_fan_in() {
         store_control_capacity(limits),
         limits
             .max_connections()
-            .saturating_add(limits.max_concurrent_jobs())
-            .saturating_add(1)
+            .saturating_add(limits.max_concurrent_jobs().saturating_add(1))
     );
-    assert!(store_control_capacity(limits) > limits.max_connections());
 }
 
 fn short_shutdown_limits() -> ServerLimits {

--- a/crates/nika-serve/src/server/tests.rs
+++ b/crates/nika-serve/src/server/tests.rs
@@ -13,7 +13,6 @@ use serde_json::{Value, json};
 use sha2::{Digest as _, Sha256};
 use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 use tokio::sync::oneshot;
-use tokio::task::JoinSet;
 
 use super::route::SNAPSHOT_WIRE_UNIT_CEILING;
 use super::test_support::assert_allowlisted;
@@ -371,6 +370,8 @@ fn four_header_limits() -> ServerLimits {
 }
 
 #[cfg(test)]
+mod cancel_race;
+#[cfg(test)]
 mod request_lifecycle;
 
 #[tokio::test(flavor = "multi_thread")]
@@ -719,60 +720,22 @@ async fn interrupted_event_stream_redacts_payload_fields() {
     second.stop().await.expect("clean stop");
 }
 
-#[tokio::test(flavor = "multi_thread")]
-async fn concurrent_cancel_is_idempotent_and_wins_the_running_settlement_race() {
-    let world = TestWorld::new();
-    let backend = Arc::new(GatedBackend::new());
-    let server = world.start(backend.clone(), limits()).await;
-    let created = server
-        .request(&post_request(
-            r#"{"workflow":"root.nika.yaml"}"#,
-            "cancel-race",
-            &auth_header(),
-        ))
-        .await;
-    let id = created.json()["id"].as_str().expect("id").to_owned();
-    wait_for_status(&server, &id, "running")
-        .await
-        .expect("running");
+#[test]
+fn missing_wire_boundary_diagnostic_omits_request_headers() {
+    let request = format!("POST /v1/jobs/cancel HTTP/1.1\r\nAuthorization: Bearer {TOKEN}\r\n\r\n");
+    let address = "127.0.0.1:1".parse().expect("test address");
+    let panic = std::panic::catch_unwind(|| assert_http_response_boundary(address, &request, &[]))
+        .expect_err("missing boundary must panic");
+    let message = panic
+        .downcast_ref::<String>()
+        .map(String::as_str)
+        .or_else(|| panic.downcast_ref::<&str>().copied())
+        .expect("string panic");
 
-    let request = cancel_request(&id);
-    let mut racers = JoinSet::new();
-    for _ in 0..12 {
-        let request = request.clone();
-        let address = server.address;
-        racers.spawn(async move { wire_request(address, &request).await });
-    }
-    while let Some(response) = racers.join_next().await {
-        let response = response.expect("cancel request");
-        assert!(matches!(response.status, 200 | 202), "{response:#?}");
-        assert_eq!(response.json()["id"], id);
-    }
-    backend.release(1);
-    wait_for_status(&server, &id, "cancelled")
-        .await
-        .expect("cancelled");
-
-    let job = server
-        .request(&get_request(&format!("/v1/jobs/{id}")))
-        .await
-        .json();
-    assert_eq!(job["status"], "cancelled");
-    assert_eq!(job["receipt"]["job_id"], id);
-    assert_eq!(job["receipt"]["execution_id"], job["execution_id"]);
-    assert_eq!(job["receipt"]["trace_id"], job["trace_id"]);
-    let replay = server.request(&cancel_request(&id)).await;
-    assert_eq!(replay.status, 200, "{}", replay.body);
-    assert_eq!(replay.json(), job);
-
-    let streamed = server.request(&events_request(&id, None)).await;
-    let events = parse_sse_data(&streamed.body);
-    let terminal = events
-        .iter()
-        .find(|event| event["status"] == "cancelled")
-        .expect("cancelled terminal event");
-    assert_eq!(terminal["receipt"], job["receipt"]);
-    server.stop().await.expect("clean stop");
+    assert!(message.contains("request=\"POST /v1/jobs/cancel HTTP/1.1\""));
+    assert!(message.contains("bytes=0"));
+    assert!(!message.contains(TOKEN));
+    assert!(!message.contains("Authorization"));
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -993,13 +956,42 @@ pub(super) async fn wait_for_status(
 }
 
 async fn wire_request(address: SocketAddr, request: &str) -> WireResponse {
-    let mut stream = tokio::net::TcpStream::connect(address)
-        .await
-        .expect("connect");
-    stream.write_all(request.as_bytes()).await.expect("write");
+    let request_line = request.lines().next().unwrap_or("<empty>");
+    let stream = tokio::net::TcpStream::connect(address).await;
+    assert!(
+        stream.is_ok(),
+        "HTTP connect failed: peer={address} request={request_line:?}: {:?}",
+        stream.as_ref().err()
+    );
+    let mut stream = stream.expect("connect result checked");
+    let written = stream.write_all(request.as_bytes()).await;
+    assert!(
+        written.is_ok(),
+        "HTTP write failed: peer={address} request={request_line:?}: {:?}",
+        written.as_ref().err()
+    );
     let mut response = Vec::new();
-    stream.read_to_end(&mut response).await.expect("read");
+    let read = stream.read_to_end(&mut response).await;
+    assert!(
+        read.is_ok(),
+        "HTTP read failed: peer={address} request={request_line:?}: {:?}",
+        read.as_ref().err()
+    );
+    assert_http_response_boundary(address, request, &response);
     WireResponse::parse(&response)
+}
+
+fn assert_http_response_boundary(address: SocketAddr, request: &str, response: &[u8]) {
+    let request_line = request.lines().next().unwrap_or("<empty>");
+    let prefix_len = response.len().min(256);
+    let prefix = String::from_utf8_lossy(&response[..prefix_len])
+        .escape_default()
+        .to_string();
+    assert!(
+        response.windows(4).any(|window| window == b"\r\n\r\n"),
+        "HTTP response boundary missing: peer={address} request={request_line:?} bytes={} prefix={prefix:?}",
+        response.len()
+    );
 }
 
 pub(super) fn post_request(body: &str, key: &str, authorization: &str) -> String {

--- a/crates/nika-serve/src/server/tests.rs
+++ b/crates/nika-serve/src/server/tests.rs
@@ -262,12 +262,7 @@ pub(super) fn limits() -> ServerLimits {
 #[test]
 fn store_control_queue_reserves_settlement_beyond_http_fan_in() {
     let limits = limits();
-    assert_eq!(
-        store_control_capacity(limits),
-        limits
-            .max_connections()
-            .saturating_add(limits.max_concurrent_jobs().saturating_add(1))
-    );
+    assert_eq!(store_control_capacity(limits), 64 + 16 + 4 + 1);
 }
 
 fn short_shutdown_limits() -> ServerLimits {

--- a/crates/nika-serve/src/server/tests.rs
+++ b/crates/nika-serve/src/server/tests.rs
@@ -259,6 +259,19 @@ pub(super) fn limits() -> ServerLimits {
     )
 }
 
+#[test]
+fn store_control_queue_reserves_settlement_beyond_http_fan_in() {
+    let limits = limits();
+    assert_eq!(
+        store_control_capacity(limits),
+        limits
+            .max_connections()
+            .saturating_add(limits.max_concurrent_jobs())
+            .saturating_add(1)
+    );
+    assert!(store_control_capacity(limits) > limits.max_connections());
+}
+
 fn short_shutdown_limits() -> ServerLimits {
     ServerLimits::new(
         1024,

--- a/crates/nika-serve/src/server/tests/cancel_race.rs
+++ b/crates/nika-serve/src/server/tests/cancel_race.rs
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::task::JoinSet;
+
+use super::*;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_cancel_is_idempotent_and_wins_the_running_settlement_race() {
+    for round in 0..32 {
+        let outcome =
+            tokio::time::timeout(Duration::from_secs(10), run_concurrent_cancel_round(round)).await;
+        assert!(outcome.is_ok(), "concurrent cancel round {round} timed out");
+    }
+}
+
+async fn run_concurrent_cancel_round(round: usize) {
+    let world = TestWorld::new();
+    let backend = Arc::new(GatedBackend::new());
+    let server = world.start(backend.clone(), limits()).await;
+    let created = server
+        .request(&post_request(
+            r#"{"workflow":"root.nika.yaml"}"#,
+            &format!("cancel-race-{round}"),
+            &auth_header(),
+        ))
+        .await;
+    let id = created.json()["id"].as_str().expect("id").to_owned();
+    wait_for_status(&server, &id, "running")
+        .await
+        .expect("running");
+
+    let request = cancel_request(&id);
+    let barrier = Arc::new(tokio::sync::Barrier::new(13));
+    let mut racers = JoinSet::new();
+    for _ in 0..12 {
+        let request = request.clone();
+        let address = server.address;
+        let barrier = Arc::clone(&barrier);
+        racers.spawn(async move {
+            barrier.wait().await;
+            wire_request(address, &request).await
+        });
+    }
+    barrier.wait().await;
+    while let Some(response) = racers.join_next().await {
+        let response = response.expect("cancel request");
+        assert!(matches!(response.status, 200 | 202), "{response:#?}");
+        assert_eq!(response.json()["id"], id);
+    }
+    backend.release(1);
+    wait_for_status(&server, &id, "cancelled")
+        .await
+        .expect("cancelled");
+
+    let job = server
+        .request(&get_request(&format!("/v1/jobs/{id}")))
+        .await
+        .json();
+    assert_eq!(job["status"], "cancelled");
+    assert_eq!(job["receipt"]["job_id"], id);
+    assert_eq!(job["receipt"]["execution_id"], job["execution_id"]);
+    assert_eq!(job["receipt"]["trace_id"], job["trace_id"]);
+    let replay = server.request(&cancel_request(&id)).await;
+    assert_eq!(replay.status, 200, "{}", replay.body);
+    assert_eq!(replay.json(), job);
+
+    let streamed = server.request(&events_request(&id, None)).await;
+    let events = parse_sse_data(&streamed.body);
+    let terminal = events
+        .iter()
+        .find(|event| event["status"] == "cancelled")
+        .expect("cancelled terminal event");
+    assert_eq!(terminal["receipt"], job["receipt"]);
+    server.stop().await.expect("clean stop");
+}


### PR DESCRIPTION
## Outcome

Prevents the resident nika serve authority from losing internal lifecycle settlements when bounded HTTP mutation ingress is full.

HTTP-originated mutations remain bounded and fail fast with StoreQueueFull. Internal start, terminal settlement, interruption, shutdown settlement, and abandoned ARM-preparation controls use synchronous backpressure to the dedicated store actor before their first await. StoreActor shutdown begins only after the execution authority joins, coupling accepted internal controls to the store lifetime. This removes the false assumption that one static capacity formula can bound controls orphaned by request timeouts or task cancellation.

## Regression proof

- 64 PreparedScheduledRun values reserve the complete jobs queue, synchronize their drops, and all 64 durably settle failed through a one-slot control queue
- 32 synchronized rounds each issue 12 concurrent HTTP cancellations with no retry or sleep; every accepted request receives a complete 200 or 202 response
- missing HTTP boundaries report peer, request line, byte count, and a 256-byte escaped prefix without request headers or bearer material
- cargo nextest run -p nika-serve --lib: 153/153
- cargo clippy -p nika-serve --all-targets -- -D warnings
- LOC, function-length, formatting, changelog, unwrap and estate gates green

Closes #1341

Signed-off-by: Thibaut Melen <thibaut@supernovae.studio>
Co-Authored-By: Nika 🦋 <nika@supernovae.studio>