### PR TITLE
fix(arm): hash the admitted world digest into arm generation + ceiling manual runs under a server default

### DIFF
--- a/crates/nika-arm/src/fire.rs
+++ b/crates/nika-arm/src/fire.rs
@@ -1048,11 +1048,7 @@ fn admit_workflow(ctx: &FireCtx, beat: &Beat) -> std::io::Result<PinnedExecution
                 format!("arm workflow admission refused: {error}"),
             )
         })?;
-    let source = admitted
-        .snapshot()
-        .unit(admitted.snapshot().root())
-        .ok_or_else(|| std::io::Error::other("arm workflow admission lost its root unit"))?;
-    let generation = ArmGeneration::compute(beat, source.bytes());
+    let generation = ArmGeneration::compute(beat, admitted.snapshot().digest());
     Ok(PinnedExecution {
         project,
         generation,
@@ -1179,10 +1175,8 @@ mod tests {
     fn public_run_and_verdict_projections_preserve_every_value() {
         let project = tempfile::tempdir().expect("project");
         let registry = registry_with(BASE);
-        let generation = ArmGeneration::compute(
-            registry.beats().next().expect("beat"),
-            b"schema: nika/workflow@0.12\ntasks: {}\n",
-        );
+        let generation =
+            ArmGeneration::compute(registry.beats().next().expect("beat"), &"d".repeat(64));
         let schedule =
             ScheduleDraft::from_project("doctor", registry.beats().next().expect("beat"))
                 .and_then(ScheduleDraft::validate)

--- a/crates/nika-arm/src/fire/firer_tests.rs
+++ b/crates/nika-arm/src/fire/firer_tests.rs
@@ -488,7 +488,14 @@ fn source_edit_after_claim_cannot_change_the_pinned_run_bytes() {
     let source = dir.path().join("workflows/doctor.nika.yaml");
     let original = std::fs::read(&source).expect("source A");
     let registry = registry_with(SAUTER);
-    let expected = ArmGeneration::compute(registry.1.beats().next().expect("beat"), &original);
+    let project = OwnedDir::open(dir.path()).expect("project capability");
+    let admitted = ExecutionService::default()
+        .admit(&project, Path::new("workflows/doctor.nika.yaml"))
+        .expect("admitted world");
+    let expected = ArmGeneration::compute(
+        registry.1.beats().next().expect("beat"),
+        admitted.snapshot().digest(),
+    );
     let logical_path = Rc::new(RefCell::new(None::<String>));
     let seen_path = Rc::clone(&logical_path);
     let seam: ExecutionRunSeam = Rc::new(move |execution, shot| {
@@ -570,6 +577,60 @@ fn child_and_skill_edits_after_claim_cannot_change_the_admitted_world() {
     assert_eq!(verdict.code, exit::OK, "{}", verdict.line);
 }
 
+/// The generation a firing pins covers the WHOLE admitted world (#1343):
+/// editing ONLY a child workflow or ONLY a skill between two admissions
+/// — two fires — mints a new generation; an unchanged world keeps its
+/// own (the seam suites above prove the fire pins exactly this value).
+#[test]
+fn a_child_or_skill_edit_between_admissions_mints_a_new_generation() {
+    let dir = project("generation-world-edit");
+    let root = "nika: doctor\nmodel: mock/echo\npermits:\n  exec: [\"echo\"]\n  fs:\n    read: [\"skills/review/SKILL.md\"]\ntasks:\n  child:\n    invoke:\n      workflow: \"child.nika.yaml\"\n      args: { url: \"https://example.com\" }\n    returns: { object: { report: string } }\n  review:\n    agent: { prompt: \"review\", skills: [\"skills/review/SKILL.md\"] }\n";
+    let child = "nika: child\ninputs:\n  url: { type: string, required: true }\npermits:\n  exec: [\"echo\"]\ntasks:\n  fetch:\n    exec: { command: [\"echo\", \"${{ inputs.url }}\"] }\noutputs:\n  report: { value: \"${{ tasks.fetch.output }}\", type: string }\n";
+    let skill = "---\nname: review\ndescription: Review code.\n---\nOriginal.\n";
+    std::fs::write(dir.path().join("workflows/doctor.nika.yaml"), root).expect("root");
+    std::fs::write(dir.path().join("workflows/child.nika.yaml"), child).expect("child");
+    std::fs::create_dir_all(dir.path().join("workflows/skills/review")).expect("skill dir");
+    std::fs::write(dir.path().join("workflows/skills/review/SKILL.md"), skill).expect("skill");
+    let registry = registry_with(SAUTER);
+    let beat = registry.1.beats().next().expect("beat");
+    let service = ExecutionService::default();
+    let admit = || {
+        let project = OwnedDir::open(dir.path()).expect("project capability");
+        service
+            .admit(&project, Path::new("workflows/doctor.nika.yaml"))
+            .expect("admitted world")
+    };
+    let base = ArmGeneration::compute(beat, admit().snapshot().digest());
+    assert_eq!(
+        base,
+        ArmGeneration::compute(beat, admit().snapshot().digest()),
+        "an unchanged world keeps its generation"
+    );
+    // Edit ONLY the child — the root bytes never move.
+    std::fs::write(
+        dir.path().join("workflows/child.nika.yaml"),
+        "nika: child-v2\ninputs:\n  url: { type: string, required: true }\npermits:\n  exec: [\"echo\"]\ntasks:\n  fetch:\n    exec: { command: [\"echo\", \"${{ inputs.url }}\"] }\noutputs:\n  report: { value: \"${{ tasks.fetch.output }}\", type: string }\n",
+    )
+    .expect("edit child");
+    assert_ne!(
+        base,
+        ArmGeneration::compute(beat, admit().snapshot().digest()),
+        "a child-only edit mints a new generation"
+    );
+    // Restore the child, edit ONLY the skill.
+    std::fs::write(dir.path().join("workflows/child.nika.yaml"), child).expect("restore child");
+    std::fs::write(
+        dir.path().join("workflows/skills/review/SKILL.md"),
+        "---\nname: review\ndescription: Review code.\n---\nRevised.\n",
+    )
+    .expect("edit skill");
+    assert_ne!(
+        base,
+        ArmGeneration::compute(beat, admit().snapshot().digest()),
+        "a skill-only edit mints a new generation"
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn source_symlink_swap_after_claim_cannot_change_the_pinned_run_bytes() {
@@ -585,7 +646,14 @@ fn source_symlink_swap_after_claim_cannot_change_the_pinned_run_bytes() {
     )
     .expect("source B");
     let registry = registry_with(SAUTER);
-    let expected = ArmGeneration::compute(registry.1.beats().next().expect("beat"), &original);
+    let project = OwnedDir::open(dir.path()).expect("project capability");
+    let admitted = ExecutionService::default()
+        .admit(&project, Path::new("workflows/doctor.nika.yaml"))
+        .expect("admitted world");
+    let expected = ArmGeneration::compute(
+        registry.1.beats().next().expect("beat"),
+        admitted.snapshot().digest(),
+    );
     let seam: ExecutionRunSeam = Rc::new(move |execution, shot| {
         std::fs::remove_file(&source).expect("remove A");
         symlink(&replacement, &source).expect("swap to symlink B");

--- a/crates/nika-cadence/public-api.txt
+++ b/crates/nika-cadence/public-api.txt
@@ -760,7 +760,8 @@ pub type nika_cadence::firing::SkipReason::Output = T
 pub struct nika_cadence::firing::ArmGeneration(_)
 impl nika_cadence::firing::ArmGeneration
 pub fn nika_cadence::firing::ArmGeneration::as_str(&self) -> &str
-pub fn nika_cadence::firing::ArmGeneration::compute(beat: &nika_cadence::registry::Beat, workflow_bytes: &[u8]) -> Self
+pub fn nika_cadence::firing::ArmGeneration::compute(beat: &nika_cadence::registry::Beat, snapshot_digest: &str) -> Self
+pub fn nika_cadence::firing::ArmGeneration::compute_resident(revision: &nika_cadence::schedule::ScheduleRevision, snapshot_digest: &str) -> Self
 pub fn nika_cadence::firing::ArmGeneration::from_wire(raw: &str) -> core::option::Option<Self>
 pub fn nika_cadence::firing::ArmGeneration::short(&self) -> &str
 impl core::clone::Clone for nika_cadence::firing::ArmGeneration
@@ -3767,7 +3768,8 @@ pub type nika_cadence::tick::TickDecision::Output = T
 pub struct nika_cadence::ArmGeneration(_)
 impl nika_cadence::firing::ArmGeneration
 pub fn nika_cadence::firing::ArmGeneration::as_str(&self) -> &str
-pub fn nika_cadence::firing::ArmGeneration::compute(beat: &nika_cadence::registry::Beat, workflow_bytes: &[u8]) -> Self
+pub fn nika_cadence::firing::ArmGeneration::compute(beat: &nika_cadence::registry::Beat, snapshot_digest: &str) -> Self
+pub fn nika_cadence::firing::ArmGeneration::compute_resident(revision: &nika_cadence::schedule::ScheduleRevision, snapshot_digest: &str) -> Self
 pub fn nika_cadence::firing::ArmGeneration::from_wire(raw: &str) -> core::option::Option<Self>
 pub fn nika_cadence::firing::ArmGeneration::short(&self) -> &str
 impl core::clone::Clone for nika_cadence::firing::ArmGeneration

--- a/crates/nika-cadence/src/firing.rs
+++ b/crates/nika-cadence/src/firing.rs
@@ -15,19 +15,24 @@
 //!   known-vector test hashes the bytes itself.
 //! - [`FencingToken`] — the claim's seq (Kleppmann): a receipt settles
 //!   the claim by naming it.
-//! - [`ArmGeneration`] — `sha256("nika/arm-gen@1\n" + beat-canonical +
-//!   "\n" + workflow_sha256)` (F17): every firing PINS its generation —
-//!   an update never changes a run in progress. beat-canonical is the
-//!   beat's DECLARED fields in the struct's fixed order (workflow ·
-//!   cadence · où · plafond · manqué · chevauchement · `après_saut` ·
-//!   actif · raison · `jusqu_au` · tolérance · décalage · par), one
-//!   `key=value` line each — strings quoted, the absent `null`, floats
-//!   in shortest roundtrip (`{f64:?}` — deterministic for a given
-//!   toolchain; an engine upgrade that moved the formatting would read
-//!   as a new generation, the cautious direction). The positional label
-//!   NEVER enters the hash; the two refused keys (`signature:` ·
-//!   `budget:`) carry no content. `workflow_sha256` is the
-//!   source-identity convention: sha256 over the exact bytes read.
+//! - [`ArmGeneration`] — `sha256("nika/arm-gen@2\n" + declaration +
+//!   "\0" + snapshot_digest)` (F17): every firing PINS its generation —
+//!   an update never changes a run in progress. ONE law, ONE domain,
+//!   both firing edges. The declaration is the edge's own identity: the
+//!   CLI arm-fire hashes the beat's DECLARED fields in the struct's
+//!   fixed order (workflow · cadence · où · plafond · manqué ·
+//!   chevauchement · `après_saut` · actif · raison · `jusqu_au` ·
+//!   tolérance · décalage · par), one `key=value` line each — strings
+//!   quoted, the absent `null`, floats in shortest roundtrip (`{f64:?}`
+//!   — deterministic for a given toolchain; an engine upgrade that
+//!   moved the formatting would read as a new generation, the cautious
+//!   direction) — the resident serve hashes its `ScheduleRevision`. The
+//!   positional label NEVER enters the hash; the two refused keys
+//!   (`signature:` · `budget:`) carry no content. The source half is
+//!   the admitted world's FULL snapshot digest (root + children +
+//!   skills + imports): editing ANY world byte between two fires mints
+//!   a new generation. `@1` hashed the root workflow's bytes alone;
+//!   those values remain interpretable as historical ledger evidence.
 //!
 //! ## The transition table (this module's law)
 //!
@@ -96,6 +101,7 @@ use std::borrow::Cow;
 use jiff::{Timestamp, Zoned};
 
 use crate::registry::{AfterSkip, Beat, Locus, MissPolicy, Overlap};
+use crate::schedule::ScheduleRevision;
 
 /// The slot's canonical identity (64 lowercase hex) — the dedup unit.
 /// NEVER the positional label: a `-2`/`-3` permutes at insertion.
@@ -158,23 +164,50 @@ impl FencingToken {
     }
 }
 
-/// The generation a firing PINS (F17 — 64 lowercase hex): the beat's
-/// declared fields + the workflow's source identity. An update to
-/// either mints a new generation; an in-flight run keeps its own.
+/// The generation a firing PINS (F17 — 64 lowercase hex): the edge's
+/// declaration identity + the admitted world's full snapshot digest.
+/// An update to either mints a new generation; an in-flight run keeps
+/// its own.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ArmGeneration(String);
 
+/// The ONE generation preimage domain, both firing edges. Bumped `@1` →
+/// `@2` when the source half stopped being the root workflow's bytes
+/// alone and became the admitted world's full snapshot digest — `@1`
+/// values stay interpretable as historical ledger evidence.
+const GENERATION_DOMAIN: &[u8] = b"nika/arm-gen@2\n";
+
 impl ArmGeneration {
-    /// Pin the generation: `sha256("nika/arm-gen@1\n" + beat-canonical +
-    /// "\n" + workflow_sha256)`. The beat canonical is the DECLARED
-    /// fields in the struct's fixed order (see the module doc).
+    /// The ONE law (see the module doc): the domain, the edge's
+    /// declaration identity, a NUL, the full snapshot digest. Exact
+    /// cross-edge equality is impossible BY DESIGN — the CLI declares a
+    /// beat, the resident serve declares a schedule revision — so both
+    /// named constructors judge through this one helper.
     #[must_use]
-    pub fn compute(beat: &Beat, workflow_bytes: &[u8]) -> Self {
-        let canonical = canonical_beat(beat);
-        let workflow_sha = sha256_hex(workflow_bytes);
-        Self(sha256_hex(
-            format!("nika/arm-gen@1\n{canonical}\n{workflow_sha}").as_bytes(),
-        ))
+    fn pin(declaration: &str, snapshot_digest: &str) -> Self {
+        let mut preimage = Vec::with_capacity(
+            GENERATION_DOMAIN.len() + declaration.len() + 1 + snapshot_digest.len(),
+        );
+        preimage.extend_from_slice(GENERATION_DOMAIN);
+        preimage.extend_from_slice(declaration.as_bytes());
+        preimage.push(0);
+        preimage.extend_from_slice(snapshot_digest.as_bytes());
+        Self(sha256_hex(&preimage))
+    }
+
+    /// The CLI arm-fire edge: the declaration is the beat's canonical
+    /// form — the DECLARED fields in the struct's fixed order (see the
+    /// module doc). The source half is the admitted world's digest.
+    #[must_use]
+    pub fn compute(beat: &Beat, snapshot_digest: &str) -> Self {
+        Self::pin(&canonical_beat(beat), snapshot_digest)
+    }
+
+    /// The resident-serve edge: the declaration is the schedule's
+    /// revision. Same domain, same preimage — the one law.
+    #[must_use]
+    pub fn compute_resident(revision: &ScheduleRevision, snapshot_digest: &str) -> Self {
+        Self::pin(revision.as_str(), snapshot_digest)
     }
 
     /// Read one off the wire — 64 lowercase hex, nothing else.
@@ -831,18 +864,20 @@ mod tests {
 
     // ── (f) the ArmGeneration (F17 — a firing pins its generation) ───
 
-    /// Identical bytes hash identically across two computations; one
-    /// changed workflow byte mints a NEW generation; a beat renamed by
+    /// Identical digests hash identically across two computations; one
+    /// changed digest mints a NEW generation; a beat renamed by
     /// position (the label never enters) keeps its gen.
     #[test]
-    fn the_generation_is_stable_on_bytes_and_deaf_to_the_label() {
+    fn the_generation_is_stable_on_the_digest_and_deaf_to_the_label() {
         let registry = registry_with("    manqué: sauter\n");
         let beat = registry.beats().next().expect("one beat");
-        let one = ArmGeneration::compute(beat, b"nika: a\ntasks: {}\n");
-        let two = ArmGeneration::compute(beat, b"nika: a\ntasks: {}\n");
-        assert_eq!(one, two, "identical bytes, identical gen");
-        let changed = ArmGeneration::compute(beat, b"nika: b\ntasks: {}\n");
-        assert_ne!(one, changed, "one workflow byte changed → a new gen");
+        let world_a = "a".repeat(64);
+        let world_b = "b".repeat(64);
+        let one = ArmGeneration::compute(beat, &world_a);
+        let two = ArmGeneration::compute(beat, &world_a);
+        assert_eq!(one, two, "identical digest, identical gen");
+        let changed = ArmGeneration::compute(beat, &world_b);
+        assert_ne!(one, changed, "one world byte changed → a new gen");
         // The renamed-but-identical beat: two registry entries with the
         // SAME fields take the labels `doctor` and `doctor-2` — the gen
         // never sees them.
@@ -852,38 +887,41 @@ mod tests {
         .expect("parse");
         let gens: Vec<ArmGeneration> = pair
             .beats()
-            .map(|b| ArmGeneration::compute(b, b"nika: a\n"))
+            .map(|b| ArmGeneration::compute(b, &world_a))
             .collect();
         assert_eq!(gens[0], gens[1], "the label never enters the hash");
         // … but any FIELD of the beat does.
         let other = registry_with("    manqué: rattraper-une-fois\n");
         let other = other.beats().next().expect("one beat");
         assert_ne!(
-            ArmGeneration::compute(beat, b"nika: a\n"),
-            ArmGeneration::compute(other, b"nika: a\n"),
+            ArmGeneration::compute(beat, &world_a),
+            ArmGeneration::compute(other, &world_a),
             "a changed beat field mints a new gen"
         );
     }
 
     /// The canonical byte shape, pinned from WITHOUT: the test builds
-    /// the hash input by hand (declared field order · quoted strings ·
-    /// `null` for the absent · the workflow's sha256 last).
+    /// the hash input by hand (the `@2` domain · declared field order ·
+    /// quoted strings · `null` for the absent · a NUL · the admitted
+    /// world's snapshot digest last).
     #[test]
     fn the_generation_hash_covers_the_declared_canonical_form() {
         use sha2::Digest as _;
         let registry = registry_with("    manqué: sauter\n");
         let beat = registry.beats().next().expect("one beat");
-        let bytes = b"nika: pinned\n";
-        let wf = format!("{:x}", sha2::Sha256::digest(bytes));
-        let canonical = format!(
-            "nika/arm-gen@1\nworkflow=\"{WORKFLOW}\"\ncadence=\"{CADENCE}\"\noù=null\nplafond=0.25\nmanqué=\"sauter\"\nchevauchement=null\naprès_saut=null\nactif=null\nraison=null\njusqu_au=null\ntolérance=null\ndécalage=null\npar=null\n{wf}"
-        );
-        let expected = format!("{:x}", sha2::Sha256::digest(canonical.as_bytes()));
-        assert_eq!(ArmGeneration::compute(beat, bytes).as_str(), expected);
+        let digest = "f".repeat(64);
+        let mut preimage = format!(
+            "nika/arm-gen@2\nworkflow=\"{WORKFLOW}\"\ncadence=\"{CADENCE}\"\noù=null\nplafond=0.25\nmanqué=\"sauter\"\nchevauchement=null\naprès_saut=null\nactif=null\nraison=null\njusqu_au=null\ntolérance=null\ndécalage=null\npar=null"
+        )
+        .into_bytes();
+        preimage.push(0);
+        preimage.extend_from_slice(digest.as_bytes());
+        let expected = format!("{:x}", sha2::Sha256::digest(&preimage));
+        assert_eq!(ArmGeneration::compute(beat, &digest).as_str(), expected);
         // The short form the report prints.
-        assert_eq!(ArmGeneration::compute(beat, bytes).short().len(), 8);
+        assert_eq!(ArmGeneration::compute(beat, &digest).short().len(), 8);
         // The wire door.
-        let generation = ArmGeneration::compute(beat, bytes);
+        let generation = ArmGeneration::compute(beat, &digest);
         assert_eq!(
             ArmGeneration::from_wire(generation.as_str()).expect("round-trip"),
             generation
@@ -912,13 +950,38 @@ mod tests {
             "    par: \"nika\"\n",
         ));
         let beat = registry.beats().next().expect("one beat");
-        let bytes = b"nika: full\n";
-        let workflow_sha = format!("{:x}", sha2::Sha256::digest(bytes));
-        let canonical = format!(
-            "nika/arm-gen@1\nworkflow=\"{WORKFLOW}\"\ncadence=\"{CADENCE}\"\noù=\"cloud\"\nplafond=0.25\nmanqué=\"rattraper-une-fois\"\nchevauchement=\"remplacer\"\naprès_saut=\"à-complétion\"\nactif=false\nraison=\"pause\\u0009contrôlée\"\njusqu_au=\"2099-12-31\"\ntolérance=\"3/4\"\ndécalage=\"hash\"\npar=\"nika\"\n{workflow_sha}"
+        let digest = "f".repeat(64);
+        let mut preimage = format!(
+            "nika/arm-gen@2\nworkflow=\"{WORKFLOW}\"\ncadence=\"{CADENCE}\"\noù=\"cloud\"\nplafond=0.25\nmanqué=\"rattraper-une-fois\"\nchevauchement=\"remplacer\"\naprès_saut=\"à-complétion\"\nactif=false\nraison=\"pause\\u0009contrôlée\"\njusqu_au=\"2099-12-31\"\ntolérance=\"3/4\"\ndécalage=\"hash\"\npar=\"nika\""
+        )
+        .into_bytes();
+        preimage.push(0);
+        preimage.extend_from_slice(digest.as_bytes());
+        let expected = format!("{:x}", sha2::Sha256::digest(&preimage));
+        assert_eq!(ArmGeneration::compute(beat, &digest).as_str(), expected);
+    }
+
+    /// The resident serve hashes the SAME preimage under the SAME `@2`
+    /// domain with its own declaration identity — the `ScheduleRevision`
+    /// string. Exact cross-edge equality is impossible by design (a beat
+    /// is not a revision); the shared `pin` is the one judge both edges
+    /// answer to.
+    #[test]
+    fn the_resident_edge_hashes_the_one_law_with_its_revision() {
+        use sha2::Digest as _;
+        let revision =
+            crate::schedule::ScheduleRevision::from_wire(&format!("sha256:{}", "e".repeat(64)))
+                .expect("revision");
+        let digest = "f".repeat(64);
+        let mut preimage = GENERATION_DOMAIN.to_vec();
+        preimage.extend_from_slice(revision.as_str().as_bytes());
+        preimage.push(0);
+        preimage.extend_from_slice(digest.as_bytes());
+        let expected = format!("{:x}", sha2::Sha256::digest(&preimage));
+        assert_eq!(
+            ArmGeneration::compute_resident(&revision, &digest).as_str(),
+            expected
         );
-        let expected = format!("{:x}", sha2::Sha256::digest(canonical.as_bytes()));
-        assert_eq!(ArmGeneration::compute(beat, bytes).as_str(), expected);
     }
 
     // ── the machine · scripted walks ─────────────────────────────────

--- a/crates/nika-cli/src/verbs/arm/mod.rs
+++ b/crates/nika-cli/src/verbs/arm/mod.rs
@@ -470,7 +470,7 @@ mod tests {
         let registry = parse_registry(body).expect("cadence registry");
         let generation = nika_cadence::ArmGeneration::compute(
             registry.beats().next().expect("first beat"),
-            b"nika: prouve\n",
+            &"b".repeat(64),
         );
         let generation_short = generation.short().to_owned();
         // prouve: the machine fired twice, skipped once — the sidecar

--- a/crates/nika-cli/src/verbs/arm/snapshots/nika_cli__verbs__arm__tests__the_report_tells_proven_from_declared_and_names_the_orphans.snap
+++ b/crates/nika-cli/src/verbs/arm/snapshots/nika_cli__verbs__arm__tests__the_report_tells_proven_from_declared_and_names_the_orphans.snap
@@ -5,7 +5,7 @@ expression: shown
 2 beats in [PROJET]/nika.yaml
 
   [idle ] workflows/prouve.nika.yaml · TZ=Europe/Paris lundi 9h07
-         ✓ PROUVÉ · fired · 2026-08-18T07:07:04Z · slot 2026-08-18T07:07:00Z · gen 3c509e2c · état succeeded · 1 saut / 3 tirs · tolérance 3/4
+         ✓ PROUVÉ · fired · 2026-08-18T07:07:04Z · slot 2026-08-18T07:07:00Z · gen 8148f2c2 · état succeeded · 1 saut / 3 tirs · tolérance 3/4
          par: thibaut — déclaré · non vérifié
 
   [idle ] workflows/declare.nika.yaml · TZ=Europe/Paris 0 3 * * *

--- a/crates/nika-serve/src/lib.rs
+++ b/crates/nika-serve/src/lib.rs
@@ -24,8 +24,8 @@ pub use schedule::{
     ScheduleApplyPrecondition, ScheduleStore, ScheduleStoreError,
 };
 pub use server::{
-    BoundServer, CredentialRefuse, ExecutionBackend, ExecutionDisposition, ExecutionOutcome,
-    PreparedScheduledRun, ResidentAuthority, ResidentClock, ResidentConfig,
+    BoundServer, CredentialRefuse, DEFAULT_MAX_COST_USD, ExecutionBackend, ExecutionDisposition,
+    ExecutionOutcome, PreparedScheduledRun, ResidentAuthority, ResidentClock, ResidentConfig,
     ResidentExecutionBackend, ResidentExecutionCoordinator, ServerConfig, ServerError,
     ServerLaunchRefuse, ServerLimits, SystemResidentClock, launch_operator_message,
     optional_server_config, process_shutdown, serve_http, serve_resident, serve_resident_process,

--- a/crates/nika-serve/src/server/config.rs
+++ b/crates/nika-serve/src/server/config.rs
@@ -40,8 +40,16 @@ impl ResidentClock for SystemResidentClock {
     }
 }
 
+/// The out-of-the-box per-run spend ceiling: every admitted run whose own
+/// declaration carries no ceiling runs under this one (#1349 — a manual
+/// `POST /v1/jobs` run never again executes with no ceiling). A schedule's
+/// required `maxCostUsd` restricts it further; an embedder retunes or
+/// explicitly disarms it through
+/// [`ServerLimits::with_default_max_cost_usd`].
+pub const DEFAULT_MAX_COST_USD: f64 = 1.0;
+
 /// Explicit ceilings for the remote HTTP and execution boundary.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 #[non_exhaustive]
 pub struct ServerLimits {
     max_body_bytes: usize,
@@ -56,6 +64,7 @@ pub struct ServerLimits {
     max_sse_clients: usize,
     sse_heartbeat: Duration,
     sse_reconnect: Duration,
+    default_max_cost_usd: Option<f64>,
 }
 
 impl ServerLimits {
@@ -85,6 +94,7 @@ impl ServerLimits {
             max_sse_clients: max_connections,
             sse_heartbeat: Duration::from_secs(15),
             sse_reconnect: Duration::from_secs(1),
+            default_max_cost_usd: Some(DEFAULT_MAX_COST_USD),
         }
     }
 
@@ -92,6 +102,17 @@ impl ServerLimits {
     #[must_use]
     pub const fn with_max_jobs(mut self, max_jobs: usize) -> Self {
         self.max_jobs = max_jobs;
+        self
+    }
+
+    /// Replace the per-run spend ceiling applied to every admitted run
+    /// whose own declaration carries none (manual `POST /v1/jobs` runs).
+    /// `None` explicitly disarms the server default — a schedule's own
+    /// required `maxCostUsd` still binds its fires, and a declaration
+    /// always RESTRICTS this default, never widens it.
+    #[must_use]
+    pub const fn with_default_max_cost_usd(mut self, ceiling: Option<f64>) -> Self {
+        self.default_max_cost_usd = ceiling;
         self
     }
 
@@ -124,6 +145,10 @@ impl ServerLimits {
             && !self.sse_heartbeat.is_zero()
             && self.sse_reconnect.as_millis() >= 100
             && self.sse_reconnect.as_millis() <= 30_000
+            && match self.default_max_cost_usd {
+                Some(cost) => cost.is_finite() && cost > 0.0,
+                None => true,
+            }
     }
 
     pub(crate) const fn max_body_bytes(self) -> usize {
@@ -172,6 +197,22 @@ impl ServerLimits {
 
     pub(crate) const fn sse_reconnect(self) -> Duration {
         self.sse_reconnect
+    }
+
+    pub(crate) const fn default_max_cost_usd(self) -> Option<f64> {
+        self.default_max_cost_usd
+    }
+
+    /// The run's effective per-run spend ceiling (#1349): a declaration
+    /// RESTRICTS the server default, never widens it — when both exist
+    /// the LOWER wins. Both operands are validated finite and positive
+    /// upstream (the coordinator at admission, `valid()` at startup).
+    pub(crate) fn effective_max_cost_usd(self, declared: Option<f64>) -> Option<f64> {
+        match (declared, self.default_max_cost_usd) {
+            (Some(declared), Some(default)) => Some(declared.min(default)),
+            (declared, None) => declared,
+            (None, default) => default,
+        }
     }
 }
 

--- a/crates/nika-serve/src/server/coordinator.rs
+++ b/crates/nika-serve/src/server/coordinator.rs
@@ -66,10 +66,16 @@ impl ResidentExecutionCoordinator {
             .await?;
         match &admission {
             Admission::Created(record) => {
-                permit.send(ExecutionTask::new(record.id().clone()));
+                permit.send(ExecutionTask::new(
+                    record.id().clone(),
+                    self.limits.default_max_cost_usd(),
+                ));
             }
             Admission::Existing(record) if record.status() == JobStatus::Queued => {
-                permit.send(ExecutionTask::new(record.id().clone()));
+                permit.send(ExecutionTask::new(
+                    record.id().clone(),
+                    self.limits.default_max_cost_usd(),
+                ));
             }
             Admission::Existing(_) | Admission::Conflict(_) => drop(permit),
         }
@@ -94,6 +100,10 @@ impl ResidentExecutionCoordinator {
 
     /// Prepare a scheduled run carrying its required per-fire spend ceiling.
     ///
+    /// The declared ceiling is validated, then folded with the server-level
+    /// default: when both exist the LOWER wins — a schedule restricts the
+    /// server's ceiling, never widens it (#1349).
+    ///
     /// # Errors
     /// Returns the same typed refusals as [`Self::prepare_scheduled`].
     pub fn prepare_scheduled_with_max_cost(
@@ -105,6 +115,7 @@ impl ResidentExecutionCoordinator {
         if max_cost_usd.is_some_and(|cost| !cost.is_finite() || cost <= 0.0) {
             return Err(ServerError::ScheduledAdmission);
         }
+        let max_cost_usd = self.limits.effective_max_cost_usd(max_cost_usd);
         let key = scheduled_key(&origin)?;
         let world = admitted
             .snapshot()

--- a/crates/nika-serve/src/server/mod.rs
+++ b/crates/nika-serve/src/server/mod.rs
@@ -41,7 +41,10 @@ use crate::{
 
 use auth::BearerToken;
 use cancel::{ActiveCancellations, CancellationRegistration};
-pub use config::{ResidentClock, ResidentConfig, ServerConfig, ServerLimits, SystemResidentClock};
+pub use config::{
+    DEFAULT_MAX_COST_USD, ResidentClock, ResidentConfig, ServerConfig, ServerLimits,
+    SystemResidentClock,
+};
 pub use coordinator::{PreparedScheduledRun, ResidentExecutionCoordinator};
 use error::diagnose_capture;
 pub use error::{CredentialRefuse, ServerError};
@@ -168,7 +171,9 @@ pub trait ExecutionBackend: Send + Sync + 'static {
         context: ExecutionContext<'a>,
     ) -> Pin<Box<dyn Future<Output = ExecutionOutcome> + Send + 'a>>;
 
-    /// Execute with an optional schedule-owned per-fire spend ceiling.
+    /// Execute with the run's effective per-fire spend ceiling — a
+    /// schedule's declared `maxCostUsd`, the server's default for
+    /// ceiling-less admissions, the lower of the two, or none.
     fn execute_with_max_cost<'a>(
         &'a self,
         context: ExecutionContext<'a>,
@@ -234,13 +239,13 @@ struct ExecutionTask {
 }
 
 impl ExecutionTask {
-    fn new(id: JobId) -> Self {
+    fn new(id: JobId, max_cost_usd: Option<f64>) -> Self {
         Self {
             id,
             admitted: None,
             prestarted: false,
             origin: JobOrigin::Manual,
-            max_cost_usd: None,
+            max_cost_usd,
         }
     }
 
@@ -290,12 +295,13 @@ impl ResidentAuthority {
             control_capacity,
         )?;
         let (jobs, receiver) = mpsc::channel(config.limits().queue_capacity());
+        let default_max_cost_usd = config.limits().default_max_cost_usd();
         let recovered = store_actor
             .handle()
             .queued_jobs()
             .await?
             .into_iter()
-            .map(|(id, _workflow)| ExecutionTask::new(id))
+            .map(|(id, _workflow)| ExecutionTask::new(id, default_max_cost_usd))
             .collect();
         let coordinator =
             ResidentExecutionCoordinator::new(store_actor.handle(), jobs, config.limits());
@@ -527,7 +533,7 @@ async fn prepare_http(config: &ServerConfig) -> Result<PreparedHttp, ServerError
 fn validate_resident_config(config: &ResidentConfig) -> Result<(), ServerError> {
     if !config.limits().valid() {
         return Err(ServerError::InvalidConfig(
-            "all size, timeout, concurrency, queue, connection, sse, and header ceilings must be non-zero",
+            "all size, timeout, concurrency, queue, connection, sse, and header ceilings must be non-zero, and the default budget ceiling must be finite and positive",
         ));
     }
     if config.limits().max_body_bytes() > crate::MAX_ENCODED_EXECUTION_SNAPSHOT_BYTES {

--- a/crates/nika-serve/src/server/schedule_tests.rs
+++ b/crates/nika-serve/src/server/schedule_tests.rs
@@ -316,6 +316,48 @@ async fn live_once_wakes_executes_persists_and_does_not_rearm_after_restart() {
     restarted.stop().await.expect("restart stop");
 }
 
+/// #1349 (b): the schedule's required `maxCostUsd` RESTRICTS the server
+/// default, never widens it — a 5.00 declaration under the 1.00 server
+/// default reaches the runtime clamped to 1.00, while the declaration
+/// itself is stored untouched (the clamp lives at the execution edge).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_schedule_ceiling_above_the_server_default_is_clamped_never_widened() {
+    let world = TestWorld::new();
+    let backend = Arc::new(CountingBackend::gated());
+    let clock = Arc::new(ManualClock::new("2026-09-01T08:00:00Z[UTC]"));
+    let server = world
+        .start_with_clock(backend.clone(), limits(), clock.clone())
+        .await;
+    let created = server
+        .request(&put_request(
+            "clamped-once",
+            &body_at("root.nika.yaml", 5.0, "2026-09-01T09:00:00Z"),
+            "If-None-Match: *\r\n",
+            true,
+        ))
+        .await;
+    assert_eq!(created.status, 200, "{}", created.body);
+    clock.wait_for_sleeps(2).await;
+    clock.advance_to("2026-09-01T09:00:00Z[UTC]");
+    backend.wait_for_call().await;
+    assert_eq!(backend.calls(), 1);
+    assert_eq!(
+        backend.max_cost_usd(),
+        Some(super::DEFAULT_MAX_COST_USD),
+        "the lower ceiling wins: the server default clamps the declaration"
+    );
+    let status = server
+        .request(&get_request("/v1/schedules/clamped-once"))
+        .await;
+    assert_eq!(
+        status.json()["definition"]["maxCostUsd"],
+        5.0,
+        "the declaration is stored untouched"
+    );
+    backend.release();
+    server.stop().await.expect("clean stop");
+}
+
 fn put_request(id: &str, body: &str, precondition: &str, authenticated: bool) -> String {
     let auth = authenticated.then(auth_header).unwrap_or_default();
     format!(

--- a/crates/nika-serve/src/server/scheduler.rs
+++ b/crates/nika-serve/src/server/scheduler.rs
@@ -11,7 +11,6 @@ use nika_cadence::{
     ScheduleDueVerdict, ScheduleOrigin, SchedulePlanError, ScheduleRevision, ScheduleSlot,
     plan_schedule,
 };
-use sha2::{Digest as _, Sha256};
 use tokio::sync::watch;
 use tokio::task::JoinSet;
 
@@ -22,7 +21,6 @@ use super::{AuthorityState, PreparedScheduledRun, ServerError};
 
 const FALLBACK_RESCAN: Duration = Duration::from_secs(5);
 const PLANNER_PROJECTION: usize = 1;
-const GENERATION_DOMAIN: &[u8] = b"nika/resident-schedule-generation@1\0";
 
 struct ResidentSchedule {
     origin: ScheduleOrigin,
@@ -231,7 +229,7 @@ async fn prepare_claim(
                 Path::new(candidate.schedule.definition.workflow()),
             )
             .map_err(|_| ServerError::ScheduledAdmission)?;
-        let generation = generation(&candidate.schedule.definition, &admitted)?;
+        let generation = generation(&candidate.schedule.definition, &admitted);
         let fired_at = clock.now();
         let origin = JobOrigin::schedule(
             candidate.schedule.origin,
@@ -376,21 +374,15 @@ fn handle_overlap(state: &AuthorityState, candidate: FireCandidate) -> Result<()
     }
 }
 
+/// The resident edge of the ONE generation law (`nika/arm-gen@2` — see
+/// `nika_cadence::firing`): the schedule's revision is the declaration,
+/// the admitted world's FULL snapshot digest is the source — a child,
+/// skill, or import edit between two fires mints a new generation.
 fn generation(
     definition: &ScheduleDefinition,
     admitted: &nika_execution::AdmittedExecution,
-) -> Result<ArmGeneration, ServerError> {
-    let unit = admitted
-        .snapshot()
-        .unit(admitted.snapshot().root())
-        .ok_or(ServerError::ScheduledAdmission)?;
-    let mut hasher = Sha256::new();
-    hasher.update(GENERATION_DOMAIN);
-    hasher.update(definition.revision().as_str().as_bytes());
-    hasher.update([0]);
-    hasher.update(unit.bytes());
-    ArmGeneration::from_wire(&format!("{:x}", hasher.finalize()))
-        .ok_or(ServerError::ScheduledAdmission)
+) -> ArmGeneration {
+    ArmGeneration::compute_resident(&definition.revision(), admitted.snapshot().digest())
 }
 
 fn publish_refusals(state: &AuthorityState, refused: Vec<RefusedProjectSchedule>) {
@@ -547,5 +539,67 @@ mod tests {
         assert!(fire_is_still_due(&store, &candidate, &due_now).expect("still due"));
         let rolled_back: Zoned = "2026-09-01T08:59:59Z[UTC]".parse().expect("rolled back");
         assert!(!fire_is_still_due(&store, &candidate, &rolled_back).expect("recomputed refusal"));
+    }
+
+    /// #1343 — the resident edge hashes the admitted world's FULL
+    /// snapshot digest: editing ONLY a child workflow or ONLY a skill
+    /// between two fires mints a new generation; the same world under
+    /// the same revision keeps its own (one law with the CLI edge —
+    /// `nika/arm-gen@2`).
+    #[test]
+    fn a_child_or_skill_edit_mints_a_new_resident_generation() {
+        let dir = tempfile::tempdir().expect("project");
+        let workflows = dir.path().join("workflows");
+        std::fs::create_dir_all(workflows.join("skills/review")).expect("skill dir");
+        let root = "nika: doctor\nmodel: mock/echo\npermits:\n  exec: [\"echo\"]\n  fs:\n    read: [\"skills/review/SKILL.md\"]\ntasks:\n  child:\n    invoke:\n      workflow: \"child.nika.yaml\"\n      args: { url: \"https://example.com\" }\n    returns: { object: { report: string } }\n  review:\n    agent: { prompt: \"review\", skills: [\"skills/review/SKILL.md\"] }\n";
+        let child = "nika: child\ninputs:\n  url: { type: string, required: true }\npermits:\n  exec: [\"echo\"]\ntasks:\n  fetch:\n    exec: { command: [\"echo\", \"${{ inputs.url }}\"] }\noutputs:\n  report: { value: \"${{ tasks.fetch.output }}\", type: string }\n";
+        let skill = "---\nname: review\ndescription: Review code.\n---\nOriginal.\n";
+        std::fs::write(workflows.join("doctor.nika.yaml"), root).expect("root");
+        std::fs::write(workflows.join("child.nika.yaml"), child).expect("child");
+        std::fs::write(workflows.join("skills/review/SKILL.md"), skill).expect("skill");
+        let registry = nika_cadence::parse_registry(
+            "nika: proj\narm:\n  - workflow: workflows/doctor.nika.yaml\n    cadence: \"TZ=UTC 0 3 * * *\"\n    plafond: 0.25\n    manqué: sauter\n",
+        )
+        .expect("parse");
+        let definition =
+            ScheduleDraft::from_project("doctor", registry.beats().next().expect("beat"))
+                .and_then(ScheduleDraft::validate)
+                .expect("schedule");
+        let service = nika_execution::ExecutionService::default();
+        let admit = || {
+            let project = nika_fs::OwnedDir::open(dir.path()).expect("project capability");
+            service
+                .admit(&project, Path::new("workflows/doctor.nika.yaml"))
+                .expect("admitted world")
+        };
+        let base = generation(&definition, &admit());
+        assert_eq!(
+            base,
+            generation(&definition, &admit()),
+            "same world + same revision → same generation"
+        );
+        // Edit ONLY the child — the root bytes never move.
+        std::fs::write(
+            workflows.join("child.nika.yaml"),
+            "nika: child-v2\ninputs:\n  url: { type: string, required: true }\npermits:\n  exec: [\"echo\"]\ntasks:\n  fetch:\n    exec: { command: [\"echo\", \"${{ inputs.url }}\"] }\noutputs:\n  report: { value: \"${{ tasks.fetch.output }}\", type: string }\n",
+        )
+        .expect("edit child");
+        assert_ne!(
+            base,
+            generation(&definition, &admit()),
+            "a child-only edit mints a new generation"
+        );
+        // Restore the child, edit ONLY the skill.
+        std::fs::write(workflows.join("child.nika.yaml"), child).expect("restore child");
+        std::fs::write(
+            workflows.join("skills/review/SKILL.md"),
+            "---\nname: review\ndescription: Review code.\n---\nRevised.\n",
+        )
+        .expect("edit skill");
+        assert_ne!(
+            base,
+            generation(&definition, &admit()),
+            "a skill-only edit mints a new generation"
+        );
     }
 }

--- a/crates/nika-serve/src/server/tests.rs
+++ b/crates/nika-serve/src/server/tests.rs
@@ -370,6 +370,8 @@ fn four_header_limits() -> ServerLimits {
 }
 
 #[cfg(test)]
+mod budget;
+#[cfg(test)]
 mod cancel_race;
 #[cfg(test)]
 mod request_lifecycle;

--- a/crates/nika-serve/src/server/tests/budget.rs
+++ b/crates/nika-serve/src/server/tests/budget.rs
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! #1349 — the server-level default budget ceiling: a manual
+//! `POST /v1/jobs` run never again executes with no spend ceiling; a
+//! declaration restricts the default, never widens it; an invalid
+//! configured ceiling refuses at startup.
+
+use std::sync::Mutex;
+
+use super::*;
+
+/// The probe the schedule suites speak: records whether a ceiling rode
+/// the admission all the way to the execution seam.
+#[derive(Debug, Default)]
+struct BudgetBackend {
+    max_cost_usd: Mutex<Option<f64>>,
+}
+
+impl BudgetBackend {
+    fn max_cost_usd(&self) -> Option<f64> {
+        *self.max_cost_usd.lock().expect("recorded max cost")
+    }
+}
+
+impl ExecutionBackend for BudgetBackend {
+    fn execute<'a>(
+        &'a self,
+        _context: nika_execution::ExecutionContext<'a>,
+    ) -> Pin<Box<dyn Future<Output = ExecutionOutcome> + Send + 'a>> {
+        Box::pin(async { ExecutionDisposition::Succeeded.into() })
+    }
+
+    fn execute_with_max_cost<'a>(
+        &'a self,
+        context: nika_execution::ExecutionContext<'a>,
+        max_cost_usd: Option<f64>,
+    ) -> Pin<Box<dyn Future<Output = ExecutionOutcome> + Send + 'a>> {
+        *self.max_cost_usd.lock().expect("record max cost") = max_cost_usd;
+        self.execute(context)
+    }
+}
+
+/// (a) A manual `POST /v1/jobs` run declares no ceiling of its own —
+/// the SERVER default rides the admission and reaches the runtime
+/// exactly the way a schedule's `maxCostUsd` does.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_manual_job_runs_under_the_server_default_budget_ceiling() {
+    let world = TestWorld::new();
+    let backend = Arc::new(BudgetBackend::default());
+    let server = world
+        .start(
+            backend.clone(),
+            limits().with_default_max_cost_usd(Some(0.75)),
+        )
+        .await;
+    let created = server
+        .request(&post_request(
+            r#"{"workflow":"root.nika.yaml"}"#,
+            "manual-default-ceiling",
+            &auth_header(),
+        ))
+        .await;
+    assert_eq!(created.status, 202, "{}", created.body);
+    let id = created.json()["id"].as_str().expect("id").to_owned();
+    wait_for_status(&server, &id, "succeeded")
+        .await
+        .expect("succeeded");
+    assert_eq!(
+        backend.max_cost_usd(),
+        Some(0.75),
+        "the server default reaches the runtime when the run declares none"
+    );
+    server.stop().await.expect("clean stop");
+}
+
+/// The escape hatch is EXPLICIT: an embedder that disarms the default
+/// gets the old unceilinged behavior — never silently.
+#[tokio::test(flavor = "multi_thread")]
+async fn an_explicitly_disarmed_default_leaves_a_manual_job_unceilinged() {
+    let world = TestWorld::new();
+    let backend = Arc::new(BudgetBackend::default());
+    let server = world
+        .start(backend.clone(), limits().with_default_max_cost_usd(None))
+        .await;
+    let created = server
+        .request(&post_request(
+            r#"{"workflow":"root.nika.yaml"}"#,
+            "manual-disarmed-ceiling",
+            &auth_header(),
+        ))
+        .await;
+    assert_eq!(created.status, 202, "{}", created.body);
+    let id = created.json()["id"].as_str().expect("id").to_owned();
+    wait_for_status(&server, &id, "succeeded")
+        .await
+        .expect("succeeded");
+    assert_eq!(
+        backend.max_cost_usd(),
+        None,
+        "an explicit None disarms the server default"
+    );
+    server.stop().await.expect("clean stop");
+}
+
+/// (c) A configured default that is zero, negative, NaN, or infinite
+/// would silently DISARM the guard it claims to arm (the CLI's
+/// `--max-cost-usd` parser refuses the same class) — startup refuses.
+#[tokio::test(flavor = "multi_thread")]
+async fn an_invalid_default_budget_ceiling_refuses_before_state_io() {
+    let world = TestWorld::new();
+    let backend = Arc::new(BudgetBackend::default());
+    for ceiling in [0.0, -0.5, f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+        let config = ResidentConfig::new(&world.state)
+            .with_limits(limits().with_default_max_cost_usd(Some(ceiling)));
+        assert!(
+            matches!(
+                ResidentAuthority::open(config, backend.clone()).await,
+                Err(ServerError::InvalidConfig(_))
+            ),
+            "ceiling {ceiling} must refuse at startup"
+        );
+    }
+}

--- a/docs/crate-specs/nika-cadence.md
+++ b/docs/crate-specs/nika-cadence.md
@@ -124,9 +124,14 @@ schedule and label inputs while `nika-cli` renders launchd/systemd units.
 
 **W7 — the pure firing machine (`firing` module)**:
 `SlotId::derive(workflow, cadence, slot)` freezes the existing
-`nika/arm-slot@1` identity; `ArmGeneration::compute(beat,
-workflow_bytes)` freezes `nika/arm-gen@1` over the beat's declared
-canonical fields and the exact workflow-byte hash; `FencingToken`
+`nika/arm-slot@1` identity; `ArmGeneration::{compute,
+compute_resident}` freezes `nika/arm-gen@2` — ONE law, ONE domain, both
+firing edges: the CLI arm-fire hashes the beat's declared canonical
+fields, the resident serve hashes its `ScheduleRevision`, and the
+source half is the admitted world's FULL snapshot digest (root +
+children + skills + imports — `@1` hashed the root bytes alone; those
+values remain interpretable as historical ledger evidence);
+`FencingToken`
 prevents naked sequence integers crossing the boundary.
 `FiringEvent` and `FiringState` carry the closed lifecycle vocabulary;
 `transition` is the table, `fold` applies fencing pairing, and `decide`


### PR DESCRIPTION
Closes #1343, closes #1349.

Found by the Nika System Perfection Campaign socratic pass (evidence: monorepo `dx/state/gauntlet/2026-09-01-perfection/evidence/socratic-pass.md` Q5, Q13).

## #1343 — ARM generation now binds the full execution world

One law, one domain, both firing edges: `SHA256("nika/arm-gen@2\n" + declaration + 0x00 + snapshotDigest)`.

- Before: generation hashed the declaration + **root workflow bytes only** — a child workflow, Agent Skill, or import edit between two fires produced the *same* generation, so a receipt's `arm_generation` could not prove what code ran. Two formula domains (CLI vs resident) additionally gave different values for the same logical firing.
- After: `nika_cadence::firing::ArmGeneration` has one private `pin(declaration, snapshot_digest)` both edges judge through — `compute` (CLI, declaration = canonical beat) and `compute_resident` (serve, declaration = `ScheduleRevision`). The source half is the admitted world's full snapshot digest (root + children + skills + imports — the existing `nika-execution` digest). The serve scheduler's private `nika/resident-schedule-generation@1` formula is deleted.
- `@1` values remain interpretable as historical ledger evidence; generation stays evidence-only (no runtime gate).
- Exact cross-edge equality is impossible by design (a beat is not a revision) — documented and pinned by test.

## #1349 — no run without a finite ceiling

- `ServerLimits` gains `default_max_cost_usd` (default **$1.00** — named const `DEFAULT_MAX_COST_USD`, embedder-retunable, explicit `None` disarms), validated finite/positive at startup.
- Manual `POST /v1/jobs` runs now execute under the server default instead of `None`.
- Scheduled runs fold their required `maxCostUsd` with the default via `effective_max_cost_usd` — **min algebra: a declaration restricts, never widens**.
- No request-level budget field (RunRequestV1 remains its own designed wave).

⚠️ **Judgment call for the reviewer**: the $1.00 default value itself is a product choice — the mechanism is the fix, the number is a named, documented, retunable default.

## Evidence

- Regression: child-only and skill-only edits mint new generations on both edges; determinism vectors re-locked to the @2 preimage; manual job runs under the server default; disarmed default leaves None; invalid values (0, negative, NaN, ±∞) refuse at startup; schedule ceiling above the default is clamped never widened.
- `cargo test --lib`: nika-cadence 183/183 · nika-arm 87/87 · nika-serve 155/155 · nika-cli 335/335
- `clippy --all-targets -D warnings` clean · `fmt` clean · zero unwrap · `public-api.txt` regenerated (exactly the two signature changes)

🦋 Co-Authored-By: Nika 🦋 <nika@supernovae.studio>
