### PR TITLE
fix(schedule): refuse unimplemented policies at apply, surface project refusals at load, wake expired pauses

### DIFF
--- a/changelog.d/1344.fixed.md
+++ b/changelog.d/1344.fixed.md
@@ -1,0 +1,5 @@
+- **`overlap: replace` is a typed refusal, not a silent no-op.**
+  `PUT /v1/schedules/{id}` with `"overlap": "replace"` now answers 422
+  with a `schedule.overlap` finding naming the policy, and a project beat
+  with `chevauchement: remplacer` surfaces the same finding instead of
+  firing with the overlap ignored.

--- a/changelog.d/1345.fixed.md
+++ b/changelog.d/1345.fixed.md
@@ -1,0 +1,5 @@
+- **`overlap: queue` is a typed refusal, not a silent no-op.**
+  `PUT /v1/schedules/{id}` with `"overlap": "queue"` now answers 422
+  with a `schedule.overlap` finding naming the policy, and a project beat
+  with `chevauchement: file` surfaces the same finding instead of firing
+  with the queue ignored.

--- a/changelog.d/1346.fixed.md
+++ b/changelog.d/1346.fixed.md
@@ -1,0 +1,5 @@
+- **`afterSkip: on_completion` is a typed refusal, not a silent no-op.**
+  `PUT /v1/schedules/{id}` with `"afterSkip": "on_completion"` now answers
+  422 with a `schedule.after-skip` finding naming the policy, and a
+  project beat with `après_saut: à-complétion` surfaces the same finding
+  instead of consuming the skip durably and never re-firing.

--- a/changelog.d/1347.fixed.md
+++ b/changelog.d/1347.fixed.md
@@ -1,0 +1,5 @@
+- **`tolerance` is a typed refusal until the (m,k)-firm law exists.**
+  `PUT /v1/schedules/{id}` with a well-formed `"tolerance"` now answers
+  422 with a `schedule.tolerance` finding, and a project beat with
+  `tolérance:` surfaces the same finding, instead of persisting a
+  documented (m,k) semantics nothing enforces.

--- a/changelog.d/1348.fixed.md
+++ b/changelog.d/1348.fixed.md
@@ -1,0 +1,5 @@
+- **`nika serve` projects a refused project beat instead of burying it.**
+  A `nika.yaml` beat whose declaration the planner refuses (hash jitter
+  today) is planned at load, surfaces as a finding on
+  `GET /v1/schedules/{id}` with `origin: "project"`, and is never carried
+  as a live beat that silently never fires.

--- a/changelog.d/serve-pause-expiry.fixed.md
+++ b/changelog.d/serve-pause-expiry.fixed.md
@@ -1,0 +1,6 @@
+- **A `pauseUntil` in the past wakes the schedule under `nika serve`.**
+  The serve planner judged `active: false` as paused forever and never
+  read the declared bound. It now evaluates the expiry the arm-fire way —
+  the date strictly before the decision instant's own civil date — so an
+  expired pause plans as active and fires, while a future one stays
+  visibly paused.

--- a/crates/nika-cadence/public-api.txt
+++ b/crates/nika-cadence/public-api.txt
@@ -2276,7 +2276,11 @@ impl<T> typenum::type_operators::Same for nika_cadence::schedule_plan::ScheduleD
 pub type nika_cadence::schedule_plan::ScheduleDueVerdict::Output = T
 #[non_exhaustive] pub enum nika_cadence::schedule_plan::SchedulePlanError
 pub nika_cadence::schedule_plan::SchedulePlanError::InvalidCanonicalCadence(alloc::string::String)
+pub nika_cadence::schedule_plan::SchedulePlanError::UnsupportedAfterSkipOnCompletion
 pub nika_cadence::schedule_plan::SchedulePlanError::UnsupportedHashJitter
+pub nika_cadence::schedule_plan::SchedulePlanError::UnsupportedOverlapQueue
+pub nika_cadence::schedule_plan::SchedulePlanError::UnsupportedOverlapReplace
+pub nika_cadence::schedule_plan::SchedulePlanError::UnsupportedTolerance
 impl core::clone::Clone for nika_cadence::schedule_plan::SchedulePlanError
 pub fn nika_cadence::schedule_plan::SchedulePlanError::clone(&self) -> nika_cadence::schedule_plan::SchedulePlanError
 impl core::cmp::Eq for nika_cadence::schedule_plan::SchedulePlanError
@@ -3473,7 +3477,11 @@ impl<T> typenum::type_operators::Same for nika_cadence::schedule::ScheduleOrigin
 pub type nika_cadence::schedule::ScheduleOrigin::Output = T
 #[non_exhaustive] pub enum nika_cadence::SchedulePlanError
 pub nika_cadence::SchedulePlanError::InvalidCanonicalCadence(alloc::string::String)
+pub nika_cadence::SchedulePlanError::UnsupportedAfterSkipOnCompletion
 pub nika_cadence::SchedulePlanError::UnsupportedHashJitter
+pub nika_cadence::SchedulePlanError::UnsupportedOverlapQueue
+pub nika_cadence::SchedulePlanError::UnsupportedOverlapReplace
+pub nika_cadence::SchedulePlanError::UnsupportedTolerance
 impl core::clone::Clone for nika_cadence::schedule_plan::SchedulePlanError
 pub fn nika_cadence::schedule_plan::SchedulePlanError::clone(&self) -> nika_cadence::schedule_plan::SchedulePlanError
 impl core::cmp::Eq for nika_cadence::schedule_plan::SchedulePlanError

--- a/crates/nika-cadence/src/schedule_plan.rs
+++ b/crates/nika-cadence/src/schedule_plan.rs
@@ -331,6 +331,11 @@ pub enum SchedulePlanError {
         "active timed schedules with afterSkip=on_completion are unsupported until a completion-trigger law exists"
     )]
     UnsupportedAfterSkipOnCompletion,
+    /// No enforcement law reads the documented (m,k) `tolerance` yet.
+    #[error(
+        "active timed schedules with tolerance are unsupported until the (m,k)-firm law exists"
+    )]
+    UnsupportedTolerance,
     /// A validated canonical cadence failed to re-enter the shared parser.
     #[error("canonical cadence failed to re-parse: {0}")]
     InvalidCanonicalCadence(String),
@@ -351,9 +356,10 @@ impl NikaErrorCode for SchedulePlanError {
 /// # Errors
 /// Active timed hash jitter refuses until a deterministic offset law is
 /// ratified, `overlap: replace` / `overlap: queue` refuse until preemption
-/// and queueing laws exist, and `afterSkip: on_completion` refuses until a
-/// completion-trigger law exists. A canonical cadence that no longer
-/// parses also fails closed.
+/// and queueing laws exist, `afterSkip: on_completion` refuses until a
+/// completion-trigger law exists, and `tolerance` refuses until the
+/// (m,k)-firm law reads it. A canonical cadence that no longer parses
+/// also fails closed.
 pub fn plan_schedule(
     definition: &ScheduleDefinition,
     now: &Zoned,
@@ -375,6 +381,9 @@ pub fn plan_schedule(
         }
         if definition.after_skip() == AfterSkip::ACompletion {
             return Err(SchedulePlanError::UnsupportedAfterSkipOnCompletion);
+        }
+        if definition.tolerance().is_some() {
+            return Err(SchedulePlanError::UnsupportedTolerance);
         }
     }
     let limit = projection_limit.min(MAX_SCHEDULE_PROJECTION_SLOTS);

--- a/crates/nika-cadence/src/schedule_plan.rs
+++ b/crates/nika-cadence/src/schedule_plan.rs
@@ -190,7 +190,8 @@ pub enum ScheduleDueVerdict {
         /// Inclusive declaration bound that the lateness exceeded.
         maximum_seconds: u64,
     },
-    /// The definition is inactive; pause evidence remains visible to status.
+    /// The definition is inactive and its declared pause bound has not
+    /// passed; pause evidence remains visible to status.
     PausedInactive {
         /// Operator-provided pause reason.
         reason: String,
@@ -366,7 +367,7 @@ pub fn plan_schedule(
     state: &ScheduleDecisionState,
     projection_limit: usize,
 ) -> Result<SchedulePlan, SchedulePlanError> {
-    if !definition.is_active() {
+    if !definition.is_active() && !pause_expired(definition, now) {
         return Ok(paused_plan(definition, now));
     }
     if !matches!(definition.when(), ScheduleWhen::Webhook) {
@@ -403,6 +404,15 @@ pub fn plan_schedule(
             now,
         )),
     }
+}
+
+/// The declared pause bound, judged the arm-fire way: a `pauseUntil`
+/// strictly before the decision instant's own civil date means the
+/// suspension is over and the definition plans as active again.
+fn pause_expired(definition: &ScheduleDefinition, now: &Zoned) -> bool {
+    definition
+        .pause_until()
+        .is_some_and(|until| crate::tick::date_expired(until, now))
 }
 
 fn paused_plan(definition: &ScheduleDefinition, now: &Zoned) -> SchedulePlan {

--- a/crates/nika-cadence/src/schedule_plan.rs
+++ b/crates/nika-cadence/src/schedule_plan.rs
@@ -316,6 +316,11 @@ pub enum SchedulePlanError {
     /// No deterministic slot-offset law exists for `jitter: hash` yet.
     #[error("active timed schedules with hash jitter are unsupported until an offset law exists")]
     UnsupportedHashJitter,
+    /// No preemption law exists for `overlap: replace` yet.
+    #[error(
+        "active timed schedules with overlap=replace are unsupported until a preemption law exists"
+    )]
+    UnsupportedOverlapReplace,
     /// A validated canonical cadence failed to re-enter the shared parser.
     #[error("canonical cadence failed to re-parse: {0}")]
     InvalidCanonicalCadence(String),
@@ -335,7 +340,8 @@ impl NikaErrorCode for SchedulePlanError {
 ///
 /// # Errors
 /// Active timed hash jitter refuses until a deterministic offset law is
-/// ratified. A canonical cadence that no longer parses also fails closed.
+/// ratified, and `overlap: replace` refuses until a preemption law exists.
+/// A canonical cadence that no longer parses also fails closed.
 pub fn plan_schedule(
     definition: &ScheduleDefinition,
     now: &Zoned,
@@ -345,8 +351,13 @@ pub fn plan_schedule(
     if !definition.is_active() {
         return Ok(paused_plan(definition, now));
     }
-    if !matches!(definition.when(), ScheduleWhen::Webhook) && definition.jitter().is_some() {
-        return Err(SchedulePlanError::UnsupportedHashJitter);
+    if !matches!(definition.when(), ScheduleWhen::Webhook) {
+        if definition.jitter().is_some() {
+            return Err(SchedulePlanError::UnsupportedHashJitter);
+        }
+        if definition.overlap() == Overlap::Remplacer {
+            return Err(SchedulePlanError::UnsupportedOverlapReplace);
+        }
     }
     let limit = projection_limit.min(MAX_SCHEDULE_PROJECTION_SLOTS);
     match definition.when() {

--- a/crates/nika-cadence/src/schedule_plan.rs
+++ b/crates/nika-cadence/src/schedule_plan.rs
@@ -326,6 +326,11 @@ pub enum SchedulePlanError {
         "active timed schedules with overlap=queue are unsupported until a queueing law exists"
     )]
     UnsupportedOverlapQueue,
+    /// No completion-trigger law exists for `afterSkip: on_completion` yet.
+    #[error(
+        "active timed schedules with afterSkip=on_completion are unsupported until a completion-trigger law exists"
+    )]
+    UnsupportedAfterSkipOnCompletion,
     /// A validated canonical cadence failed to re-enter the shared parser.
     #[error("canonical cadence failed to re-parse: {0}")]
     InvalidCanonicalCadence(String),
@@ -345,8 +350,9 @@ impl NikaErrorCode for SchedulePlanError {
 ///
 /// # Errors
 /// Active timed hash jitter refuses until a deterministic offset law is
-/// ratified, and `overlap: replace` / `overlap: queue` refuse until
-/// preemption and queueing laws exist. A canonical cadence that no longer
+/// ratified, `overlap: replace` / `overlap: queue` refuse until preemption
+/// and queueing laws exist, and `afterSkip: on_completion` refuses until a
+/// completion-trigger law exists. A canonical cadence that no longer
 /// parses also fails closed.
 pub fn plan_schedule(
     definition: &ScheduleDefinition,
@@ -366,6 +372,9 @@ pub fn plan_schedule(
         }
         if definition.overlap() == Overlap::File {
             return Err(SchedulePlanError::UnsupportedOverlapQueue);
+        }
+        if definition.after_skip() == AfterSkip::ACompletion {
+            return Err(SchedulePlanError::UnsupportedAfterSkipOnCompletion);
         }
     }
     let limit = projection_limit.min(MAX_SCHEDULE_PROJECTION_SLOTS);

--- a/crates/nika-cadence/src/schedule_plan.rs
+++ b/crates/nika-cadence/src/schedule_plan.rs
@@ -321,6 +321,11 @@ pub enum SchedulePlanError {
         "active timed schedules with overlap=replace are unsupported until a preemption law exists"
     )]
     UnsupportedOverlapReplace,
+    /// No queueing law exists for `overlap: queue` yet.
+    #[error(
+        "active timed schedules with overlap=queue are unsupported until a queueing law exists"
+    )]
+    UnsupportedOverlapQueue,
     /// A validated canonical cadence failed to re-enter the shared parser.
     #[error("canonical cadence failed to re-parse: {0}")]
     InvalidCanonicalCadence(String),
@@ -340,8 +345,9 @@ impl NikaErrorCode for SchedulePlanError {
 ///
 /// # Errors
 /// Active timed hash jitter refuses until a deterministic offset law is
-/// ratified, and `overlap: replace` refuses until a preemption law exists.
-/// A canonical cadence that no longer parses also fails closed.
+/// ratified, and `overlap: replace` / `overlap: queue` refuse until
+/// preemption and queueing laws exist. A canonical cadence that no longer
+/// parses also fails closed.
 pub fn plan_schedule(
     definition: &ScheduleDefinition,
     now: &Zoned,
@@ -357,6 +363,9 @@ pub fn plan_schedule(
         }
         if definition.overlap() == Overlap::Remplacer {
             return Err(SchedulePlanError::UnsupportedOverlapReplace);
+        }
+        if definition.overlap() == Overlap::File {
+            return Err(SchedulePlanError::UnsupportedOverlapQueue);
         }
     }
     let limit = projection_limit.min(MAX_SCHEDULE_PROJECTION_SLOTS);

--- a/crates/nika-cadence/src/schedule_plan/tests.rs
+++ b/crates/nika-cadence/src/schedule_plan/tests.rs
@@ -659,6 +659,53 @@ fn active_timed_after_skip_on_completion_refuses_until_a_trigger_law_exists() {
 }
 
 #[test]
+fn active_timed_tolerance_refuses_until_the_firm_law_exists() {
+    let mut candidate = daily(MissPolicy::Rattraper);
+    candidate.tolerance = Some("3/4".to_owned());
+    let definition = candidate.validate().expect("definition");
+    assert!(matches!(
+        plan_schedule(
+            &definition,
+            &zoned("2026-09-01T08:00:00Z"),
+            &ScheduleDecisionState::empty(),
+            4,
+        ),
+        Err(SchedulePlanError::UnsupportedTolerance)
+    ));
+
+    let mut paused = daily(MissPolicy::Rattraper);
+    paused.tolerance = Some("3/4".to_owned());
+    paused.active = Some(false);
+    paused.pause_reason = Some("maintenance".to_owned());
+    paused.pause_until = Some("2026-09-10".to_owned());
+    assert!(matches!(
+        plan_schedule(
+            &paused.validate().expect("paused definition"),
+            &zoned("2026-09-01T08:00:00Z"),
+            &ScheduleDecisionState::empty(),
+            4,
+        )
+        .expect("inactive plans without effective times")
+        .due(),
+        ScheduleDueVerdict::PausedInactive { .. }
+    ));
+
+    let mut webhook = draft(ScheduleWhenDraft::Webhook, MissPolicy::Rattraper);
+    webhook.tolerance = Some("3/4".to_owned());
+    assert!(matches!(
+        plan_schedule(
+            &webhook.validate().expect("webhook definition"),
+            &zoned("2026-09-01T08:00:00Z"),
+            &ScheduleDecisionState::empty(),
+            4,
+        )
+        .expect("webhooks have no effective timed slot")
+        .due(),
+        ScheduleDueVerdict::NotDue
+    ));
+}
+
+#[test]
 fn active_timed_hash_jitter_refuses_until_a_law_exists() {
     let mut jittered = daily(MissPolicy::Rattraper);
     jittered.jitter = Some(ScheduleJitter::Hash);
@@ -721,6 +768,10 @@ fn planner_refusals_speak_the_schedule_registry_code() {
     );
     assert_eq!(
         SchedulePlanError::UnsupportedAfterSkipOnCompletion.nika_code(),
+        nika_error::codes::NIKA_017
+    );
+    assert_eq!(
+        SchedulePlanError::UnsupportedTolerance.nika_code(),
         nika_error::codes::NIKA_017
     );
     assert_eq!(

--- a/crates/nika-cadence/src/schedule_plan/tests.rs
+++ b/crates/nika-cadence/src/schedule_plan/tests.rs
@@ -459,7 +459,7 @@ fn dst_gap_and_fold_keep_the_existing_oracles_shift_evidence() {
 }
 
 #[test]
-fn projection_is_bounded_and_after_skip_is_exposed_not_executed() {
+fn projection_is_bounded() {
     let candidate = daily(MissPolicy::Rattraper);
     let definition = candidate.validate().expect("definition");
     let plan = plan_schedule(
@@ -470,17 +470,6 @@ fn projection_is_bounded_and_after_skip_is_exposed_not_executed() {
     )
     .expect("plan");
     assert_eq!(plan.next_slots().count(), MAX_SCHEDULE_PROJECTION_SLOTS);
-
-    let mut completion = daily(MissPolicy::RattraperUneFois);
-    completion.overlap = Some(Overlap::Sauter);
-    completion.after_skip = Some(AfterSkip::ACompletion);
-    let plan = planned(
-        completion,
-        "2026-09-01T08:00:00Z",
-        &ScheduleDecisionState::empty(),
-    );
-    assert_eq!(plan.overlap(), Overlap::Sauter);
-    assert_eq!(plan.after_skip(), AfterSkip::ACompletion);
 }
 
 #[test]
@@ -620,6 +609,56 @@ fn active_timed_overlap_queue_refuses_until_a_queueing_law_exists() {
 }
 
 #[test]
+fn active_timed_after_skip_on_completion_refuses_until_a_trigger_law_exists() {
+    let mut candidate = daily(MissPolicy::Rattraper);
+    candidate.overlap = Some(Overlap::Sauter);
+    candidate.after_skip = Some(AfterSkip::ACompletion);
+    let definition = candidate.validate().expect("definition");
+    assert!(matches!(
+        plan_schedule(
+            &definition,
+            &zoned("2026-09-01T08:00:00Z"),
+            &ScheduleDecisionState::empty(),
+            4,
+        ),
+        Err(SchedulePlanError::UnsupportedAfterSkipOnCompletion)
+    ));
+
+    let mut paused = daily(MissPolicy::Rattraper);
+    paused.overlap = Some(Overlap::Sauter);
+    paused.after_skip = Some(AfterSkip::ACompletion);
+    paused.active = Some(false);
+    paused.pause_reason = Some("maintenance".to_owned());
+    paused.pause_until = Some("2026-09-10".to_owned());
+    assert!(matches!(
+        plan_schedule(
+            &paused.validate().expect("paused definition"),
+            &zoned("2026-09-01T08:00:00Z"),
+            &ScheduleDecisionState::empty(),
+            4,
+        )
+        .expect("inactive plans without effective times")
+        .due(),
+        ScheduleDueVerdict::PausedInactive { .. }
+    ));
+
+    let mut webhook = draft(ScheduleWhenDraft::Webhook, MissPolicy::Rattraper);
+    webhook.overlap = Some(Overlap::Sauter);
+    webhook.after_skip = Some(AfterSkip::ACompletion);
+    assert!(matches!(
+        plan_schedule(
+            &webhook.validate().expect("webhook definition"),
+            &zoned("2026-09-01T08:00:00Z"),
+            &ScheduleDecisionState::empty(),
+            4,
+        )
+        .expect("webhooks have no effective timed slot")
+        .due(),
+        ScheduleDueVerdict::NotDue
+    ));
+}
+
+#[test]
 fn active_timed_hash_jitter_refuses_until_a_law_exists() {
     let mut jittered = daily(MissPolicy::Rattraper);
     jittered.jitter = Some(ScheduleJitter::Hash);
@@ -678,6 +717,10 @@ fn planner_refusals_speak_the_schedule_registry_code() {
     );
     assert_eq!(
         SchedulePlanError::UnsupportedOverlapQueue.nika_code(),
+        nika_error::codes::NIKA_017
+    );
+    assert_eq!(
+        SchedulePlanError::UnsupportedAfterSkipOnCompletion.nika_code(),
         nika_error::codes::NIKA_017
     );
     assert_eq!(

--- a/crates/nika-cadence/src/schedule_plan/tests.rs
+++ b/crates/nika-cadence/src/schedule_plan/tests.rs
@@ -410,6 +410,55 @@ fn inactive_pause_is_a_machine_verdict_and_never_a_wake_hint() {
 }
 
 #[test]
+fn a_pause_whose_until_passed_wakes_at_the_decision_date() {
+    let mut woke = daily(MissPolicy::Rattraper);
+    woke.active = Some(false);
+    woke.pause_reason = Some("operator maintenance".to_owned());
+    woke.pause_until = Some("2026-08-31".to_owned());
+    let plan = planned(
+        woke,
+        "2026-09-01T09:00:00Z",
+        &ScheduleDecisionState::empty(),
+    );
+    assert!(matches!(
+        plan.due(),
+        ScheduleDueVerdict::ScheduledOnTime { .. }
+    ));
+
+    let mut boundary = daily(MissPolicy::Rattraper);
+    boundary.active = Some(false);
+    boundary.pause_reason = Some("operator maintenance".to_owned());
+    boundary.pause_until = Some("2026-09-01".to_owned());
+    let plan = planned(
+        boundary,
+        "2026-09-01T09:00:00Z",
+        &ScheduleDecisionState::empty(),
+    );
+    assert!(
+        matches!(plan.due(), ScheduleDueVerdict::PausedInactive { .. }),
+        "the bound is a strict date: on its own date the pause still holds"
+    );
+}
+
+#[test]
+fn a_woke_pause_faces_the_same_refusals_as_an_active_declaration() {
+    let mut woke = daily(MissPolicy::Rattraper);
+    woke.active = Some(false);
+    woke.pause_reason = Some("operator maintenance".to_owned());
+    woke.pause_until = Some("2026-08-31".to_owned());
+    woke.jitter = Some(ScheduleJitter::Hash);
+    assert!(matches!(
+        plan_schedule(
+            &woke.validate().expect("definition"),
+            &zoned("2026-09-01T08:00:00Z"),
+            &ScheduleDecisionState::empty(),
+            4,
+        ),
+        Err(SchedulePlanError::UnsupportedHashJitter)
+    ));
+}
+
+#[test]
 fn webhook_has_no_timed_slot_or_wake() {
     let plan = planned(
         draft(ScheduleWhenDraft::Webhook, MissPolicy::Rattraper),

--- a/crates/nika-cadence/src/schedule_plan/tests.rs
+++ b/crates/nika-cadence/src/schedule_plan/tests.rs
@@ -459,10 +459,8 @@ fn dst_gap_and_fold_keep_the_existing_oracles_shift_evidence() {
 }
 
 #[test]
-fn projection_is_bounded_and_policy_inputs_are_exposed_not_executed() {
-    let mut candidate = daily(MissPolicy::Rattraper);
-    candidate.overlap = Some(Overlap::Remplacer);
-    candidate.after_skip = None;
+fn projection_is_bounded_and_after_skip_is_exposed_not_executed() {
+    let candidate = daily(MissPolicy::Rattraper);
     let definition = candidate.validate().expect("definition");
     let plan = plan_schedule(
         &definition,
@@ -472,8 +470,6 @@ fn projection_is_bounded_and_policy_inputs_are_exposed_not_executed() {
     )
     .expect("plan");
     assert_eq!(plan.next_slots().count(), MAX_SCHEDULE_PROJECTION_SLOTS);
-    assert_eq!(plan.overlap(), Overlap::Remplacer);
-    assert_eq!(plan.after_skip(), AfterSkip::ProchainCreneau);
 
     let mut completion = daily(MissPolicy::RattraperUneFois);
     completion.overlap = Some(Overlap::Sauter);
@@ -521,6 +517,56 @@ fn project_and_api_equivalents_share_revision_and_slots() {
         .cloned()
         .collect();
     assert_eq!(project_slots, api_slots);
+}
+
+#[test]
+fn active_timed_overlap_replace_refuses_until_a_preemption_law_exists() {
+    let mut candidate = daily(MissPolicy::Rattraper);
+    candidate.overlap = Some(Overlap::Remplacer);
+    candidate.after_skip = None;
+    let definition = candidate.validate().expect("definition");
+    assert!(matches!(
+        plan_schedule(
+            &definition,
+            &zoned("2026-09-01T08:00:00Z"),
+            &ScheduleDecisionState::empty(),
+            4,
+        ),
+        Err(SchedulePlanError::UnsupportedOverlapReplace)
+    ));
+
+    let mut paused = daily(MissPolicy::Rattraper);
+    paused.overlap = Some(Overlap::Remplacer);
+    paused.after_skip = None;
+    paused.active = Some(false);
+    paused.pause_reason = Some("maintenance".to_owned());
+    paused.pause_until = Some("2026-09-10".to_owned());
+    assert!(matches!(
+        plan_schedule(
+            &paused.validate().expect("paused definition"),
+            &zoned("2026-09-01T08:00:00Z"),
+            &ScheduleDecisionState::empty(),
+            4,
+        )
+        .expect("inactive plans without effective times")
+        .due(),
+        ScheduleDueVerdict::PausedInactive { .. }
+    ));
+
+    let mut webhook = draft(ScheduleWhenDraft::Webhook, MissPolicy::Rattraper);
+    webhook.overlap = Some(Overlap::Remplacer);
+    webhook.after_skip = None;
+    assert!(matches!(
+        plan_schedule(
+            &webhook.validate().expect("webhook definition"),
+            &zoned("2026-09-01T08:00:00Z"),
+            &ScheduleDecisionState::empty(),
+            4,
+        )
+        .expect("webhooks have no effective timed slot")
+        .due(),
+        ScheduleDueVerdict::NotDue
+    ));
 }
 
 #[test]
@@ -574,6 +620,10 @@ fn active_timed_hash_jitter_refuses_until_a_law_exists() {
 fn planner_refusals_speak_the_schedule_registry_code() {
     assert_eq!(
         SchedulePlanError::UnsupportedHashJitter.nika_code(),
+        nika_error::codes::NIKA_017
+    );
+    assert_eq!(
+        SchedulePlanError::UnsupportedOverlapReplace.nika_code(),
         nika_error::codes::NIKA_017
     );
     assert_eq!(

--- a/crates/nika-cadence/src/schedule_plan/tests.rs
+++ b/crates/nika-cadence/src/schedule_plan/tests.rs
@@ -570,6 +570,56 @@ fn active_timed_overlap_replace_refuses_until_a_preemption_law_exists() {
 }
 
 #[test]
+fn active_timed_overlap_queue_refuses_until_a_queueing_law_exists() {
+    let mut candidate = daily(MissPolicy::Rattraper);
+    candidate.overlap = Some(Overlap::File);
+    candidate.after_skip = None;
+    let definition = candidate.validate().expect("definition");
+    assert!(matches!(
+        plan_schedule(
+            &definition,
+            &zoned("2026-09-01T08:00:00Z"),
+            &ScheduleDecisionState::empty(),
+            4,
+        ),
+        Err(SchedulePlanError::UnsupportedOverlapQueue)
+    ));
+
+    let mut paused = daily(MissPolicy::Rattraper);
+    paused.overlap = Some(Overlap::File);
+    paused.after_skip = None;
+    paused.active = Some(false);
+    paused.pause_reason = Some("maintenance".to_owned());
+    paused.pause_until = Some("2026-09-10".to_owned());
+    assert!(matches!(
+        plan_schedule(
+            &paused.validate().expect("paused definition"),
+            &zoned("2026-09-01T08:00:00Z"),
+            &ScheduleDecisionState::empty(),
+            4,
+        )
+        .expect("inactive plans without effective times")
+        .due(),
+        ScheduleDueVerdict::PausedInactive { .. }
+    ));
+
+    let mut webhook = draft(ScheduleWhenDraft::Webhook, MissPolicy::Rattraper);
+    webhook.overlap = Some(Overlap::File);
+    webhook.after_skip = None;
+    assert!(matches!(
+        plan_schedule(
+            &webhook.validate().expect("webhook definition"),
+            &zoned("2026-09-01T08:00:00Z"),
+            &ScheduleDecisionState::empty(),
+            4,
+        )
+        .expect("webhooks have no effective timed slot")
+        .due(),
+        ScheduleDueVerdict::NotDue
+    ));
+}
+
+#[test]
 fn active_timed_hash_jitter_refuses_until_a_law_exists() {
     let mut jittered = daily(MissPolicy::Rattraper);
     jittered.jitter = Some(ScheduleJitter::Hash);
@@ -624,6 +674,10 @@ fn planner_refusals_speak_the_schedule_registry_code() {
     );
     assert_eq!(
         SchedulePlanError::UnsupportedOverlapReplace.nika_code(),
+        nika_error::codes::NIKA_017
+    );
+    assert_eq!(
+        SchedulePlanError::UnsupportedOverlapQueue.nika_code(),
         nika_error::codes::NIKA_017
     );
     assert_eq!(

--- a/crates/nika-cadence/src/tick.rs
+++ b/crates/nika-cadence/src/tick.rs
@@ -120,14 +120,26 @@ pub fn v0_unsupported(beat: &Beat) -> Option<(&'static str, &'static str)> {
     Some((policy.what(), V0Policy::ARRIVES))
 }
 
+/// The shared pause-bound law: an ISO civil date strictly before the
+/// decision instant's own date ⇒ the bounded suspension is over. The
+/// arm-fire edge and the serve planner judge on the same instant's civil
+/// date (a bare `--now` rides UTC); a zone-exact reading in the cadence's
+/// own zone remains future work.
+#[must_use]
+pub(crate) fn date_expired(raw: &str, now: &Zoned) -> bool {
+    let Ok(date) = raw.parse::<jiff::civil::Date>() else {
+        return false;
+    };
+    date < now.date()
+}
+
 /// `jusqu_au` strictly before the decision instant's own date ⇒ the
-/// suspension is over. v0 judges on the instant's civil date (a bare
-/// `--now` rides UTC) — the zone-exact expiry lands with serve.
+/// suspension is over. v0 judges on the instant's civil date through the
+/// crate-private `date_expired` helper.
 #[must_use]
 pub fn expiry_passed(beat: &Beat, now: &Zoned) -> Option<String> {
     let raw = beat.jusqu_au.as_deref()?;
-    let date = raw.parse::<jiff::civil::Date>().ok()?;
-    (date < now.date()).then(|| raw.to_owned())
+    date_expired(raw, now).then(|| raw.to_owned())
 }
 
 /// The named-beat decision, pure. Order: the file's own truth

--- a/crates/nika-serve/src/server/mod.rs
+++ b/crates/nika-serve/src/server/mod.rs
@@ -204,6 +204,7 @@ struct AppState {
     event_page_limit: EventPageLimit,
     schedules: Arc<ScheduleStore>,
     schedule_wake: Arc<Notify>,
+    project_refusals: scheduler::ProjectRefusals,
     clock: Arc<dyn ResidentClock>,
     cancellations: Arc<ActiveCancellations>,
 }
@@ -217,6 +218,7 @@ struct AuthorityState {
     project: Arc<OnceLock<Arc<OwnedDir>>>,
     schedules: Arc<ScheduleStore>,
     schedule_wake: Arc<Notify>,
+    project_refusals: scheduler::ProjectRefusals,
     coordinator: ResidentExecutionCoordinator,
     clock: Arc<dyn ResidentClock>,
     cancellations: Arc<ActiveCancellations>,
@@ -306,6 +308,7 @@ impl ResidentAuthority {
         }
         let schedules = Arc::new(prepared.schedules);
         let schedule_wake = Arc::new(Notify::new());
+        let project_refusals = scheduler::ProjectRefusals::default();
         let cancellations = Arc::new(ActiveCancellations::default());
         let state = Arc::new(AuthorityState {
             store: store_actor.handle(),
@@ -316,6 +319,7 @@ impl ResidentAuthority {
             project,
             schedules,
             schedule_wake,
+            project_refusals,
             coordinator: coordinator.clone(),
             clock: Arc::clone(config.clock()),
             cancellations,
@@ -407,6 +411,7 @@ impl BoundServer {
             event_page_limit,
             schedules: Arc::clone(&authority.state.schedules),
             schedule_wake: Arc::clone(&authority.state.schedule_wake),
+            project_refusals: Arc::clone(&authority.state.project_refusals),
             clock: Arc::clone(&authority.state.clock),
             cancellations: Arc::clone(&authority.state.cancellations),
         });

--- a/crates/nika-serve/src/server/schedule_http.rs
+++ b/crates/nika-serve/src/server/schedule_http.rs
@@ -485,7 +485,8 @@ fn pause_json(definition: &ScheduleDefinition) -> Value {
 fn planner_finding(error: &SchedulePlanError) -> Value {
     let code = match error {
         SchedulePlanError::UnsupportedHashJitter => "schedule.jitter",
-        SchedulePlanError::UnsupportedOverlapReplace => "schedule.overlap",
+        SchedulePlanError::UnsupportedOverlapReplace
+        | SchedulePlanError::UnsupportedOverlapQueue => "schedule.overlap",
         SchedulePlanError::InvalidCanonicalCadence(_) => "schedule.cadence",
         _ => "schedule.plan",
     };

--- a/crates/nika-serve/src/server/schedule_http.rs
+++ b/crates/nika-serve/src/server/schedule_http.rs
@@ -485,6 +485,7 @@ fn pause_json(definition: &ScheduleDefinition) -> Value {
 fn planner_finding(error: &SchedulePlanError) -> Value {
     let code = match error {
         SchedulePlanError::UnsupportedHashJitter => "schedule.jitter",
+        SchedulePlanError::UnsupportedOverlapReplace => "schedule.overlap",
         SchedulePlanError::InvalidCanonicalCadence(_) => "schedule.cadence",
         _ => "schedule.plan",
     };

--- a/crates/nika-serve/src/server/schedule_http.rs
+++ b/crates/nika-serve/src/server/schedule_http.rs
@@ -187,13 +187,52 @@ pub(super) async fn get(id: String, state: &AppState) -> Response<ResponseBody> 
     let schedules = Arc::clone(&state.schedules);
     let lookup = id.clone();
     let definition = tokio::task::spawn_blocking(move || schedules.get(&lookup)).await;
-    let definition = match definition {
-        Ok(Ok(Some(definition))) => definition,
-        Ok(Ok(None)) => return schedule_not_found(),
+    match definition {
+        Ok(Ok(Some(definition))) => status_response(state, definition, None).await,
+        Ok(Ok(None)) => project_refusal_response(&id, state).await,
+        Ok(Err(error)) => store_error_response(&error),
+        Err(_) => ApiError::internal().into_response(),
+    }
+}
+
+/// A project beat the planner refused at load reads as a finding on the
+/// same status projection, never as a live schedule that fires nothing.
+async fn project_refusal_response(id: &str, state: &AppState) -> Response<ResponseBody> {
+    let refused = {
+        let projection = state
+            .project_refusals
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        projection.get(id).cloned()
+    };
+    let Some(refused) = refused else {
+        return schedule_not_found();
+    };
+    let definition = refused.definition().clone();
+    let revision = definition.revision();
+    let schedules = Arc::clone(&state.schedules);
+    let lookup = id.to_owned();
+    let last = tokio::task::spawn_blocking(move || {
+        schedules.last_decision(ScheduleOrigin::Project, &lookup)
+    })
+    .await;
+    let last = match last {
+        Ok(Ok(last)) => last,
         Ok(Err(error)) => return store_error_response(&error),
         Err(_) => return ApiError::internal().into_response(),
     };
-    status_response(state, definition, None).await
+    let body = json!({
+        "definition": definition_json(&definition),
+        "origin": "project",
+        "revision": revision.as_str(),
+        "active": definition.is_active(),
+        "pause": pause_json(&definition),
+        "finding": planner_finding(refused.error()),
+        "next": [],
+        "earliestWakeHint": Value::Null,
+        "lastDecision": last.as_ref().map(last_decision_json),
+    });
+    with_etag(json_response(StatusCode::OK, &body), &revision)
 }
 
 async fn applied_response(

--- a/crates/nika-serve/src/server/schedule_http.rs
+++ b/crates/nika-serve/src/server/schedule_http.rs
@@ -487,6 +487,7 @@ fn planner_finding(error: &SchedulePlanError) -> Value {
         SchedulePlanError::UnsupportedHashJitter => "schedule.jitter",
         SchedulePlanError::UnsupportedOverlapReplace
         | SchedulePlanError::UnsupportedOverlapQueue => "schedule.overlap",
+        SchedulePlanError::UnsupportedAfterSkipOnCompletion => "schedule.after-skip",
         SchedulePlanError::InvalidCanonicalCadence(_) => "schedule.cadence",
         _ => "schedule.plan",
     };

--- a/crates/nika-serve/src/server/schedule_http.rs
+++ b/crates/nika-serve/src/server/schedule_http.rs
@@ -488,6 +488,7 @@ fn planner_finding(error: &SchedulePlanError) -> Value {
         SchedulePlanError::UnsupportedOverlapReplace
         | SchedulePlanError::UnsupportedOverlapQueue => "schedule.overlap",
         SchedulePlanError::UnsupportedAfterSkipOnCompletion => "schedule.after-skip",
+        SchedulePlanError::UnsupportedTolerance => "schedule.tolerance",
         SchedulePlanError::InvalidCanonicalCadence(_) => "schedule.cadence",
         _ => "schedule.plan",
     };

--- a/crates/nika-serve/src/server/schedule_tests.rs
+++ b/crates/nika-serve/src/server/schedule_tests.rs
@@ -928,3 +928,49 @@ async fn project_beat_with_tolerance_surfaces_a_load_finding_and_never_fires() {
     assert_eq!(backend.calls(), 0, "a refused beat never fires");
     server.stop().await.expect("stop");
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_project_beat_whose_pause_until_passed_fires_and_a_bound_one_stays_paused() {
+    let world = TestWorld::new();
+    std::fs::write(
+        world.workflows.join("report.nika.yaml"),
+        "nika: report\npermits:\n  tools: [\"nika:jq\"]\ntasks:\n  value:\n    invoke:\n      tool: nika:jq\n      args: { input: 2, expression: \".\" }\n",
+    )
+    .expect("report workflow");
+    std::fs::write(
+        world.workflows.join("nika.yaml"),
+        concat!(
+            "nika: proj\narm:\n",
+            "  - workflow: root.nika.yaml\n",
+            "    cadence: \"TZ=UTC * * * * *\"\n",
+            "    plafond: 0.25\n",
+            "    manqué: sauter\n",
+            "    actif: false\n",
+            "    raison: \"maintenance\"\n",
+            "    jusqu_au: \"2026-08-31\"\n",
+            "  - workflow: report.nika.yaml\n",
+            "    cadence: \"TZ=UTC * * * * *\"\n",
+            "    plafond: 0.25\n",
+            "    manqué: sauter\n",
+            "    actif: false\n",
+            "    raison: \"maintenance\"\n",
+            "    jusqu_au: \"2026-09-10\"\n",
+        ),
+    )
+    .expect("project nika.yaml");
+    let backend = Arc::new(CountingBackend::default());
+    let clock = Arc::new(ManualClock::new("2026-09-01T08:00:00Z[UTC]"));
+    let server = world
+        .start_with_clock(backend.clone(), limits(), clock.clone())
+        .await;
+    backend.wait_for_call().await;
+    clock.wait_for_sleeps(2).await;
+    assert_eq!(backend.calls(), 1, "only the woke beat fires");
+    assert!(
+        backend.root_bytes().is_some_and(|bytes| bytes
+            .windows(b"input: 1".len())
+            .any(|part| part == b"input: 1")),
+        "the fired run captured the root workflow"
+    );
+    server.stop().await.expect("stop");
+}

--- a/crates/nika-serve/src/server/schedule_tests.rs
+++ b/crates/nika-serve/src/server/schedule_tests.rs
@@ -725,6 +725,66 @@ async fn active_overlap_replace_is_refused_before_persistence() {
     server.stop().await.expect("stop");
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn active_overlap_queue_is_refused_before_persistence() {
+    let world = TestWorld::new();
+    let server = world.start(Arc::new(NoopBackend), limits()).await;
+    let candidate = json!({
+        "workflow": "root.nika.yaml",
+        "when": {"kind": "once", "at": "2099-09-01T07:00:00Z"},
+        "maxCostUsd": 0.25,
+        "missed": "skip",
+        "overlap": "queue"
+    })
+    .to_string();
+    let refused = server
+        .request(&put_request(
+            "overlap-queue",
+            &candidate,
+            "If-None-Match: *\r\n",
+            true,
+        ))
+        .await;
+    assert_eq!(refused.status, 422, "{}", refused.body);
+    assert_eq!(refused.json()["findings"][0]["code"], "schedule.overlap");
+    assert!(
+        refused.json()["findings"][0]["detail"]
+            .as_str()
+            .expect("finding detail")
+            .contains("overlap=queue"),
+        "{}",
+        refused.body
+    );
+    let absent = server
+        .request(&get_request("/v1/schedules/overlap-queue"))
+        .await;
+    assert_eq!(absent.status, 404, "schedule must not be persisted");
+    server.stop().await.expect("stop");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn project_beat_with_overlap_queue_surfaces_a_load_finding_and_never_fires() {
+    let world = TestWorld::new();
+    write_project_beat(&world, "    chevauchement: file\n");
+    let backend = Arc::new(CountingBackend::default());
+    let clock = Arc::new(ManualClock::new("2026-09-01T08:00:00Z[UTC]"));
+    let server = world
+        .start_with_clock(backend.clone(), limits(), clock.clone())
+        .await;
+    clock.wait_for_sleeps(1).await;
+    let finding = project_finding(&server, "root").await;
+    assert_eq!(finding["code"], "schedule.overlap", "{finding}");
+    assert!(
+        finding["detail"]
+            .as_str()
+            .expect("finding detail")
+            .contains("overlap=queue"),
+        "{finding}"
+    );
+    assert_eq!(backend.calls(), 0, "a refused beat never fires");
+    server.stop().await.expect("stop");
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn project_beat_with_overlap_replace_surfaces_a_load_finding_and_never_fires() {
     let world = TestWorld::new();

--- a/crates/nika-serve/src/server/schedule_tests.rs
+++ b/crates/nika-serve/src/server/schedule_tests.rs
@@ -868,3 +868,63 @@ async fn project_beat_with_overlap_replace_surfaces_a_load_finding_and_never_fir
     assert_eq!(backend.calls(), 0, "a refused beat never fires");
     server.stop().await.expect("stop");
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn active_tolerance_is_refused_before_persistence() {
+    let world = TestWorld::new();
+    let server = world.start(Arc::new(NoopBackend), limits()).await;
+    let candidate = json!({
+        "workflow": "root.nika.yaml",
+        "when": {"kind": "once", "at": "2099-09-01T07:00:00Z"},
+        "maxCostUsd": 0.25,
+        "missed": "skip",
+        "tolerance": "3/4"
+    })
+    .to_string();
+    let refused = server
+        .request(&put_request(
+            "tolerance",
+            &candidate,
+            "If-None-Match: *\r\n",
+            true,
+        ))
+        .await;
+    assert_eq!(refused.status, 422, "{}", refused.body);
+    assert_eq!(refused.json()["findings"][0]["code"], "schedule.tolerance");
+    assert!(
+        refused.json()["findings"][0]["detail"]
+            .as_str()
+            .expect("finding detail")
+            .contains("tolerance"),
+        "{}",
+        refused.body
+    );
+    let absent = server
+        .request(&get_request("/v1/schedules/tolerance"))
+        .await;
+    assert_eq!(absent.status, 404, "schedule must not be persisted");
+    server.stop().await.expect("stop");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn project_beat_with_tolerance_surfaces_a_load_finding_and_never_fires() {
+    let world = TestWorld::new();
+    write_project_beat(&world, "    tolérance: \"3/4\"\n");
+    let backend = Arc::new(CountingBackend::default());
+    let clock = Arc::new(ManualClock::new("2026-09-01T08:00:00Z[UTC]"));
+    let server = world
+        .start_with_clock(backend.clone(), limits(), clock.clone())
+        .await;
+    clock.wait_for_sleeps(1).await;
+    let finding = project_finding(&server, "root").await;
+    assert_eq!(finding["code"], "schedule.tolerance", "{finding}");
+    assert!(
+        finding["detail"]
+            .as_str()
+            .expect("finding detail")
+            .contains("tolerance"),
+        "{finding}"
+    );
+    assert_eq!(backend.calls(), 0, "a refused beat never fires");
+    server.stop().await.expect("stop");
+}

--- a/crates/nika-serve/src/server/schedule_tests.rs
+++ b/crates/nika-serve/src/server/schedule_tests.rs
@@ -762,6 +762,67 @@ async fn active_overlap_queue_is_refused_before_persistence() {
     server.stop().await.expect("stop");
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn active_after_skip_on_completion_is_refused_before_persistence() {
+    let world = TestWorld::new();
+    let server = world.start(Arc::new(NoopBackend), limits()).await;
+    let candidate = json!({
+        "workflow": "root.nika.yaml",
+        "when": {"kind": "once", "at": "2099-09-01T07:00:00Z"},
+        "maxCostUsd": 0.25,
+        "missed": "skip",
+        "overlap": "skip",
+        "afterSkip": "on_completion"
+    })
+    .to_string();
+    let refused = server
+        .request(&put_request(
+            "after-skip-completion",
+            &candidate,
+            "If-None-Match: *\r\n",
+            true,
+        ))
+        .await;
+    assert_eq!(refused.status, 422, "{}", refused.body);
+    assert_eq!(refused.json()["findings"][0]["code"], "schedule.after-skip");
+    assert!(
+        refused.json()["findings"][0]["detail"]
+            .as_str()
+            .expect("finding detail")
+            .contains("afterSkip=on_completion"),
+        "{}",
+        refused.body
+    );
+    let absent = server
+        .request(&get_request("/v1/schedules/after-skip-completion"))
+        .await;
+    assert_eq!(absent.status, 404, "schedule must not be persisted");
+    server.stop().await.expect("stop");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn project_beat_with_after_skip_on_completion_surfaces_a_load_finding() {
+    let world = TestWorld::new();
+    write_project_beat(&world, "    après_saut: à-complétion\n");
+    let backend = Arc::new(CountingBackend::default());
+    let clock = Arc::new(ManualClock::new("2026-09-01T08:00:00Z[UTC]"));
+    let server = world
+        .start_with_clock(backend.clone(), limits(), clock.clone())
+        .await;
+    clock.wait_for_sleeps(1).await;
+    let finding = project_finding(&server, "root").await;
+    assert_eq!(finding["code"], "schedule.after-skip", "{finding}");
+    assert!(
+        finding["detail"]
+            .as_str()
+            .expect("finding detail")
+            .contains("afterSkip=on_completion"),
+        "{finding}"
+    );
+    assert_eq!(backend.calls(), 0, "a refused beat never fires");
+    server.stop().await.expect("stop");
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn project_beat_with_overlap_queue_surfaces_a_load_finding_and_never_fires() {
     let world = TestWorld::new();

--- a/crates/nika-serve/src/server/schedule_tests.rs
+++ b/crates/nika-serve/src/server/schedule_tests.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use serde_json::json;
 
 use super::store::ShutdownPhase;
-use super::tests::{TestWorld, auth_header, get_request, limits};
+use super::tests::{TestServer, TestWorld, auth_header, get_request, limits};
 use super::{ExecutionBackend, ExecutionDisposition, ExecutionOutcome};
 
 #[derive(Debug)]
@@ -647,5 +647,43 @@ async fn no_schedule_list_delete_trigger_backfill_or_arm_routes_exist() {
         auth_header()
     );
     assert_eq!(server.request(&delete).await.status, 404);
+    server.stop().await.expect("stop");
+}
+
+fn write_project_beat(world: &TestWorld, extra: &str) {
+    std::fs::write(
+        world.workflows.join("nika.yaml"),
+        format!(
+            "nika: proj\narm:\n  - workflow: root.nika.yaml\n    cadence: \"TZ=UTC * * * * *\"\n    plafond: 0.25\n    manqué: sauter\n{extra}"
+        ),
+    )
+    .expect("project nika.yaml");
+}
+
+async fn project_finding(server: &TestServer, id: &str) -> serde_json::Value {
+    let response = server
+        .request(&get_request(&format!("/v1/schedules/{id}")))
+        .await;
+    assert_eq!(response.status, 200, "{}", response.body);
+    let body = response.json();
+    assert_eq!(body["origin"], "project", "{body}");
+    body["finding"].clone()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn project_beat_with_hash_jitter_surfaces_a_load_finding_and_never_fires() {
+    let world = TestWorld::new();
+    write_project_beat(&world, "    décalage: hash\n");
+    let backend = Arc::new(CountingBackend::default());
+    let clock = Arc::new(ManualClock::new("2026-09-01T08:00:00Z[UTC]"));
+    let server = world
+        .start_with_clock(backend.clone(), limits(), clock.clone())
+        .await;
+    clock.wait_for_sleeps(1).await;
+    let finding = project_finding(&server, "root").await;
+    assert_eq!(finding["code"], "schedule.jitter", "{finding}");
+    clock.advance_to("2026-09-01T08:03:00Z[UTC]");
+    clock.wait_for_sleeps(2).await;
+    assert_eq!(backend.calls(), 0, "a refused beat never fires");
     server.stop().await.expect("stop");
 }

--- a/crates/nika-serve/src/server/schedule_tests.rs
+++ b/crates/nika-serve/src/server/schedule_tests.rs
@@ -687,3 +687,63 @@ async fn project_beat_with_hash_jitter_surfaces_a_load_finding_and_never_fires()
     assert_eq!(backend.calls(), 0, "a refused beat never fires");
     server.stop().await.expect("stop");
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn active_overlap_replace_is_refused_before_persistence() {
+    let world = TestWorld::new();
+    let server = world.start(Arc::new(NoopBackend), limits()).await;
+    let candidate = json!({
+        "workflow": "root.nika.yaml",
+        "when": {"kind": "once", "at": "2099-09-01T07:00:00Z"},
+        "maxCostUsd": 0.25,
+        "missed": "skip",
+        "overlap": "replace"
+    })
+    .to_string();
+    let refused = server
+        .request(&put_request(
+            "overlap-replace",
+            &candidate,
+            "If-None-Match: *\r\n",
+            true,
+        ))
+        .await;
+    assert_eq!(refused.status, 422, "{}", refused.body);
+    assert_eq!(refused.json()["findings"][0]["code"], "schedule.overlap");
+    assert!(
+        refused.json()["findings"][0]["detail"]
+            .as_str()
+            .expect("finding detail")
+            .contains("overlap=replace"),
+        "{}",
+        refused.body
+    );
+    let absent = server
+        .request(&get_request("/v1/schedules/overlap-replace"))
+        .await;
+    assert_eq!(absent.status, 404, "schedule must not be persisted");
+    server.stop().await.expect("stop");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn project_beat_with_overlap_replace_surfaces_a_load_finding_and_never_fires() {
+    let world = TestWorld::new();
+    write_project_beat(&world, "    chevauchement: remplacer\n");
+    let backend = Arc::new(CountingBackend::default());
+    let clock = Arc::new(ManualClock::new("2026-09-01T08:00:00Z[UTC]"));
+    let server = world
+        .start_with_clock(backend.clone(), limits(), clock.clone())
+        .await;
+    clock.wait_for_sleeps(1).await;
+    let finding = project_finding(&server, "root").await;
+    assert_eq!(finding["code"], "schedule.overlap", "{finding}");
+    assert!(
+        finding["detail"]
+            .as_str()
+            .expect("finding detail")
+            .contains("overlap=replace"),
+        "{finding}"
+    );
+    assert_eq!(backend.calls(), 0, "a refused beat never fires");
+    server.stop().await.expect("stop");
+}

--- a/crates/nika-serve/src/server/scheduler.rs
+++ b/crates/nika-serve/src/server/scheduler.rs
@@ -1,14 +1,15 @@
 //! Resident schedule planner/firer integration.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use jiff::{Timestamp, Zoned};
 use nika_cadence::{
-    ArmGeneration, ScheduleDecision, ScheduleDefinition, ScheduleDraft, ScheduleDueVerdict,
-    ScheduleOrigin, ScheduleRevision, ScheduleSlot, plan_schedule,
+    ArmGeneration, ScheduleDecision, ScheduleDecisionState, ScheduleDefinition, ScheduleDraft,
+    ScheduleDueVerdict, ScheduleOrigin, SchedulePlanError, ScheduleRevision, ScheduleSlot,
+    plan_schedule,
 };
 use sha2::{Digest as _, Sha256};
 use tokio::sync::watch;
@@ -26,6 +27,33 @@ const GENERATION_DOMAIN: &[u8] = b"nika/resident-schedule-generation@1\0";
 struct ResidentSchedule {
     origin: ScheduleOrigin,
     definition: ScheduleDefinition,
+}
+
+/// A project beat whose declaration the planner refused at load. The
+/// refusal is projected onto schedule status; the beat never rides the
+/// scan loop as a live declaration that silently never fires.
+#[derive(Debug, Clone)]
+pub(super) struct RefusedProjectSchedule {
+    definition: ScheduleDefinition,
+    error: SchedulePlanError,
+}
+
+impl RefusedProjectSchedule {
+    pub(super) fn definition(&self) -> &ScheduleDefinition {
+        &self.definition
+    }
+
+    pub(super) fn error(&self) -> &SchedulePlanError {
+        &self.error
+    }
+}
+
+/// The load-time refusal projection, replaced wholesale by every scan.
+pub(super) type ProjectRefusals = Arc<Mutex<BTreeMap<String, RefusedProjectSchedule>>>;
+
+struct ProjectLoad {
+    live: Vec<ResidentSchedule>,
+    refused: Vec<RefusedProjectSchedule>,
 }
 
 struct FireCandidate {
@@ -120,9 +148,12 @@ fn scan(state: &AuthorityState) -> Result<Scan, ServerError> {
         });
     }
     if let Some(project) = state.project.get() {
-        match load_project(project) {
-            Ok(project_schedules) => schedules.extend(project_schedules),
-            Err(ServerError::ScheduledAdmission) => {}
+        match load_project(project, &now) {
+            Ok(load) => {
+                publish_refusals(state, load.refused);
+                schedules.extend(load.live);
+            }
+            Err(ServerError::ScheduledAdmission) => publish_refusals(state, Vec::new()),
             Err(error) => return Err(error),
         }
     }
@@ -362,7 +393,40 @@ fn generation(
         .ok_or(ServerError::ScheduledAdmission)
 }
 
-fn load_project(project: &nika_fs::OwnedDir) -> Result<Vec<ResidentSchedule>, ServerError> {
+fn publish_refusals(state: &AuthorityState, refused: Vec<RefusedProjectSchedule>) {
+    let mut projection = state
+        .project_refusals
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    projection.clear();
+    for refusal in refused {
+        projection.insert(refusal.definition.id().to_owned(), refusal);
+    }
+}
+
+fn load_project(project: &nika_fs::OwnedDir, now: &Zoned) -> Result<ProjectLoad, ServerError> {
+    let mut live = Vec::new();
+    let mut refused = Vec::new();
+    for definition in load_project_definitions(project)? {
+        match plan_schedule(
+            &definition,
+            now,
+            &ScheduleDecisionState::empty(),
+            PLANNER_PROJECTION,
+        ) {
+            Ok(_) => live.push(ResidentSchedule {
+                origin: ScheduleOrigin::Project,
+                definition,
+            }),
+            Err(error) => refused.push(RefusedProjectSchedule { definition, error }),
+        }
+    }
+    Ok(ProjectLoad { live, refused })
+}
+
+fn load_project_definitions(
+    project: &nika_fs::OwnedDir,
+) -> Result<Vec<ScheduleDefinition>, ServerError> {
     let Some(text) = project
         .read_optional(nika_vocab::project::FILE_NAME)
         .map_err(|error| ServerError::WorkflowRoot(error.kind()))?
@@ -384,10 +448,6 @@ fn load_project(project: &nika_fs::OwnedDir) -> Result<Vec<ResidentSchedule>, Se
         .map(|(beat, id)| {
             ScheduleDraft::from_project(id, beat)
                 .and_then(ScheduleDraft::validate)
-                .map(|definition| ResidentSchedule {
-                    origin: ScheduleOrigin::Project,
-                    definition,
-                })
                 .map_err(|_| ServerError::ScheduledAdmission)
         })
         .collect()
@@ -398,9 +458,9 @@ fn project_revision_current(
     id: &str,
     revision: &ScheduleRevision,
 ) -> Result<bool, ServerError> {
-    Ok(load_project(project)?.into_iter().any(|schedule| {
-        schedule.definition.id() == id && schedule.definition.revision() == *revision
-    }))
+    Ok(load_project_definitions(project)?
+        .into_iter()
+        .any(|definition| definition.id() == id && definition.revision() == *revision))
 }
 
 fn schedule_key(origin: ScheduleOrigin, id: &str) -> String {


### PR DESCRIPTION
Closes #1344, closes #1345, closes #1346, closes #1347, closes #1348. Also fixes pause-until expiry in serve (no issue — P2 from the same audit).

Found by the Nika System Perfection Campaign socratic pass (evidence: monorepo `dx/state/gauntlet/2026-09-01-perfection/evidence/socratic-pass.md` Q7–Q10).

**The law restored**: an accepted schedule policy must behave as declared, or be refused at apply with a typed finding. Never accept-then-silently-no-op.

## What changes

- `plan_schedule` gains four typed refusals (mirroring the existing `UnsupportedHashJitter` precedent, all NIKA_017): `UnsupportedOverlapReplace`, `UnsupportedOverlapQueue`, `UnsupportedAfterSkipOnCompletion`, `UnsupportedTolerance` — gated on active + non-webhook declarations, exactly like jitter. Paused and webhook declarations are untouched (overlap is meaningless there).
- API applies map them to the existing 422 `{"findings":[…]}` shape (`schedule.overlap` / `schedule.after-skip` / `schedule.tolerance`) — the SDK path is unchanged.
- **#1348**: project beats are now planned at load with the same call the API pre-apply runs. A refused beat leaves the live set and lands in a scan-replaced `ProjectRefusals` projection; `GET /v1/schedules/{id}` surfaces it as `origin: "project"` + the finding + ETag — a project beat with `décalage: hash` (or any refused policy) is never again a silently-dead schedule.
- **Pause expiry**: `tick::date_expired` extracted (behavior identical for arm-fire) and reused by the serve planner — a `pauseUntil` strictly before the decision date wakes the schedule; the bound's own date stays paused. A woke pause faces the same refusals as an active declaration.

## Discovered while red-testing

- API `overlap=replace`/`queue` previously died with a misleading **500 `schedule_store_corrupt`** (the store's own round-trip trips `afterSkip requires overlap=skip`). The typed 422 replaces that lie; the accept-then-noop half was the project path, which the load partition now refuses visibly.
- Premise correction on pause: arm-fire does **not** re-activate expired suspensions today (`tick_decision` checks `is_active()` first). Serve now wakes per the parse grammar's own teaching; the edges diverge intentionally — a follow-up to align arm-fire is flagged in the code.

## Evidence

- Red→green per finding: API 422-before-persistence, project load finding + never-fires, woke-pause fires (bound one stays paused), all refusal variants map to NIKA_017.
- `cargo test --lib`: nika-cadence 188 · nika-serve 160 · nika-arm 86 — all green. `clippy -D warnings` clean · `fmt` clean · zero unwrap.
- `changelog.d/` fragments per change.

⚠️ Note: this branch and `fix/arm-generation-and-budget` both touch `crates/nika-serve/src/server/scheduler.rs` — merge this one first; the other rebases cleanly (small import/`generation()` region conflict).

🦋 Co-Authored-By: Nika 🦋 <nika@supernovae.studio>
