### PR TITLE
fix(check): refuse uncataloged models instead of metering $0 silently (#1368)

### DIFF
--- a/changelog.d/1368.fixed.md
+++ b/changelog.d/1368.fixed.md
@@ -1,0 +1,14 @@
+- **An uncataloged model id no longer meters $0 past an armed budget.**
+  The `--max-cost-usd` admission walk judged only *priced-ness*, and its
+  unpriced-cloud arm spared any provider the catalog does not know — so a
+  workflow pinned to a bare or misspelled id (the gauntlet's
+  `claude-opus-4.1`, never a catalog row) floored at $0, passed any cap,
+  and ran with zero budget protection. The walk now judges every resolved
+  infer/agent id through the MODELS rung's own predicate
+  (`nika_providers::resolve_refusal`): an id this binary cannot resolve
+  refuses NIKA-1709 before the prologue, quoting the resolver's repair
+  (the `<provider>/<model>` contract · the pasteable catalog seat ·
+  `nika catalog`). Local seats (ollama & friends) and mock stay admitted
+  — free by construction, never by silence — and the priced-floor refusal
+  (`anthropic/claude-opus-4-1` at $0.057600 over a $0.02 cap) is
+  unchanged.

--- a/crates/nika-cli/src/main.rs
+++ b/crates/nika-cli/src/main.rs
@@ -525,8 +525,9 @@ struct RunArgs {
     /// stop (per-task values live in the trace). Spending EXACTLY the
     /// budget does not trip it. Costs use LIST RATES from the vendored
     /// public catalog — private/proxy/negotiated pricing is not
-    /// reflected; local · mock · unpriced work is never blocked (the
-    /// budget bounds what the catalog can meter).
+    /// reflected; local · mock work is never blocked (the budget bounds
+    /// what the catalog can meter — an unmeterable cloud seat under a cap
+    /// refuses, the UNCATALOGED bullet below).
     ///
     /// KNOW THREE LIMITS (the budget is a floor-refusal + between-admission
     /// meter, not a per-token cap):
@@ -538,9 +539,12 @@ struct RunArgs {
     ///     input/prompt tokens are not priced statically, so a huge
     ///     `max_tokens` safety ceiling can over-refuse, and an input-heavy
     ///     workflow under-floors (the ledger catches it at run time).
-    ///   · UNCATALOGED ≠ FREE — a model absent from the catalog meters as
-    ///     $0 (same as local/mock), so a genuinely PAID uncataloged model
-    ///     (custom endpoint · brand-new id) runs with no budget protection.
+    ///   · UNCATALOGED REFUSES — a statically known model the catalog cannot price (a
+    ///     typo · a brand-new id · a bare or unknown `<provider>/<model>` spelling · a
+    ///     cataloged vendor this binary cannot drive) refuses NIKA-1709 before any spend:
+    ///     the cap cannot bound a seat it cannot meter — an uncataloged id never meters
+    ///     $0 by silence under an armed cap. Local (ollama & friends) and mock seats stay
+    ///     admitted — free by construction, never by silence.
     #[arg(long = "max-cost-usd", value_name = "USD", value_parser = parse_budget_usd)]
     max_cost_usd: Option<f64>,
     /// Skip the opportunistic trace collection for this invocation

--- a/crates/nika-runtime/src/admit.rs
+++ b/crates/nika-runtime/src/admit.rs
@@ -66,6 +66,13 @@ pub(crate) fn gates(
 /// `model:` CEL is not on the static report. The internal `gates` path
 /// passes those bindings so the live id is judged here; this 4-arg form (the CLI
 /// preflight) still prices `--model` and the file.
+///
+/// #1368 · the unresolvable arm: a resolved id the ONE resolver
+/// (`nika_providers::resolve_refusal`) refuses — a bare id · an unknown
+/// prefix · a cataloged vendor this binary cannot drive — joins the
+/// unpriced cloud class here. Such an id floored at $0 and passed ANY
+/// budget (the gauntlet's `claude-opus-4.1`): an armed cap cannot
+/// bound a seat it cannot name.
 #[must_use]
 pub fn budget_floor_refusal(
     wf: &RawWorkflow,
@@ -84,7 +91,7 @@ fn budget_floor_at(
     overrides: &BTreeMap<String, Value>,
 ) -> Option<RuntimeError> {
     let budget = budget?;
-    if let Some(err) = unpriced_cloud_on_resolved_ids(wf, budget, model_override, overrides) {
+    if let Some(err) = unmeterable_seat_on_resolved_ids(wf, budget, model_override, overrides) {
         return Some(err);
     }
     let owned;
@@ -122,17 +129,64 @@ fn unpriced_cloud_cap_refusal(report: &CheckReport, budget: f64) -> Option<Runti
 /// CLI `--model`, envelope/task CEL that a `--var` or a declared
 /// default fills, the envelope literal — an unpriced cloud seat
 /// under a cap refuses even when `nika check` named a priced default.
-fn unpriced_cloud_on_resolved_ids(
+///
+/// #1368 · the stronger arm: an id the ONE resolver
+/// ([`nika_providers::resolve_refusal`] — the MODELS rung's own
+/// predicate, so check ≡ run by construction) REFUSES is not merely
+/// unpriced — an armed cap cannot bound a seat the binary cannot even
+/// name. That id used to skip BOTH arms below (`unpriced_cloud_seat`
+/// spares an unknown provider by construction), floor at $0, and pass
+/// ANY budget — the gauntlet's `claude-opus-4.1` dot variant ran with
+/// zero budget protection, dying at dispatch (or « succeeding » under
+/// `on_error: skip`) after the cap had silently disarmed.
+fn unmeterable_seat_on_resolved_ids(
     wf: &RawWorkflow,
     budget: f64,
     model_override: Option<&str>,
     overrides: &BTreeMap<String, Value>,
 ) -> Option<RuntimeError> {
-    let unpriced: Vec<String> = resolved_infer_models(wf, model_override, overrides)
-        .into_iter()
-        .filter(|model| unpriced_cloud_seat(model))
-        .collect();
-    unpriced_cloud_message(&unpriced, budget)
+    let mut unresolvable: Vec<(String, String)> = Vec::new();
+    let mut unpriced: Vec<String> = Vec::new();
+    for model in resolved_infer_models(wf, model_override, overrides) {
+        // The resolver's refusal is the stronger claim, judged first: a
+        // cataloged vendor this binary cannot drive (the azure class) is
+        // unresolvable HERE, not merely unpriced.
+        if let Some(refusal) = nika_providers::resolve_refusal(&model) {
+            unresolvable.push((model, refusal.why));
+        } else if unpriced_cloud_seat(&model) {
+            unpriced.push(model);
+        }
+    }
+    unresolvable_seat_message(&unresolvable, budget)
+        .or_else(|| unpriced_cloud_message(&unpriced, budget))
+}
+
+/// #1368 · the unresolvable arm's refusal: every seat with the resolver's
+/// own why verbatim (the `<provider>/<model>` contract · the pasteable
+/// repair · the did-you-mean — the MODELS rung's teaching, never a second
+/// phrasing), then the budget law and the two honest ways out (pin a
+/// catalog seat · drop the cap for a local/mock rehearsal).
+fn unresolvable_seat_message(
+    unresolvable: &[(String, String)],
+    budget: f64,
+) -> Option<RuntimeError> {
+    if unresolvable.is_empty() {
+        return None;
+    }
+    let models = unresolvable
+        .iter()
+        .map(|(model, why)| format!("`{model}` — {why}"))
+        .collect::<Vec<_>>()
+        .join(" · ");
+    Some(RuntimeError::BudgetFloor {
+        message: format!(
+            "refusing to start: model {models}. --max-cost-usd ${budget:.6} cannot bound \
+             a model this binary cannot resolve — an uncataloged id is not free, it is \
+             unmetered, and a budget it disarms is no budget. Pin a `<provider>/<model>` \
+             catalog seat (`nika catalog` lists the runnable providers under LOCAL and \
+             CLOUD), or drop the cap for a local/mock rehearsal.\n"
+        ),
+    })
 }
 
 fn unpriced_cloud_message(unpriced: &[String], budget: f64) -> Option<RuntimeError> {
@@ -240,7 +294,9 @@ fn with_alias(
 }
 
 /// A recognized third-party cloud seat with no snapshot row. Unknown
-/// providers stay unknown (never promoted to cloud). Mock and local
+/// providers stay unknown (never promoted to cloud — but NOT spared:
+/// the resolved-id walk's unresolvable arm refuses them under a cap
+/// through [`nika_providers::resolve_refusal`], #1368). Mock and local
 /// are the sparing arms — unpriced, never this class.
 pub(crate) fn unpriced_cloud_seat(model: &str) -> bool {
     if model == "mock" || model.starts_with("mock/") {

--- a/crates/nika-runtime/src/admit_resolved_tests.rs
+++ b/crates/nika-runtime/src/admit_resolved_tests.rs
@@ -307,3 +307,198 @@ fn cel_index_mock_plus_cap_still_admits() {
         "mock through the index form is still a proven zero"
     );
 }
+
+// ---------------------------------------------------------------------
+// Issue 1368 · the uncataloged-id budget hole. An id the ONE resolver
+// (`nika_providers::resolve_refusal` — the MODELS rung's own predicate)
+// refuses used to skip BOTH budget arms: `unpriced_cloud_seat` spares an
+// unknown provider by construction, so a bare/unknown id floored at $0
+// and ANY `--max-cost-usd` passed. The run then died at dispatch — after
+// earlier tasks may have spent — or, under `on_error: { skip: true }`,
+// « succeeded » with the cap silently disarmed.
+// ---------------------------------------------------------------------
+
+/// The gauntlet's exact shape (#1368): the DOT form `claude-opus-4.1` is
+/// not a catalog id (the catalog's row is the DASH `claude-opus-4-1`).
+fn gauntlet_wf(model: &str) -> String {
+    format!(
+        "nika: g1368\nmodel: \"{model}\"\npermits: {{}}\ntasks:\n  ping:\n    infer: {{ prompt: \"PONG\", max_tokens: 768 }}\n"
+    )
+}
+
+/// The issue's repro: `claude-opus-4.1` metered a $0.000000 floor, so a
+/// $0.02 cap passed and the run proceeded with zero budget protection.
+#[test]
+fn uncataloged_dot_variant_plus_cap_refuses_to_start() {
+    let wf = parse(&gauntlet_wf("claude-opus-4.1"));
+    let report = nika_check::check(&wf);
+    assert!(
+        report.is_clean(),
+        "the MODELS rung is a CLI ladder — the nika-check report stays clean"
+    );
+    let err = gates(&wf, &report, &BTreeMap::new(), Some(0.02), None, None, &[])
+        .expect_err("an uncataloged id must not pass an armed cap by metering $0");
+    assert_eq!(err.spec_code(), "NIKA-1709");
+    let msg = err.to_string();
+    assert!(msg.contains("claude-opus-4.1"), "names the seat");
+    assert!(
+        msg.contains("<provider>/<model>"),
+        "teaches the pin contract"
+    );
+    assert!(msg.contains("nika catalog"), "names the catalog");
+    assert!(msg.contains("0.020000"), "the armed cap rides");
+}
+
+/// The issue's « excellent behavior — keep it »: the cataloged seat
+/// spelling `anthropic/claude-opus-4-1` prices a $0.057600 floor (768
+/// output tokens × $75/M) that refuses the $0.02 cap — the floor arm,
+/// with its exact teaching text, unchanged.
+#[test]
+fn cataloged_prefixed_twin_keeps_the_1709_floor_refusal() {
+    let wf = parse(&gauntlet_wf("anthropic/claude-opus-4-1"));
+    let report = nika_check::check(&wf);
+    assert!(report.is_clean());
+    let err = gates(&wf, &report, &BTreeMap::new(), Some(0.02), None, None, &[])
+        .expect_err("the priced floor refuses the tiny cap");
+    assert_eq!(err.spec_code(), "NIKA-1709");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("unavoidable cost floor $0.057600"),
+        "the floor arm's own text, kept verbatim"
+    );
+}
+
+/// The bare DASH form is priced (the floor sees it) but never RESOLVES — a bare id is not
+/// `<provider>/<model>`. Under a generous cap the run used to start and die at dispatch;
+/// admission now refuses with the resolver's contract teaching (no unique pasteable
+/// seat exists for this id, so the generic form speaks).
+#[test]
+fn bare_cataloged_dash_under_a_generous_cap_refuses_at_admission() {
+    let wf = parse(&gauntlet_wf("claude-opus-4-1"));
+    let report = nika_check::check(&wf);
+    assert!(report.is_clean());
+    let err = gates(&wf, &report, &BTreeMap::new(), Some(1.00), None, None, &[])
+        .expect_err("a bare id — priced or not — cannot be bounded by a cap");
+    assert_eq!(err.spec_code(), "NIKA-1709");
+    let msg = err.to_string();
+    assert!(msg.contains("claude-opus-4-1"), "names the seat");
+    assert!(
+        msg.contains("bare model id"),
+        "the resolver's why rides verbatim"
+    );
+    assert!(msg.contains("<provider>/<model>"), "the contract is taught");
+}
+
+/// The spare arm that hid the hole: an UNKNOWN provider prefix stayed
+/// « unknown, never promoted to cloud » — floor $0, any cap passed.
+#[test]
+fn unknown_provider_prefix_plus_cap_refuses_to_start() {
+    let wf = parse(&gauntlet_wf("not-a-provider/gpt-4"));
+    let report = nika_check::check(&wf);
+    let err = gates(&wf, &report, &BTreeMap::new(), Some(0.02), None, None, &[])
+        .expect_err("an unresolvable prefix must not pass an armed cap");
+    assert_eq!(err.spec_code(), "NIKA-1709");
+    let msg = err.to_string();
+    assert!(msg.contains("not-a-provider"), "names the prefix");
+    assert!(msg.contains("does not resolve"), "the resolver names why");
+}
+
+/// The task-level pin is judged the same as the envelope pin.
+#[test]
+fn task_level_dot_variant_plus_cap_refuses_to_start() {
+    let wf = parse(
+        "nika: g1368-task\nmodel: mock/echo\npermits: {}\ntasks:\n  ping:\n    infer: { prompt: \"PONG\", max_tokens: 768, model: \"claude-opus-4.1\" }\n",
+    );
+    let report = nika_check::check(&wf);
+    assert!(report.is_clean());
+    let err = gates(&wf, &report, &BTreeMap::new(), Some(0.02), None, None, &[])
+        .expect_err("the task-pinned dot variant refuses too");
+    assert_eq!(err.spec_code(), "NIKA-1709");
+    assert!(err.to_string().contains("claude-opus-4.1"));
+}
+
+/// The `--var`-resolved form (W0-D-R1's walk): the live id is judged.
+#[test]
+fn var_resolved_dot_variant_plus_cap_refuses_to_start() {
+    let wf = parse(&runtime_model_input_wf());
+    let report = nika_check::check(&wf);
+    let overrides = BTreeMap::from([(
+        "model".to_owned(),
+        Value::String("claude-opus-4.1".to_owned()),
+    )]);
+    let err = gates(&wf, &report, &overrides, Some(0.02), None, None, &[])
+        .expect_err("a var-resolved dot variant refuses under a cap");
+    assert_eq!(err.spec_code(), "NIKA-1709");
+    assert!(err.to_string().contains("claude-opus-4.1"));
+}
+
+/// The CLI `--model` override is the live id the gate prices (#342) —
+/// overriding INTO an uncataloged id refuses the same way.
+#[test]
+fn cli_model_override_to_a_dot_variant_refuses() {
+    let wf = parse(&gauntlet_wf("mock/echo"));
+    let report = nika_check::check(&wf);
+    let err = gates(
+        &wf,
+        &report,
+        &BTreeMap::new(),
+        Some(0.02),
+        Some("claude-opus-4.1"),
+        None,
+        &[],
+    )
+    .expect_err("the override is the run's real seat");
+    assert_eq!(err.spec_code(), "NIKA-1709");
+    assert!(err.to_string().contains("claude-opus-4.1"));
+}
+
+/// The sparing arms that MUST keep working (#1368's explicit constraint):
+/// local/self-hosted seats (the catalog's five loopback providers) and
+/// the mock are free by CONSTRUCTION, never by silence — a cap admits
+/// them, as today.
+#[test]
+fn local_and_mock_seats_still_admit_under_a_cap() {
+    for model in [
+        "mock/echo",
+        "ollama/qwen3.5:4b",
+        "lmstudio/anything-pulled",
+        "llamacpp/anything-pulled",
+        "localai/anything-pulled",
+        "vllm/anything-pulled",
+    ] {
+        let wf = parse(&gauntlet_wf(model));
+        let report = nika_check::check(&wf);
+        assert!(
+            gates(&wf, &report, &BTreeMap::new(), Some(0.02), None, None, &[]).is_ok(),
+            "{model} is free by construction — a cap must keep admitting it"
+        );
+    }
+}
+
+/// The honest boundary of the fix: with NO cap armed the admission gate
+/// makes no budget claim — the FORM law (NIKA-PROVIDER) still speaks
+/// loud at dispatch, per task, and the run fails there as today. What
+/// changed is that an ARMED cap can no longer be disarmed by an
+/// uncataloged id.
+#[test]
+fn without_a_cap_the_gate_makes_no_budget_claim() {
+    let wf = parse(&gauntlet_wf("claude-opus-4.1"));
+    let report = nika_check::check(&wf);
+    assert!(
+        gates(&wf, &report, &BTreeMap::new(), None, None, None, &[]).is_ok(),
+        "no budget armed → no budget-floor claim (dispatch owns the FORM refusal)"
+    );
+}
+
+/// The run-level pin: the refusal precedes the prologue — zero events,
+/// zero spend (the `run_refused` helper asserts the empty sink).
+#[tokio::test]
+async fn dot_variant_under_cap_refuses_before_the_prologue() {
+    let wf = parse(&gauntlet_wf("claude-opus-4.1"));
+    let runtime = runtime_with(MockShell::new()).with_max_cost_usd(Some(0.02));
+    let err = run_refused(&runtime, &wf).await;
+    assert_eq!(err.spec_code(), "NIKA-1709");
+    let msg = err.to_string();
+    assert!(msg.contains("claude-opus-4.1"), "names the seat");
+    assert!(msg.contains("nika catalog"), "names the catalog");
+}


### PR DESCRIPTION
## Evidence (#1368)

Engine 0.116.2, multi-tenant budget gauntlet: a workflow pinned to `claude-opus-4.1` (the DOT form — never a catalog row; the catalog's row is the DASH `claude-opus-4-1`) computed a static cost floor of **$0.000000**, so **any `--max-cost-usd` passed** and the run proceeded with zero budget protection — dying at dispatch (`NIKA-INFER-001: must be 'provider/name'`), or « succeeding » under `on_error: { skip: true }` with the cap silently disarmed.

Root cause: the `--max-cost-usd` admission walk (`nika-runtime::admit`) judged only *priced-ness*. Its unpriced-cloud arm (B20 / #1297) deliberately spares any provider the catalog does not know (« unknown stays unknown, never promoted to cloud ») — and a bare or misspelled id fell exactly through that arm: floor $0, cap disarmed by silence.

Reproduced on `main` before the fix — 7 new gate tests red with `Ok(())` where a refusal is required — and with the CLI:

```text
$ nika run dot.nika.yaml --max-cost-usd 0.02          # BEFORE
⚠ --max-cost-usd 0.02: 1 task(s) have no static ceiling (1 on an unpriced model) …
  X NIKA-INFER-001 · model `claude-opus-4.1` failed to resolve … · 1 failed · $0.00
exit=1                                                # the cap never spoke
```

## The law

**An armed cap refuses any resolved infer/agent model id this binary cannot resolve — NIKA-1709, before the prologue (zero events · zero spend).** The admission walk now judges every resolved id (`--model` override · `--var`-resolved CEL · envelope/task literal) through the MODELS rung's own predicate, `nika_providers::resolve_refusal` — check ≡ run by construction, one predicate, never a second phrasing. The refusal quotes the resolver's repair verbatim (the `<provider>/<model>` contract · `nika catalog` · the did-you-mean), then the budget law and the two honest outs (pin a catalog seat · drop the cap for a local/mock rehearsal):

```text
$ nika run dot.nika.yaml --max-cost-usd 0.02          # AFTER
NIKA-1709 · refusing to start: model `claude-opus-4.1` — `claude-opus-4.1` is a bare model id —
the contract is `<provider>/<model>` (pick the provider that serves it; `nika catalog` names the
16 runnable providers under LOCAL and CLOUD). --max-cost-usd $0.020000 cannot bound a model this
binary cannot resolve — an uncataloged id is not free, it is unmetered, and a budget it disarms
is no budget. Pin a `<provider>/<model>` catalog seat (`nika catalog` lists the runnable
providers under LOCAL and CLOUD), or drop the cap for a local/mock rehearsal.
exit=2                                                # before the prologue: no trace, no spend
```

Refuse-over-conservative-pricing: inventing a price for an unknown id would meter a lie (the `find_pricing` contains-fallback already documents that trade-off); the honest static claim is a refusal that teaches the pin.

## What stays working

- **The issue's « excellent behavior » is kept verbatim** — `anthropic/claude-opus-4-1` under a $0.02 cap still refuses with the floor arm's exact text: `the workflow's unavoidable cost floor $0.057600 exceeds --max-cost-usd $0.020000 …` (pinned by test).
- **Local/self-hosted seats** (`ollama/*` · `lmstudio/*` · `llamacpp/*` · `localai/*` · `vllm/*`) and `mock/*` stay admitted under a cap — free by construction, never by silence. Pinned for all five local providers, and live-verified against a running ollama: admission passed, the task ran 6.3s and failed on its own merits (`NIKA-INFER-004`), never on the budget gate.
- **The custom-endpoint escape** (`NIKA_<ID>_BASE_URL` → an OpenAI-compatible local behind a known provider id) keeps the B20 posture: a *resolvable* provider with a catalog-unknown model under a cap refuses as « unpriced cloud » (pre-existing #1297 behavior — its tests still pin the exact message); without a cap it runs, as today.
- **No-cap posture unchanged**: with no budget armed, the FORM law (`NIKA-PROVIDER`) still speaks loud at dispatch, per task — the admission gate makes no budget claim it cannot cover.

One deliberate message-level change: a *bare but priced* id (`claude-opus-4-1`, no provider) under a cap that covers its floor used to start and die at dispatch; it now refuses at admission (still NIKA-1709) with the `<provider>/<model>` contract teaching — the NIKA-1708 « refuse before the prologue what would fail loud mid-run » precedent. The over-floor refusal the issue exhibits is byte-identical.

## Test proof

- TDD: 10 new pins in `crates/nika-runtime/src/admit_resolved_tests.rs` — 7 red on `main` for exactly the issue's class (dot variant · unknown prefix · task-level pin · `--var`-resolved · `--model` override · bare-priced-dash · before-the-prologue sink-empty), 3 keep-behavior pins green throughout (floor refusal verbatim · local+mock admitted under cap · no-cap posture).
- `cargo test -p nika-runtime --lib` — 331/331 ✔ · `cargo test -p nika-cli --lib` — 335/335 ✔
- `cargo clippy -p nika-runtime -p nika-cli --all-targets -- -D warnings` — clean · `cargo fmt --check` — clean
- CLI repro before/after quoted above (dot+cap refuses NIKA-1709 · prefixed-cataloged keeps the $0.057600 floor refusal · ollama+cap passes admission · dot-no-cap unchanged dispatch failure).
- No public-API change (private fns + rustdoc only; `public-api.txt` snapshots untouched).

Closes #1368.
