### PR TITLE
fix(release): the assets barrier runs comm under the C locale

### DIFF
--- a/scripts/release/release-assets-barrier.sh
+++ b/scripts/release/release-assets-barrier.sh
@@ -87,7 +87,7 @@ validate_inventory() {
     return 73
   fi
   local extras
-  extras="$(comm -13 "$scratch/expected" "$remote_manifest")"
+  extras="$(LC_ALL=C comm -13 "$scratch/expected" "$remote_manifest")"
   if [ -n "$extras" ]; then
     echo "release assets: REFUSED extra public assets:" >&2
     printf '%s\n' "$extras" >&2


### PR DESCRIPTION
The barrier sorts both manifests with `LC_ALL=C` and then compares them with `comm` under the ambient locale. On macOS the two collations disagree, so a correctly sorted expected list reads as unsorted and a legitimate asset is refused as extra (the self-test's `nika-macos-arm64-9.9.9.tar.gz` case). Every push from a macOS clone failed hygiene vector 49 on this false refusal: the trunk's pre-push gate was red for everyone here.

`comm` now runs under the same locale as the sorts. `scripts/release/tests/release-tooling.test.sh` passes and vector 49 is green again on macOS.

Closes #1379.