### PR TITLE
fix(trace): verify states an unsealed journal and can require the seal

### DIFF
--- a/changelog.d/1384.fixed.md
+++ b/changelog.d/1384.fixed.md
@@ -1,0 +1,7 @@
+- **`nika trace verify` states an UNSEALED journal and can require the seal.**
+  A journal whose `run_sealed` line was cut used to verify « OK · chain intact »
+  with the SEALED line simply gone and the same exit as a clean run. The ladder
+  now prints `UNSEALED — no run_sealed frame …` naming the three honest causes
+  (a keyless run, a run killed before its seal, a journal cut after it), and
+  `--sealed` makes a missing seal the same exit-3 refusal `--anchored` gives a
+  missing sidecar, so CI can demand the signed tier.

--- a/crates/nika-dap/public-api.txt
+++ b/crates/nika-dap/public-api.txt
@@ -697,7 +697,7 @@ impl<T> tracing::instrument::WithSubscriber for nika_dap::anchor::tier::TierRepo
 impl<T> typenum::type_operators::Same for nika_dap::anchor::tier::TierReport
 pub type nika_dap::anchor::tier::TierReport::Output = T
 pub fn nika_dap::anchor::tier::anchor_tier(trace: &str, head32: core::option::Option<[u8; 32]>, seal: &nika_dap::anchor::tier::SealVerdict, required: bool) -> nika_dap::anchor::tier::AnchorTier
-pub fn nika_dap::anchor::tier::evaluate(trace: &str, raw: &str, events: usize, head: &str, require_anchor: bool, replay: core::option::Option<&nika_dap::anchor::tier::ReplayCompare>, candidates: &[(alloc::string::String, alloc::string::String)]) -> nika_dap::anchor::tier::TierReport
+pub fn nika_dap::anchor::tier::evaluate(trace: &str, raw: &str, events: usize, head: &str, require_anchor: bool, require_seal: bool, replay: core::option::Option<&nika_dap::anchor::tier::ReplayCompare>, candidates: &[(alloc::string::String, alloc::string::String)]) -> nika_dap::anchor::tier::TierReport
 pub fn nika_dap::anchor::tier::last_complete_line(raw: &str, events: usize) -> core::option::Option<serde_json::value::Value>
 pub fn nika_dap::anchor::tier::seal_tier(line: core::option::Option<&serde_json::value::Value>, events: usize, candidates: &[(alloc::string::String, alloc::string::String)]) -> nika_dap::anchor::tier::SealTier
 #[non_exhaustive] pub enum nika_dap::anchor::HeadRefusal

--- a/crates/nika-dap/src/anchor/tier.rs
+++ b/crates/nika-dap/src/anchor/tier.rs
@@ -306,6 +306,7 @@ mod tests {
             2,
             &"0".repeat(64),
             true, // --anchored
+            false,
             None,
             &[],
         );
@@ -325,11 +326,18 @@ mod tests {
             2,
             &"0".repeat(64),
             false,
+            false,
             None,
             &[],
         );
         assert_eq!(report.exit, TierExit::Ok);
-        assert!(report.lines.is_empty());
+        // nika#1384 · quiet no more: the absent seal names itself.
+        assert_eq!(report.lines.len(), 1, "{:?}", report.lines);
+        assert!(
+            report.lines[0].starts_with("UNSEALED"),
+            "{:?}",
+            report.lines
+        );
     }
 
     /// A chained journal sealed with the given key — the seal line is
@@ -425,6 +433,7 @@ mod tests {
             3,
             &"0".repeat(64),
             false,
+            false,
             None,
             &candidates,
         );
@@ -452,6 +461,7 @@ mod tests {
             &forged,
             4,
             &"0".repeat(64),
+            false,
             false,
             None,
             &candidates,
@@ -495,6 +505,7 @@ mod tests {
             &torn,
             3,
             &"0".repeat(64),
+            false,
             false,
             None,
             &candidates,
@@ -690,6 +701,7 @@ pub fn evaluate(
     events: usize,
     head: &str,
     require_anchor: bool,
+    require_seal: bool,
     replay: Option<&ReplayCompare>,
     candidates: &[(String, String)],
 ) -> TierReport {
@@ -718,7 +730,7 @@ pub fn evaluate(
         );
     }
     let seal = seal_tier(last_complete_line(raw, events).as_ref(), events, candidates);
-    let verdict = match seal_leg(&seal, require_anchor, &mut lines) {
+    let verdict = match seal_leg(&seal, require_anchor, require_seal, &mut lines) {
         Ok(verdict) => verdict,
         Err((anchor, exit)) => return terminal_seal_report(seal, anchor, exit, lines),
     };
@@ -799,6 +811,7 @@ fn terminal_seal_report(
 fn seal_leg(
     seal: &SealTier,
     require_anchor: bool,
+    require_seal: bool,
     lines: &mut Vec<String>,
 ) -> Result<SealVerdict, (AnchorTier, TierExit)> {
     match seal {
@@ -810,6 +823,30 @@ fn seal_leg(
             Ok(v.clone())
         }
         SealTier::Unsealed => {
+            // nika#1384 · the seal tier's absence is STATED, never silent.
+            // Measured on 0.116.2: a journal with its run_sealed line cut
+            // verified « OK · chain intact » with the SEALED line simply
+            // gone and the same exit as a clean run — the cheapest edit a
+            // trace can suffer left no mark. The line names the three
+            // honest causes; the exit stays Ok (the journal is what it is)
+            // unless the operator REQUIRED the tier, which is the ENV
+            // class `--anchored` already answers for a missing sidecar.
+            if require_seal {
+                lines.push(
+                    "SEALED — REQUIRED but the journal is unsealed (no run_sealed \
+                     line): a keyless run, a run killed before its seal, or a \
+                     journal cut after it — a missing seal is a missing input"
+                        .to_owned(),
+                );
+            } else {
+                lines.push(
+                    "UNSEALED — no run_sealed frame: the run was not signed (no \
+                     signing key at run time · a run killed before its seal · or a \
+                     journal cut after it) — `nika sign` seals future runs · \
+                     `--sealed` requires the tier"
+                        .to_owned(),
+                );
+            }
             // The 2026-07-29 audit (run 2 · the anchor contract's silent
             // arm): this return used to swallow `require_anchor` —
             // `--anchored` on an UNSEALED journal exited Ok without a word
@@ -827,6 +864,9 @@ fn seal_leg(
                         .to_owned(),
                 );
                 return Err((AnchorTier::Required, TierExit::Env));
+            }
+            if require_seal {
+                return Err((AnchorTier::NotPresent, TierExit::Env));
             }
             Err((AnchorTier::NotPresent, TierExit::Ok))
         }

--- a/crates/nika-trace/public-api.txt
+++ b/crates/nika-trace/public-api.txt
@@ -781,6 +781,7 @@ pub struct nika_trace::trace_verify::VerifyOptions
 pub nika_trace::trace_verify::VerifyOptions::anchored: bool
 pub nika_trace::trace_verify::VerifyOptions::key: core::option::Option<std::path::PathBuf>
 pub nika_trace::trace_verify::VerifyOptions::replay: core::option::Option<std::path::PathBuf>
+pub nika_trace::trace_verify::VerifyOptions::sealed: bool
 impl core::clone::Clone for nika_trace::trace_verify::VerifyOptions
 pub fn nika_trace::trace_verify::VerifyOptions::clone(&self) -> nika_trace::trace_verify::VerifyOptions
 impl core::default::Default for nika_trace::trace_verify::VerifyOptions

--- a/crates/nika-trace/public-api.txt
+++ b/crates/nika-trace/public-api.txt
@@ -518,6 +518,7 @@ pub nika_trace::trace::action::TraceAction::Verify
 pub nika_trace::trace::action::TraceAction::Verify::anchored: bool
 pub nika_trace::trace::action::TraceAction::Verify::key: core::option::Option<std::path::PathBuf>
 pub nika_trace::trace::action::TraceAction::Verify::replay: core::option::Option<std::path::PathBuf>
+pub nika_trace::trace::action::TraceAction::Verify::sealed: bool
 pub nika_trace::trace::action::TraceAction::Verify::traces: alloc::vec::Vec<std::path::PathBuf>
 impl clap_builder::derive::FromArgMatches for nika_trace::trace::action::TraceAction
 pub fn nika_trace::trace::action::TraceAction::from_arg_matches(__clap_arg_matches: &clap_builder::parser::matches::arg_matches::ArgMatches) -> core::result::Result<Self, clap_builder::Error>
@@ -689,6 +690,7 @@ pub nika_trace::trace::TraceAction::Verify
 pub nika_trace::trace::TraceAction::Verify::anchored: bool
 pub nika_trace::trace::TraceAction::Verify::key: core::option::Option<std::path::PathBuf>
 pub nika_trace::trace::TraceAction::Verify::replay: core::option::Option<std::path::PathBuf>
+pub nika_trace::trace::TraceAction::Verify::sealed: bool
 pub nika_trace::trace::TraceAction::Verify::traces: alloc::vec::Vec<std::path::PathBuf>
 impl clap_builder::derive::FromArgMatches for nika_trace::trace::action::TraceAction
 pub fn nika_trace::trace::action::TraceAction::from_arg_matches(__clap_arg_matches: &clap_builder::parser::matches::arg_matches::ArgMatches) -> core::result::Result<Self, clap_builder::Error>

--- a/crates/nika-trace/src/dispatch.rs
+++ b/crates/nika-trace/src/dispatch.rs
@@ -106,12 +106,14 @@ pub fn trace_verb(
             traces,
             key,
             anchored,
+            sealed,
             replay,
         } => verify_verb(
             traces,
             &trace_verify::VerifyOptions {
                 key,
                 anchored,
+                sealed,
                 replay,
             },
         ),

--- a/crates/nika-trace/src/trace/action.rs
+++ b/crates/nika-trace/src/trace/action.rs
@@ -101,6 +101,10 @@ pub enum TraceAction {
         /// forged one is exit 2 either way).
         #[arg(long)]
         anchored: bool,
+        /// Require the seal tier: an UNSEALED journal (no `run_sealed`
+        /// line) is exit 3 (a forged seal is exit 2 either way).
+        #[arg(long)]
+        sealed: bool,
         /// The REPLAYED tier: a FRESH journal of the same workflow to
         /// compare against (verify never re-executes).
         #[arg(long)]

--- a/crates/nika-trace/src/trace_verify.rs
+++ b/crates/nika-trace/src/trace_verify.rs
@@ -20,6 +20,13 @@
 //!   `~/.nika/keys/run-signing.pub` · the `retired.pub` ledger),
 //!   matched by the seal's `key_id` fingerprint. A re-written journal
 //!   now needs the key, not just write access.
+//! - **UNSEALED** — the chain is intact but the journal carries no
+//!   `run_sealed` frame (a keyless run · a run killed before its seal
+//!   · a journal cut after it): stated on its own line, never silent
+//!   (nika#1384 · a cut seal used to leave no mark). The exit stays OK
+//!   (the journal is honestly what it is) unless `--sealed` requires
+//!   the tier — then the missing seal is the ENV failure the operator
+//!   asked for, exactly like `--anchored` with no sidecar.
 //! - **ANCHORED** — SEALED, plus the detached `<trace>.anchor.json`
 //!   sidecar verifies fully OFFLINE: the recomputed head is the one
 //!   the Rekor v2 entry binds (digest + Ed25519ph signature with the
@@ -45,7 +52,8 @@
 //! Exit codes (the house taxonomy): 0 = the reported tier holds ·
 //! 2 (FILE) = broken chain · forged seal · forged anchor · replay
 //! divergence · 3 (ENV) = unchained (a pre-chain journal — stated,
-//! never guessed) · missing input · `--anchored` with no sidecar.
+//! never guessed) · missing input · `--anchored` with no sidecar ·
+//! `--sealed` with no seal.
 
 use std::path::PathBuf;
 
@@ -62,6 +70,10 @@ pub struct VerifyOptions {
     /// Require the anchor tier: a MISSING sidecar becomes the ENV
     /// failure the operator asked for (a broken one is FILE anyway).
     pub anchored: bool,
+    /// Require the seal tier: an UNSEALED journal (no `run_sealed`
+    /// line) becomes the ENV failure the operator asked for — a
+    /// missing seal is a missing input (a forged one is FILE anyway).
+    pub sealed: bool,
     /// A fresh journal of the same workflow for the REPLAYED tier.
     pub replay: Option<PathBuf>,
 }
@@ -268,6 +280,7 @@ fn tiered(
         events,
         head,
         opts.anchored,
+        opts.sealed,
         compared.as_ref(),
         candidates,
     );
@@ -846,6 +859,7 @@ mod tests {
         let opts = VerifyOptions {
             key: Some(key.clone()),
             anchored: true,
+            sealed: false,
             replay: None,
         };
         let out = verify_with(&trace.to_string_lossy(), &opts);
@@ -867,6 +881,7 @@ mod tests {
         let opts = VerifyOptions {
             key: None,
             anchored: true,
+            sealed: false,
             replay: None,
         };
         let out = verify_with(&trace.to_string_lossy(), &opts);
@@ -889,6 +904,7 @@ mod tests {
         let opts = VerifyOptions {
             key: Some(key),
             anchored: false,
+            sealed: false,
             replay: Some(trace.clone()),
         };
         let out = verify_with(&trace.to_string_lossy(), &opts);
@@ -1187,5 +1203,63 @@ mod tests {
             out.text
         );
         assert!(out.text.contains("DIVERGES"), "{}", out.text);
+    }
+
+    /// nika#1384 · an UNSEALED journal names itself. Measured on
+    /// 0.116.2: a journal with its `run_sealed` line cut verified
+    /// « OK · chain intact » with the SEALED line simply gone and the
+    /// same exit as a clean run — the cheapest edit a trace can suffer
+    /// left no mark. The line states the tier; the exit stays OK.
+    #[test]
+    fn an_unsealed_journal_names_itself_and_stays_ok() {
+        let journal = chained_with(&[("workflow_completed", &[])]);
+        let trace = stage("unsealed-named.ndjson", &journal);
+        let out = verify_with(&trace.to_string_lossy(), &VerifyOptions::default());
+        assert_eq!(out.code, super::super::exit::OK, "{}", out.text);
+        assert!(out.text.contains("UNSEALED"), "{}", out.text);
+        assert!(out.text.contains("--sealed"), "{}", out.text);
+        let _ = std::fs::remove_file(trace);
+    }
+
+    /// `--sealed` on an unsealed journal is the ENV refusal `--anchored`
+    /// already gives for a missing sidecar: a required tier that cannot
+    /// be attained, named out loud.
+    #[test]
+    fn a_required_seal_on_an_unsealed_journal_is_env() {
+        let journal = chained_with(&[("workflow_completed", &[])]);
+        let trace = stage("unsealed-seal-required.ndjson", &journal);
+        let opts = VerifyOptions {
+            key: None,
+            anchored: false,
+            sealed: true,
+            replay: None,
+        };
+        let out = verify_with(&trace.to_string_lossy(), &opts);
+        assert_eq!(out.code, super::super::exit::ENV, "{}", out.text);
+        assert!(out.text.contains("REQUIRED"), "{}", out.text);
+        assert!(out.text.contains("unsealed"), "{}", out.text);
+        let _ = std::fs::remove_file(trace);
+    }
+
+    /// `--sealed` on a sealed journal changes nothing: the tier holds,
+    /// and the UNSEALED statement never appears beside a SEALED one.
+    #[test]
+    fn a_required_seal_on_a_sealed_journal_holds() {
+        let (pk_box, sk) = keypair();
+        let journal = sealed_journal(&["workflow_started"], &sk, &pk_box);
+        let trace = stage("sealed-required.ndjson", &journal);
+        let key = stage_key("sealed-required.pub", &pk_box);
+        let opts = VerifyOptions {
+            key: Some(key.clone()),
+            anchored: false,
+            sealed: true,
+            replay: None,
+        };
+        let out = verify_with(&trace.to_string_lossy(), &opts);
+        assert_eq!(out.code, super::super::exit::OK, "{}", out.text);
+        assert!(out.text.contains("SEALED —"), "{}", out.text);
+        assert!(!out.text.contains("UNSEALED"), "{}", out.text);
+        let _ = std::fs::remove_file(trace);
+        let _ = std::fs::remove_file(key);
     }
 }


### PR DESCRIPTION
A journal whose `run_sealed` line was cut verified `OK — chain intact` with the SEALED line simply gone and the same exit as a clean run (#1384): the cheapest edit a trace can suffer left no mark.

- The ladder now prints `UNSEALED — no run_sealed frame …` naming the three honest causes (a keyless run · a run killed before its seal · a journal cut after it); the exit stays 0, the journal is honestly what it is.
- `--sealed` makes a missing seal the same exit-3 refusal `--anchored` gives a missing sidecar, so CI can demand the signed tier. `--sealed --anchored` voices both requirements.
- Both public API locks follow (`VerifyOptions::sealed` · `TraceAction::Verify::sealed` · `evaluate(…, require_seal, …)`); the dap ladder test that asserted silence now asserts the statement; three verify-level tests pin the three cases.

Same change as #1389 on signed single commits atop the green trunk (the DCO check refused #1389's unsigned merge commit; nothing was force-pushed).

Closes #1384.