### PR TITLE
test(pack): the canon's extract modes are the checker's closed set

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4800,6 +4800,7 @@ version = "0.116.2"
 dependencies = [
  "include_dir",
  "nika-catalog",
+ "nika-types",
  "serde_yaml_bw",
  "sha2 0.10.9",
 ]

--- a/crates/nika-cap/src/shape_tests.rs
+++ b/crates/nika-cap/src/shape_tests.rs
@@ -357,10 +357,18 @@ fn fetch_default_mode_is_markdown_and_pairs_with_nothing() {
 
 #[test]
 fn fetch_mode_is_a_closed_string_set() {
-    for mode in [
-        "markdown", "article", "text", "metadata", "links", "feed", "sitemap", "raw",
-    ] {
-        silent("nika:fetch", &json!({"url": "u", "mode": mode}));
+    // The closed set itself, never a hand-typed mirror of it (nika#1386 ·
+    // a mirror is green on the day it is typed and blind the day after).
+    for mode in nika_types::ExtractMode::ALL {
+        // `selector` and `jq` pair with their expression argument; the
+        // other modes pair with nothing.
+        let mut args = json!({"url": "u", "mode": mode.as_str()});
+        match mode {
+            nika_types::ExtractMode::Selector => args["selector"] = json!("h1"),
+            nika_types::ExtractMode::Jq => args["jq"] = json!("."),
+            _ => {}
+        }
+        silent("nika:fetch", &args);
     }
     let out = only("nika:fetch", &json!({"url": "u", "mode": "markdwon"}));
     assert!(out.contains("is not a stdlib v0.1 extract mode"), "{out}");

--- a/crates/nika-pack/Cargo.toml
+++ b/crates/nika-pack/Cargo.toml
@@ -16,6 +16,7 @@ include_dir = { workspace = true }
 [dev-dependencies]
 sha2          = { workspace = true }
 nika-catalog  = { path = "../nika-catalog", version = "0.116.2" }  # spec_parity — the vendored canon's 17 must resolve in the shipped catalog
+nika-types    = { path = "../nika-types", version = "0.116.2" }    # spec_parity — the vendored canon's extract modes ARE the checker's closed set
 serde_yaml_bw = { workspace = true }
 
 [lints]

--- a/crates/nika-pack/tests/spec_parity.rs
+++ b/crates/nika-pack/tests/spec_parity.rs
@@ -134,3 +134,60 @@ fn canon_templates_equal_the_embedded_surface() {
          embedded-not-declared {extra:?} (run scripts/sync-pack.sh <spec>)"
     );
 }
+
+/// Parse `extract_modes.{count,items}` out of the vendored canon.yaml.
+fn canon_extract_modes() -> (u64, Vec<String>) {
+    let canon: serde_yaml_bw::Value =
+        serde_yaml_bw::from_str(nika_pack::canon()).expect("vendored canon.yaml parses");
+    let modes = canon
+        .get("extract_modes")
+        .expect("canon.yaml carries an extract_modes section");
+    let count = modes
+        .get("count")
+        .and_then(serde_yaml_bw::Value::as_u64)
+        .expect("extract_modes.count is an integer");
+    let items = modes
+        .get("items")
+        .and_then(serde_yaml_bw::Value::as_sequence)
+        .expect("extract_modes.items is a list");
+    let names = items
+        .iter()
+        .map(|v| {
+            v.as_str()
+                .expect("every extract mode is a string")
+                .to_owned()
+        })
+        .collect();
+    (count, names)
+}
+
+/// The projection (`nika spec --canon` prints the vendored canon) and the
+/// judge (`nika check` refuses a `mode:` outside `ExtractMode::ALL`) MUST
+/// hold the same closed set. The released 0.116.2 printed 9 while its
+/// checker accepted 10 (`raw`) — supernovae-st/nika#1386. Equality, in
+/// both directions: a mode the checker knows and the canon does not is a
+/// projection lag; a mode the canon names and the checker refuses is a
+/// spec the binary does not speak.
+#[test]
+fn canon_extract_modes_are_the_checkers_closed_set() {
+    let (count, names) = canon_extract_modes();
+    let canon: BTreeSet<&str> = names.iter().map(String::as_str).collect();
+    assert_eq!(
+        canon.len(),
+        names.len(),
+        "an extract mode appears twice in canon.yaml"
+    );
+    assert_eq!(
+        count,
+        names.len() as u64,
+        "extract_modes.count disagrees with its own list"
+    );
+    let checker: BTreeSet<&str> = nika_types::ExtractMode::ALL
+        .iter()
+        .map(|m| m.as_str())
+        .collect();
+    assert_eq!(
+        canon, checker,
+        "canon.yaml extract_modes and ExtractMode::ALL diverge — the projection and the judge must hold one list"
+    );
+}


### PR DESCRIPTION
The released 0.116.2 printed nine extract modes from `spec --canon` while its checker accepted ten (`raw`). The vendored canon on main already carries the tenth (07d28b14), but nothing held the projection and the judge to one list.

- `spec_parity` diffs `canon.yaml` `extract_modes` against `ExtractMode::ALL` in both directions (a projection lag and an unspoken spec both fail).
- The cap shape test iterates the closed set instead of a hand-typed mirror of it, pairing `selector` and `jq` with their expression argument.
- `nika-pack` gains `nika-types` as a dev-dependency (test-only, L0 data against L0 types).

Signed single commit on the green trunk.

Closes #1386.