### PR TITLE
fix(thread): a /run inside the conversation leaves its journal

### DIFF
--- a/changelog.d/1385.fixed.md
+++ b/changelog.d/1385.fixed.md
@@ -1,0 +1,5 @@
+- **`nika thread` `/run` leaves its journal.** A workflow run from inside the
+  conversation now writes its hash-chained trace under `.nika/traces/` and
+  prints the trace line, exactly like `nika run`; the thread used to strip the
+  accountability layer (no trace, no cost line, no seal). Staged conversational
+  turns stay journal-less.

--- a/crates/nika-cli/src/verbs/run/mod.rs
+++ b/crates/nika-cli/src/verbs/run/mod.rs
@@ -1182,7 +1182,11 @@ fn fold_lane_verdict(
     let teardown = attended_facts(wf, report, outcome, trace.path());
     let trace_path = match surfaced_trace(surface_trace(
         trace,
-        if matches!(mode, RenderMode::Quiet | RenderMode::Thread) {
+        // The thread prints the trace note too (nika#1385): a `/run`
+        // inside the conversation is a real run, and its journal line is
+        // the accountability the human can act on. A journal-less turn
+        // surfaces no path, so nothing is claimed.
+        if matches!(mode, RenderMode::Quiet) {
             TraceNote::Silent
         } else {
             TraceNote::Stdout

--- a/crates/nika-cli/src/verbs/run/tests.rs
+++ b/crates/nika-cli/src/verbs/run/tests.rs
@@ -670,3 +670,39 @@ fn mock_model_with_harness_pin_refuses_before_a_live_seat() {
         "mock/echo must refuse before any harness backend can be seated"
     );
 }
+
+/// nika#1385 · a `/run <path>` inside the thread is a real run: it leaves
+/// its hash-chained journal under `.nika/traces/` exactly like `nika run`;
+/// a staged conversational turn (journal = false) leaves none. The cwd is
+/// leased (process-global) so the journal lands in a scratch dir.
+#[test]
+fn a_thread_run_journals_when_asked_and_a_turn_does_not() {
+    let scratch = std::env::temp_dir().join(format!("nika-thread-journal-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&scratch);
+    std::fs::create_dir_all(&scratch).expect("scratch dir");
+    std::fs::write(
+        scratch.join("hello.nika.yaml"),
+        "nika: hello\nmodel: mock/echo\ntasks:\n  say:\n    infer:\n      prompt: \"hi\"\n",
+    )
+    .expect("fixture written");
+    let lease = crate::cwd::enter(&scratch).expect("cwd lease");
+
+    let turn = super::thread::run_in_thread("hello.nika.yaml", plain_theme(), false);
+    assert!(!turn.interrupted);
+    assert!(
+        !scratch.join(".nika/traces").exists(),
+        "a staged turn leaves no journal"
+    );
+
+    let asked = super::thread::run_in_thread("hello.nika.yaml", plain_theme(), true);
+    assert!(!asked.interrupted);
+    let traces: Vec<_> = std::fs::read_dir(scratch.join(".nika/traces"))
+        .expect("the journal dir exists after a /run")
+        .flatten()
+        .filter(|e| e.path().extension().is_some_and(|x| x == "ndjson"))
+        .collect();
+    assert_eq!(traces.len(), 1, "one journal for the one /run: {traces:?}");
+
+    drop(lease);
+    let _ = std::fs::remove_dir_all(&scratch);
+}

--- a/crates/nika-cli/src/verbs/run/thread.rs
+++ b/crates/nika-cli/src/verbs/run/thread.rs
@@ -13,7 +13,13 @@ pub(crate) struct ThreadRun {
     pub(crate) interrupted: bool,
 }
 
-pub(crate) fn run_in_thread(file: &str, theme: Theme) -> ThreadRun {
+/// Run a workflow from the thread. `journal` decides whether the run
+/// leaves its hash-chained trace under `.nika/traces/` the way `nika run`
+/// does: a `/run <path>` the human asked for is a real run and MUST
+/// (nika#1385 · the thread used to strip the accountability layer: no
+/// trace, no cost line, no seal); a staged conversational turn is the
+/// thread's own scratch and leaves none.
+pub(crate) fn run_in_thread(file: &str, theme: Theme, journal: bool) -> ThreadRun {
     let verdict = run_verdict(
         file,
         false,
@@ -25,7 +31,7 @@ pub(crate) fn run_in_thread(file: &str, theme: Theme) -> ThreadRun {
         None,
         &[],
         None,
-        true,
+        !journal, // no_trace_file
         None,
         false,
         None,

--- a/crates/nika-cli/src/verbs/session.rs
+++ b/crates/nika-cli/src/verbs/session.rs
@@ -20,7 +20,7 @@ const HELP: &str = "text                 talk in this thread\n\
 /model provider/model choose the thread model\n\
 /list                list workflows below here\n\
 /workflow <path>     post a workflow card\n\
-/run <path>          run a workflow in this thread\n\
+/run <path>          run a workflow here · journaled like nika run\n\
 /quit                close the thread\n";
 const HISTORY_LIMIT: usize = 12;
 static TURN_ID: AtomicU64 = AtomicU64::new(0);
@@ -64,7 +64,7 @@ impl ThreadRuntime for LiveRuntime {
             eprintln!("nika: cannot stage thread turn: {error}");
             return Turn::answered(String::new());
         }
-        let result = super::run::run_in_thread(&path.to_string_lossy(), theme);
+        let result = super::run::run_in_thread(&path.to_string_lossy(), theme, false);
         let _ = std::fs::remove_file(path);
         if result.interrupted {
             Turn::interrupted()
@@ -78,7 +78,7 @@ impl ThreadRuntime for LiveRuntime {
     }
 
     fn run_workflow(&mut self, path: &str, theme: Theme) -> Turn {
-        let result = super::run::run_in_thread(path, theme);
+        let result = super::run::run_in_thread(path, theme, true);
         if result.interrupted {
             Turn::interrupted()
         } else {


### PR DESCRIPTION
The thread's `/run` handed the run pipeline `no_trace_file: true`, so a workflow the human asked to run left no hash-chained trace, no cost line and no seal, while the same file under `nika run` left all three (#1385): the conversation stripped the accountability layer.

- `/run <path>` now journals under `.nika/traces` and prints the trace line like `nika run` (the thread render mode no longer silences the trace note; a journal-less turn surfaces no path, so nothing is claimed).
- Staged conversational turns stay journal-less (the thread's own scratch).
- A test leases the cwd and pins both halves; the `/run` help line says it.

Signed single commit on the green trunk.

Closes #1385.