### PR TITLE
fix(check): three refusals name what they refuse

### DIFF
--- a/changelog.d/1402.fixed.md
+++ b/changelog.d/1402.fixed.md
@@ -1,0 +1,5 @@
+- **Three refusals name what they refuse.** `retry: 3` now says the mapping's
+  keys (`max_attempts · backoff_ms · backoff_strategy · backoff_max_ms · jitter ·
+  on_codes`), a bare-number `timeout:` shows the duration forms, and a tool that
+  is not a canonical builtin points at `nika catalog --tools` when no near name
+  exists, instead of refusing in silence.

--- a/crates/nika-display/src/check_render.rs
+++ b/crates/nika-display/src/check_render.rs
@@ -413,9 +413,13 @@ pub fn required_inputs(wf: &RawWorkflow) -> Vec<&str> {
 
 /// The `· fix: did you mean ___?` clause, or empty when no suggestion.
 fn fix_clause(suggestion: Option<&str>) -> String {
-    suggestion
-        .map(|s| format!(" · fix: did you mean `{s}`?"))
-        .unwrap_or_default()
+    // No near name to offer: name the door to the closed set instead of
+    // refusing in silence (a gauntlet persona tried --help, doctor, spec
+    // and explain before giving up · 2026-09-02).
+    suggestion.map_or_else(
+        || " · fix: the closed set is `nika catalog --tools`".to_owned(),
+        |s| format!(" · fix: did you mean `{s}`?"),
+    )
 }
 
 /// One row per gate-liveness refusal (DAG-006 statically dead · DAG-007

--- a/crates/nika-schema/src/parser/tasks.rs
+++ b/crates/nika-schema/src/parser/tasks.rs
@@ -389,7 +389,10 @@ pub(super) fn parse_timeout(
     // ambiguous · forbidden ».
     if scalar.may_coerce() && (text.parse::<i64>().is_ok() || text.parse::<f64>().is_ok()) {
         return Err(SchemaError::BadTimeout {
-            reason: format!("bare number `{text}` is ambiguous — use a quoted Go-duration string"),
+            reason: format!(
+                "bare number `{text}` is ambiguous — use a quoted Go-duration string \
+                 (e.g. \"30s\" · \"5m\" · \"1h30m\")"
+            ),
             span: cx.span(scalar.span()),
         });
     }
@@ -411,7 +414,9 @@ fn parse_retry(
     };
     let Some(retry_map) = node.as_mapping() else {
         return Err(SchemaError::BadRetry {
-            reason: "`retry` must be a mapping".to_owned(),
+            reason: "`retry` must be a mapping · `{ max_attempts, backoff_ms, \
+                     backoff_strategy, backoff_max_ms, jitter, on_codes }`"
+                .to_owned(),
             span: cx.span(node.span()),
         });
     };


### PR DESCRIPTION
Measured by two gauntlet personas on 0.116.2: one left the terminal for the docs on the `retry:` shape, the other tried `--help`, `doctor`, `spec` and `explain` to find the builtin set and gave up.

- `retry: 3` now says the mapping's keys (`max_attempts · backoff_ms · backoff_strategy · backoff_max_ms · jitter · on_codes`).
- A bare-number `timeout:` shows the duration forms (`"30s" · "5m" · "1h30m"`).
- A tool that is not a canonical builtin points at `nika catalog --tools` when no near name exists, instead of refusing in silence.

Refs #1402 (the foreign-term map stays open there).