### PR TITLE
fix(check): the refusal teaches the whole repair, not its first step

### DIFF
--- a/changelog.d/1394.fixed.md
+++ b/changelog.d/1394.fixed.md
@@ -1,0 +1,6 @@
+- **The first TRIFECTA refusal states the whole dominance rule.** A blocking
+  `nika:prompt` must dominate every path to the egress task, data edges
+  (`with:`) included; the refusal now names every entry task the gate must
+  precede (the judge had already computed them) and the whole repair shape in
+  one sentence: the gate in `permits.tools`, its answer bound with `with:`,
+  the effect gated with `when:`.

--- a/changelog.d/1395.fixed.md
+++ b/changelog.d/1395.fixed.md
@@ -1,0 +1,6 @@
+- **A value that looks like a reference and is not one is named.** The
+  mustache island `{{ inputs.topic }}` and a whole `with:` value shaped like a
+  shell sigil (`$a`) used to pass check silently and reach the model as
+  literal text; a `silent-literal` hint now names the literal and the one
+  reference form (`${{ inputs.topic }}` · `${{ tasks.a.output }}`). Real
+  islands, dollar amounts and the shell's own `$HOME` in argv stay silent.

--- a/changelog.d/1396.fixed.md
+++ b/changelog.d/1396.fixed.md
@@ -1,0 +1,4 @@
+- **`nika explain NIKA-EXEC-001` no longer claims check catches it.** The
+  closer draws the same line check's EXEC row draws: a literal argv the floor
+  refuses is check's; a templated program name and a non-zero exit status are
+  the run's verdict.

--- a/changelog.d/1399.fixed.md
+++ b/changelog.d/1399.fixed.md
@@ -1,0 +1,6 @@
+- **A TRIFECTA finding says why the legs are legs here.** One clause names
+  the grant arming each leg (an exec output is untrusted content · an exec
+  grant reaches anywhere · a net grant · a write outside `./`), so a purely
+  local shell pipeline no longer reads as an unexplained exfiltration. The
+  bypass sentence names the sink's PARENT that skirts the gate, never a
+  second « source » that contradicted the first.

--- a/changelog.d/1402.fixed.md
+++ b/changelog.d/1402.fixed.md
@@ -1,5 +1,7 @@
-- **Three refusals name what they refuse.** `retry: 3` now says the mapping's
-  keys (`max_attempts · backoff_ms · backoff_strategy · backoff_max_ms · jitter ·
-  on_codes`), a bare-number `timeout:` shows the duration forms, and a tool that
-  is not a canonical builtin points at `nika catalog --tools` when no near name
-  exists, instead of refusing in silence.
+- **Foreign terms name their mechanism.** Airflow and GitHub Actions keys
+  that reached the generic field list now teach the replacement inline:
+  `schedule_interval` → the project file's `arm:` · `default_args` → per-task
+  fields and `inputs:` knobs · `dag_id` → `nika:` · `on_failure_callback` →
+  `after: { x: failure }` · `trigger_rule` → the `after:` outcomes · `retries`
+  → the `retry:` mapping's fields · `if` → `when:` · `continue-on-error` →
+  `on_error:`.

--- a/crates/nika-cap/src/trifecta.rs
+++ b/crates/nika-cap/src/trifecta.rs
@@ -237,6 +237,90 @@ fn legs(permits: &Permits, subjects: &[TrifectaSubject]) -> (bool, bool, bool) {
     (private_read, untrusted_ingress, external_egress)
 }
 
+/// WHY the three legs are legs HERE — one clause per leg, naming the
+/// grant that arms it (#1399: a twenty-line local shell pipeline read as
+/// an exfiltration scenario with nothing anywhere saying that an exec
+/// output is untrusted ingress and an exec grant is external egress).
+fn leg_reasons(permits: &Permits, subjects: &[TrifectaSubject]) -> String {
+    let sources: Vec<String> = subjects
+        .iter()
+        .filter(|s| s.ingress_source)
+        .map(|s| format!("`{}`", s.id))
+        .collect();
+    let mut ingress_by = Vec::new();
+    if permits.allows_exec() {
+        ingress_by.push("`permits.exec` (an exec output is untrusted content)");
+    }
+    if permits
+        .tools
+        .as_ref()
+        .is_some_and(|t| grants_untrusted_ingress(t))
+    {
+        ingress_by.push("`permits.tools` admitting a fetch / MCP / browsing tool (its result is untrusted content)");
+    }
+    let mut egress_by = Vec::new();
+    if permits.net.as_ref().is_some_and(|n| !n.http.is_empty()) {
+        egress_by.push("`permits.net.http`");
+    }
+    if permits
+        .fs
+        .as_ref()
+        .is_some_and(|fs| fs.write.iter().any(|g| write_glob_escapes(g)))
+    {
+        egress_by.push("an `fs.write` grant outside `./`");
+    }
+    if permits.allows_exec() {
+        egress_by.push("`permits.exec` (a program reaches anywhere)");
+    }
+    format!(
+        "legs here: private read = `permits.fs.read` · untrusted ingress = {} via {} · external egress via {}",
+        if sources.is_empty() {
+            "an ingress task".to_owned()
+        } else {
+            sources.join(", ")
+        },
+        ingress_by.join(" and "),
+        egress_by.join(" and "),
+    )
+}
+
+/// The ENTRY tasks feeding `sink` — its ancestors with no parents (or
+/// `sink` itself when it has none). A blocking gate dominates every path
+/// to the sink exactly when every one of these runs after it (#1394: the
+/// first refusal said « upstream of the fetch task » while a `with:` data
+/// edge from a private read reached the sink around that placement; the
+/// judge had already computed the set, so it names it).
+fn entry_ancestors(subjects: &[TrifectaSubject], sink: usize) -> Vec<String> {
+    let mut seen = BTreeSet::new();
+    let mut stack = vec![sink];
+    let mut roots = BTreeSet::new();
+    while let Some(i) = stack.pop() {
+        if !seen.insert(i) {
+            continue;
+        }
+        let Some(s) = subjects.get(i) else {
+            continue;
+        };
+        if s.parents.is_empty() {
+            roots.insert(i);
+        }
+        stack.extend(s.parents.iter().copied());
+    }
+    roots
+        .into_iter()
+        .filter_map(|i| subjects.get(i).map(|s| format!("`{}`", s.id)))
+        .collect()
+}
+
+/// `a` · `a and b` · `a, b and c`.
+fn join_names(names: &[String]) -> String {
+    match names {
+        [] => "the ingress".to_owned(),
+        [one] => one.clone(),
+        [head @ .., last] => format!("{} and {last}", head.join(", ")),
+    }
+}
+
 /// The virtual-root marker in dominator sets (never a subject index).
 const ROOT: usize = usize::MAX;
 
@@ -296,22 +380,28 @@ pub fn trifecta_verdict(
             // cannot dominate it — the data edges feeding the sink from
             // pre-gate tasks are paths too. Upstream of the ingress,
             // EVERY path (order and data alike) crosses the gate.
-            let ingress = source.as_deref().unwrap_or("the untrusted ingress");
             let why = bypass_note(&dom, subjects, i).unwrap_or_else(|| {
                 format!(
                     "no blocking `invoke: {}` dominates every path to it",
                     crate::HUMAN_GATE_TOOL
                 )
             });
+            let legs = leg_reasons(permits, subjects);
+            let entries = join_names(&entry_ancestors(subjects, i));
             out.push(TrifectaViolation {
                 task: s.id.clone(),
                 detail: format!(
                     "lethal trifecta complete · human gate required — untrusted content from \
                      `{}` reaches egress task `{}` while private read + untrusted ingress + \
-                     external egress are all permitted, and {why} · fix: place the blocking \
-                     `invoke: {}` upstream of `{ingress}` — every path to `{}`, order and \
-                     data edges alike, then crosses it (NEP-0002 · the Rule of Two as a check)",
+                     external egress are all permitted ({legs}), and {why} · fix: a blocking \
+                     `invoke: {}` must dominate EVERY path to `{}`, data edges (`with:`) \
+                     included — place it upstream of {entries} (grant `{}` in `permits.tools` · \
+                     bind its answer into the effect with `with:` · gate the effect with \
+                     `when:`), then every path to `{}`, order and data edges alike, crosses \
+                     it (NEP-0002 · the Rule of Two as a check)",
                     source.as_deref().unwrap_or("<ingress>"),
+                    s.id,
+                    crate::HUMAN_GATE_TOOL,
                     s.id,
                     crate::HUMAN_GATE_TOOL,
                     s.id,
@@ -371,10 +461,14 @@ fn bypass_note(
         .parents
         .iter()
         .find(|&&p| !dom.get(p).is_some_and(|d| d.contains(&gate)))?;
+    // « its parent », not « the edge from »: the source of the untrusted
+    // content and the parent that bypasses the gate are two different
+    // roles, and a sentence that named both as bare task ids read as a
+    // finding contradicting itself (#1399).
     Some(format!(
-        "the blocking gate `{}` does not dominate it — the edge from `{}` reaches `{}` \
+        "the blocking gate `{}` does not dominate `{}` — its parent `{}` reaches it \
          without crossing the gate (a `with:` data edge is a path too)",
-        subjects[gate].id, subjects[*bypass].id, subjects[sink].id,
+        subjects[gate].id, subjects[sink].id, subjects[*bypass].id,
     ))
 }
 

--- a/crates/nika-check/src/hints.rs
+++ b/crates/nika-check/src/hints.rs
@@ -106,6 +106,7 @@
 
 use std::collections::BTreeSet;
 
+use crate::flow::{action_effect_fields, collect_json_strings};
 use crate::walk::{consumed_outputs, deeply_referenced, envelope_bound_outputs};
 use nika_schema::expression::scan_templates;
 use nika_schema::raw::{RawAction, RawTask, RawWorkflow};
@@ -125,7 +126,7 @@ pub struct Hint {
     /// · `analysis` · `consent` · `digit-string-enum`
     /// · `glob-readme` · `assert-quarantine` · `jq-as-map` · `infer-as-law`
     /// · `fail-open-consent`
-    /// · `unproven-law`
+    /// · `unproven-law` · `silent-literal`
     /// (additive · agents route on it; the module doc describes each).
     /// The paid-run family ([`PAID_RUN_KINDS`]) is what [`paid_ready`]
     /// reads — never `is_clean`.
@@ -296,6 +297,7 @@ pub(super) fn scan_hints(wf: &RawWorkflow) -> Vec<Hint> {
             other => unreachable!("unknown action: {other:?}"),
         }
         push_retry_effects_hint(&mut hints, t);
+        push_silent_literal_hints(&mut hints, t);
     }
 
     // F-O8 · the old « no `permits:` boundary declared » advisory is
@@ -1340,6 +1342,87 @@ fn value_mentions_tasks(v: &serde_json::Value, ids: &BTreeSet<&str>) -> bool {
     task_ids_in_value(v)
         .iter()
         .any(|id| ids.contains(id.as_str()))
+}
+
+/// #1395 — a value that LOOKS like a reference and is not one. The
+/// mustache island `{{ inputs.topic }}` (Jinja · Airflow · GitHub
+/// Actions) and the shell sigil `$name` as a whole `with:` value are
+/// neither refused nor resolved: the engine sends the literal text, so
+/// `topic=boundaries` reached a model as « {{ inputs.topic }} » under a
+/// green check. The hint names the literal and the one reference form.
+fn push_silent_literal_hints(hints: &mut Vec<Hint>, t: &RawTask) {
+    let id = t.id.value.as_str();
+    for text in action_effect_fields(&t.action) {
+        for island in mustache_refs(text) {
+            hints.push(hint("silent-literal", id, format!(
+                "`{{{{ {island} }}}}` in `{id}` is literal text here (a mustache island, not a reference) — the reference form is `${{{{ {island} }}}}`"
+            )));
+        }
+    }
+    for (name, v) in &t.with {
+        let bound = name.value.as_str();
+        for text in collect_json_strings(&v.value) {
+            for island in mustache_refs(text) {
+                hints.push(hint("silent-literal", id, format!(
+                    "`{{{{ {island} }}}}` bound to `with.{bound}` of `{id}` is literal text (a mustache island, not a reference) — the reference form is `${{{{ {island} }}}}`"
+                )));
+            }
+            if let Some(ident) = shell_sigil(text) {
+                hints.push(hint("silent-literal", id, format!(
+                    "`${ident}` bound to `with.{bound}` of `{id}` is literal text (a shell sigil, not a reference) — a binding reads `${{{{ tasks.{ident}.output }}}}` (an upstream output) or `${{{{ inputs.{ident} }}}}`"
+                )));
+            }
+        }
+    }
+}
+
+/// The reference-shaped mustache islands of one string: `{{ inputs.x }}`
+/// whose head is one of the five namespaces or a loop local, and which
+/// is NOT the `${{` island (the `$` in front is the whole difference).
+fn mustache_refs(text: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut rest = text;
+    while let Some(at) = rest.find("{{") {
+        let sigil = at > 0 && rest.as_bytes()[at - 1] == b'$';
+        let after = &rest[at + 2..];
+        let Some(end) = after.find("}}") else {
+            break;
+        };
+        let inner = after[..end].trim();
+        if !sigil && reference_shaped(inner) {
+            out.push(inner.to_owned());
+        }
+        rest = &after[end + 2..];
+    }
+    out
+}
+
+/// `inputs.x` · `tasks.a.output` · `item` · `index` — a head from the
+/// reference vocabulary, then dotted identifiers (or nothing).
+fn reference_shaped(inner: &str) -> bool {
+    let (head, tail) = inner.split_once('.').unwrap_or((inner, ""));
+    let head_ok = matches!(
+        head,
+        "inputs" | "const" | "secrets" | "with" | "tasks" | "item" | "index" | "group"
+    );
+    head_ok
+        && tail
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '.' | '[' | ']' | '-'))
+}
+
+/// A whole value that is a shell sigil — `$a` · `$tasks.a.output` — and
+/// nothing else (a `${{` island starts with `{`, a `$100` with a digit:
+/// neither is a sigil). Returns the bare identifier.
+fn shell_sigil(text: &str) -> Option<&str> {
+    let ident = text.strip_prefix('$')?;
+    let first = ident.chars().next()?;
+    (first.is_ascii_alphabetic() || first == '_')
+        .then_some(ident)
+        .filter(|i| {
+            i.chars()
+                .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '.'))
+        })
 }
 
 pub(super) fn hint(kind: &'static str, task: &str, advice: String) -> Hint {

--- a/crates/nika-check/src/hints/tests.rs
+++ b/crates/nika-check/src/hints/tests.rs
@@ -1228,3 +1228,62 @@ tasks:
         );
     }
 }
+
+/// #1395 — measured twice on 0.116.2: `{{ inputs.t }}` in a prompt and
+/// `with: { d: $a }` passed check with no signal and the run delivered
+/// the literal text. Both now carry a hint naming the literal AND the
+/// one reference form; the real islands and the shell's own `$HOME`
+/// stay silent.
+#[test]
+fn a_mustache_island_or_a_shell_sigil_is_named_as_literal_text() {
+    let hints = hints_of(
+        "nika: w\nmodel: mock/echo\ninputs:\n  topic: { type: string, default: \"x\" }\npermits: {}\ntasks:\n  a:\n    infer: { prompt: \"Write about {{ inputs.topic }}\", max_tokens: 5 }\n  b:\n    with: { d: $a, e: \"${{ tasks.a.output }}\", f: \"$100 budget\", g: \"{{ inputs.topic }}\" }\n    infer: { prompt: \"${{ with.d }} ${{ with.e }} ${{ with.f }} ${{ with.g }}\", max_tokens: 5 }\n",
+    );
+    let silent: Vec<&str> = hints
+        .iter()
+        .filter(|h| h.kind == "silent-literal")
+        .map(|h| h.advice.as_str())
+        .collect();
+    assert_eq!(
+        silent.len(),
+        3,
+        "prompt mustache · with sigil · with mustache: {silent:#?}"
+    );
+    assert!(
+        silent
+            .iter()
+            .any(|a| a.contains("`{{ inputs.topic }}` in `a`")
+                && a.contains("the reference form is `${{ inputs.topic }}`")),
+        "the prompt island names its reference form: {silent:#?}"
+    );
+    assert!(
+        silent
+            .iter()
+            .any(|a| a.contains("`$a` bound to `with.d` of `b`")
+                && a.contains("`${{ tasks.a.output }}`")),
+        "the sigil names the binding form: {silent:#?}"
+    );
+    assert!(
+        silent
+            .iter()
+            .any(|a| a.contains("`{{ inputs.topic }}` bound to `with.g` of `b`")),
+        "the with-value island is named too: {silent:#?}"
+    );
+    assert!(
+        !silent
+            .iter()
+            .any(|a| a.contains("$100") || a.contains("tasks.a.output }}` bound")),
+        "a dollar amount and a real island stay silent: {silent:#?}"
+    );
+}
+
+#[test]
+fn the_shells_own_sigils_and_prose_braces_stay_silent() {
+    let hints = hints_of(
+        "nika: w\nmodel: mock/echo\npermits: { exec: [\"echo\"] }\ntasks:\n  a:\n    exec: { command: [\"echo\", \"$HOME\", \"{{ not a ref }}\"] }\n",
+    );
+    assert!(
+        !hints.iter().any(|h| h.kind == "silent-literal"),
+        "argv `$HOME` is the shell's business and `{{ not a ref }}` is prose: {hints:#?}"
+    );
+}

--- a/crates/nika-check/src/trifecta.rs
+++ b/crates/nika-check/src/trifecta.rs
@@ -271,11 +271,11 @@ mod tests {
         assert_eq!(r.trifecta_findings.len(), 1, "{:?}", r.trifecta_findings);
         let d = &r.trifecta_findings[0].detail;
         assert!(
-            d.contains("the blocking gate `approve` does not dominate it"),
+            d.contains("the blocking gate `approve` does not dominate `leak`"),
             "the existing gate is NAMED: {d}"
         );
         assert!(
-            d.contains("the edge from `fetch_page` reaches `leak` without crossing the gate"),
+            d.contains("its parent `fetch_page` reaches it without crossing the gate"),
             "the bypassing edge is named: {d}"
         );
         assert!(
@@ -283,7 +283,7 @@ mod tests {
             "the rule itself is spoken: {d}"
         );
         assert!(
-            d.contains("fix: place the blocking `invoke: nika:prompt` upstream of `fetch_page`"),
+            d.contains("place it upstream of `fetch_page`"),
             "the placement that works is taught — upstream of the ingress: {d}"
         );
         // And the gate placed THERE goes clean (the taught fix, applied,
@@ -313,6 +313,71 @@ mod tests {
         assert!(
             !d.contains("gate the egress path"),
             "the defeated placement is no longer taught: {d}"
+        );
+    }
+
+    /// #1394 — the gauntlet's shape: a private read AND an untrusted
+    /// fetch both feed the egress through `with:`. The old first refusal
+    /// said « upstream of `fetch_untrusted` »; a gate placed exactly there
+    /// still lost to the data edge from `read_secret`. The judge names
+    /// EVERY entry the gate must precede, and the applied placement is
+    /// clean.
+    #[test]
+    fn the_first_refusal_names_every_entry_the_gate_must_precede() {
+        let y = "nika: t\npermits:\n  fs: { read: [\"./secrets/**\"], write: [\"./out/**\"] }\n  net: { http: [\"api.example.com\"] }\n  tools: [\"nika:read\", \"nika:fetch\", \"nika:write\", \"nika:prompt\"]\ntasks:\n  read_secret:\n    invoke:\n      tool: \"nika:read\"\n      args: { path: \"./secrets/key.txt\" }\n  fetch_untrusted:\n    invoke:\n      tool: \"nika:fetch\"\n      args: { url: \"https://api.example.com/page\" }\n  write_both:\n    with: { a: \"${{ tasks.read_secret.output }}\", b: \"${{ tasks.fetch_untrusted.output }}\" }\n    invoke:\n      tool: \"nika:write\"\n      args: { path: \"./out/both.txt\", content: \"${{ with.a }} ${{ with.b }}\" }\n";
+        let r = report(y);
+        assert_eq!(r.trifecta_findings.len(), 1, "{:?}", r.trifecta_findings);
+        let d = &r.trifecta_findings[0].detail;
+        assert!(
+            d.contains("must dominate EVERY path to `write_both`, data edges (`with:`) included"),
+            "the dominance rule is stated in full on the FIRST refusal: {d}"
+        );
+        assert!(
+            d.contains("upstream of `read_secret` and `fetch_untrusted`"),
+            "every entry the gate must precede is named: {d}"
+        );
+        assert!(
+            d.contains("`permits.tools`") && d.contains("`when:`") && d.contains("`with:`"),
+            "the whole repair shape is one sentence: {d}"
+        );
+        // The taught placement, applied: a gate both entries wait on.
+        let gated = y.replace(
+            "tasks:\n  read_secret:\n",
+            "tasks:\n  approve:\n    invoke:\n      tool: \"nika:prompt\"\n      args: { mode: \"confirm\", message: \"read and fetch?\" }\n  read_secret:\n    after: { approve: success }\n",
+        ).replace(
+            "  fetch_untrusted:\n    invoke:",
+            "  fetch_untrusted:\n    after: { approve: success }\n    invoke:",
+        );
+        assert!(
+            report(&gated).trifecta_findings.is_empty(),
+            "a gate upstream of every entry dominates: {:?}",
+            report(&gated).trifecta_findings
+        );
+    }
+
+    /// #1399 — a purely local shell pipeline trips the trifecta because an
+    /// exec output is untrusted ingress and an exec grant is external
+    /// egress. The finding SAYS so, and the bypass sentence names a
+    /// PARENT, never a second « source » that reads as a contradiction.
+    #[test]
+    fn a_local_shell_pipeline_names_its_legs_and_speaks_of_a_parent() {
+        let y = "nika: etl\npermits:\n  fs: { read: [\"./data/**\"], write: [\"./out/**\"] }\n  exec: true\n  tools: [\"nika:prompt\"]\ntasks:\n  extract:\n    exec: { command: [\"cat\", \"./data/in.csv\"] }\n  gate:\n    after: { extract: success }\n    invoke:\n      tool: \"nika:prompt\"\n      args: { mode: \"confirm\", message: \"load?\" }\n  transform:\n    after: { gate: success }\n    with: { rows: \"${{ tasks.extract.output }}\" }\n    exec: { command: [\"sort\"], stdin: \"${{ with.rows }}\" }\n";
+        let r = report(y);
+        assert_eq!(r.trifecta_findings.len(), 1, "{:?}", r.trifecta_findings);
+        let d = &r.trifecta_findings[0].detail;
+        assert!(
+            d.contains("legs here:")
+                && d.contains("`permits.exec` (an exec output is untrusted content)")
+                && d.contains("`permits.exec` (a program reaches anywhere)"),
+            "why the three legs are legs HERE is spoken: {d}"
+        );
+        assert!(
+            d.contains("its parent `extract` reaches it without crossing the gate"),
+            "the bypass names a PARENT, not a second source: {d}"
+        );
+        assert!(
+            !d.contains("the edge from"),
+            "the contradictory phrasing is gone: {d}"
         );
     }
 

--- a/crates/nika-cli-host/src/explain.rs
+++ b/crates/nika-cli-host/src/explain.rs
@@ -154,6 +154,14 @@ fn closer_line(code: &str) -> &'static str {
              floor predicate the run judges with); a templated command — \
              a `${{ }}` island — is judged at RUN."
         }
+        // #1396: check's own EXEC row says « a templated argv is the
+        // RUN's verdict », and an exit status can never be a check-time
+        // finding — the blanket closer contradicted the card it explained.
+        "NIKA-EXEC-001" => {
+            "`nika check` refuses a LITERAL argv the exec floor would refuse; a \
+             templated program name and a non-zero exit status are the RUN's \
+             verdict — an exit status can never be a check-time finding."
+        }
         _ => "`nika check` catches this before a run ever starts.",
     }
 }
@@ -397,6 +405,25 @@ mod tests {
         let out = run("NIKA-440");
         assert_eq!(out.code, exit::OK);
         assert!(out.text.contains("NIKA-440"));
+    }
+
+    /// #1396 — `explain NIKA-EXEC-001` promised what check's own EXEC
+    /// row disowns. The closer now draws the literal/run line and says
+    /// an exit status is never check's.
+    #[test]
+    fn the_exec_closer_hands_the_exit_status_to_the_run() {
+        let exec = run("NIKA-EXEC-001");
+        assert_eq!(exec.code, exit::OK);
+        assert!(
+            !exec.text.contains("catches this before a run ever starts"),
+            "no blanket promise over a run-judged class:\n{}",
+            exec.text
+        );
+        assert!(
+            exec.text.contains("exit status") && exec.text.contains("RUN's verdict"),
+            "the honest split is taught:\n{}",
+            exec.text
+        );
     }
 
     /// V7-2 (wave-3 · 4 personas · Priya BLOCKER): the closing claim is

--- a/crates/nika-schema/src/parser/mod.rs
+++ b/crates/nika-schema/src/parser/mod.rs
@@ -401,7 +401,9 @@ fn retired_key_teaching(key: &str, location: &str) -> Option<&'static str> {
     // in the 2026-08-11/13 sweep — the envelope and the task body — and
     // each arm fires in ITS scope only.
     if location.contains("envelope") {
-        return retired::envelope(key);
+        // A RETIRED envelope key was ours and moved; a FOREIGN one is
+        // another tool's word for a concept we spell elsewhere (#1402).
+        return retired::envelope(key).or_else(|| retired::foreign_envelope(key));
     }
     if location.starts_with("task `") {
         // Three tables, one scope, tried in order of how much the author

--- a/crates/nika-schema/src/parser/retired.rs
+++ b/crates/nika-schema/src/parser/retired.rs
@@ -133,6 +133,64 @@ pub(super) fn foreign(key: &str) -> Option<&'static str> {
              is `invoke: { tool: nika:fetch, args: { url: \"https://example.com\" } }` \
              (spec 03 §invoke)",
         ),
+        // Airflow's task vocabulary (#1402 · the rival-tool persona renamed
+        // its way through every refusal that named a replacement and
+        // stopped at the five that did not).
+        "on_failure_callback" | "on_success_callback" | "on_retry_callback" => Some(
+            "a callback is a TASK that runs on the outcome — declare it with \
+             `after: { <task>: failure }` (or `success` · `terminal` · `unwind`) \
+             on the task that should react, never as a field of the task it watches",
+        ),
+        "trigger_rule" => Some(
+            "the outcome a task waits for rides `after:` — `after: { x: terminal }` \
+             runs whatever `x` did (Airflow `all_done`) · `failure` only after a \
+             failed `x` · `unwind` on the failure path · `success` (the default) \
+             only after a green `x`",
+        ),
+        "retries" | "retry_delay" | "retry_exponential_backoff" => Some(
+            "retries ride one `retry:` mapping — `retry: { max_attempts: 3, \
+             backoff_ms: 1000, backoff_strategy: exponential, jitter: true }` \
+             (`on_codes:` narrows it to named refusals)",
+        ),
+        "execution_timeout" | "timeout_minutes" | "timeout-minutes" => Some(
+            "a hard kill rides `timeout:` as a Go duration — `timeout: \"30s\"` \
+             (`\"5m\"` · `\"2h\"` · at most `24h`)",
+        ),
+        "if" => Some(
+            "a condition rides `when:` as a CEL boolean — `when: \"${{ inputs.ship }}\"` \
+             (a `tasks.*` read is hoisted into `with:` first)",
+        ),
+        "continue-on-error" | "continue_on_error" => Some(
+            "a failure the run may survive rides `on_error:` — `on_error: { skip: true }` \
+             skips the task, `on_error: { recover: <value> }` substitutes a value",
+        ),
+        _ => None,
+    }
+}
+
+/// An ENVELOPE key from another dialect (#1402 · Airflow · GitHub
+/// Actions). The concept exists; it lives in another file or under
+/// another word, and the refusal says which.
+pub(super) fn foreign_envelope(key: &str) -> Option<&'static str> {
+    match key {
+        "schedule_interval" | "schedule" | "cron" | "on" | "catchup" => Some(
+            "a cadence is not a workflow field — the file proposes, the machine \
+             disposes: the beat is declared in the project file (`nika.yaml` → `arm:`) \
+             and `nika arm` reads what is armed and when each beat next fires",
+        ),
+        "default_args" => Some(
+            "there are no task defaults — each task declares its own `retry:` · \
+             `timeout:` · `model:`; a deployment knob is an `inputs:` entry with \
+             `required: false` and a `default:`, read as `${{ inputs.<name> }}`",
+        ),
+        "dag_id" | "workflow_id" => Some(
+            "the file's name is `nika: <kebab-id>` — the mark AND the name, never a \
+             version",
+        ),
+        "jobs" | "steps" => Some(
+            "the work lives under `tasks:` — a map keyed by task id (snake_case), \
+             each task exactly one verb (`infer:` · `exec:` · `invoke:` · `agent:`)",
+        ),
         _ => None,
     }
 }
@@ -156,6 +214,65 @@ pub(super) fn envelope_key_at_task_level(key: &str) -> Option<&'static str> {
 mod tests {
     use crate::parser::{ParseMode, parse};
     use crate::source::FileId;
+
+    /// #1402 — the five Airflow / GitHub Actions terms that reached the
+    /// generic field list with no replacement anywhere in the CLI. Each
+    /// now names the mechanism it maps to; the assertions name
+    /// MECHANISMS, never whole sentences.
+    #[test]
+    fn foreign_envelope_and_task_terms_name_their_mechanism() {
+        let envelope = |line: &str| {
+            let yaml =
+                format!("nika: w\n{line}\ntasks:\n  t:\n    exec: {{ command: [\"true\"] }}\n");
+            parse(&yaml, FileId::new(0), ParseMode::Strict)
+                .expect_err("an unknown envelope key refuses")
+                .to_string()
+        };
+        let cadence = envelope("schedule_interval: \"@daily\"");
+        assert!(
+            cadence.contains("`arm:`")
+                && cadence.contains("nika.yaml")
+                && cadence.contains("nika arm"),
+            "a cadence routes to the project file and the arm verb · {cadence}"
+        );
+        let defaults = envelope("default_args: { retries: 2 }");
+        assert!(
+            defaults.contains("`inputs:`") && defaults.contains("`retry:`"),
+            "task defaults route to per-task fields and inputs knobs · {defaults}"
+        );
+        let dag = envelope("dag_id: etl");
+        assert!(
+            dag.contains("`nika: <kebab-id>`"),
+            "dag_id routes to the mark · {dag}"
+        );
+        let jobs = envelope("jobs: {}");
+        assert!(jobs.contains("`tasks:`") && jobs.contains("verb"), "{jobs}");
+
+        let task = |body: &str| {
+            let yaml =
+                format!("nika: w\ntasks:\n  t:\n{body}    exec: {{ command: [\"true\"] }}\n");
+            parse(&yaml, FileId::new(0), ParseMode::Strict)
+                .expect_err("an unknown task key refuses")
+                .to_string()
+        };
+        let callback = task("    on_failure_callback: notify\n");
+        assert!(
+            callback.contains("after:") && callback.contains("failure"),
+            "a callback routes to `after: {{ x: failure }}` · {callback}"
+        );
+        let rule = task("    trigger_rule: all_done\n");
+        assert!(
+            rule.contains("terminal") && rule.contains("all_done"),
+            "`trigger_rule` routes to the `after:` outcomes · {rule}"
+        );
+        let retries = task("    retries: 3\n");
+        assert!(
+            retries.contains("max_attempts") && retries.contains("backoff_ms"),
+            "`retries` names the retry mapping's fields · {retries}"
+        );
+        let cond = task("    if: true\n");
+        assert!(cond.contains("`when:`"), "`if` routes to `when:` · {cond}");
+    }
 
     /// A key from another dialect, and our own key at the wrong depth,
     /// both TEACH — because in neither case is the author confused about


### PR DESCRIPTION
Closes #1394
Closes #1395
Closes #1396
Closes #1399
Closes #1402

Five gauntlet findings on what `check` SAYS, one batch.

- **#1394** · the first TRIFECTA refusal states the dominance rule in full (every path to the egress, data edges included), names every entry task the gate must precede (the judge had computed them) and the whole repair shape in one sentence: the gate in `permits.tools`, its answer bound with `with:`, the effect gated with `when:`.
- **#1399** · the finding says why the three legs are legs here, one clause per grant; the bypass sentence names the sink's PARENT that skirts the gate instead of a second « source » that read as a contradiction.
- **#1395** · a value that looks like a reference and is not one carries a `silent-literal` hint: the mustache island and a `with:` value shaped like a shell sigil, each with its one reference form. Real islands, dollar amounts and argv `$HOME` stay silent.
- **#1396** · `explain NIKA-EXEC-001` hands the exit status to the run.
- **#1402** · foreign terms name their mechanism: `schedule_interval` · `default_args` · `dag_id` · `on_failure_callback` · `trigger_rule` · `retries` · `if` · `continue-on-error`.

## Proof

Unit tests in `nika-cap` (sentences), `nika-check` (the #1394 shape with its applied placement going clean · the #1399 pipeline · the hint over the measured probes), `nika-cli-host` (the closer) and `nika-schema` (every foreign term names its mechanism).

proven_by: rust

🤖 Generated with [Claude Code](https://claude.com/claude-code)