### PR TITLE
feat(cli): the machine faces say the whole verdict

### DIFF
--- a/changelog.d/1403.fixed.md
+++ b/changelog.d/1403.fixed.md
@@ -1,0 +1,4 @@
+- **`run --json` ends on the whole verdict.** The terminal `run_settled`
+  frame of a failed run now carries `error: { code, message, task }` (the
+  first failed task), so the last line a machine reads says why; a
+  succeeded or paused run carries no `error` key.

--- a/changelog.d/1404.fixed.md
+++ b/changelog.d/1404.fixed.md
@@ -1,0 +1,6 @@
+- **`check --help` and `test --help` carry their exit-code table.** The
+  house taxonomy is spoken on the verb: 0 the report holds · 2 the FILE (a
+  grammar refusal or findings · `--json` `kind` tells them apart) · 3 the
+  ENVIRONMENT (a missing or unreadable file, an unreachable registry, a
+  misused flag) · never 1 or 4 on `check`; the golden test names its 3 (no
+  golden yet).

--- a/changelog.d/1405.added.md
+++ b/changelog.d/1405.added.md
@@ -1,0 +1,6 @@
+- **`trace verify --json`.** One JSON document per trace (`verify_version`
+  1): the attained `tier` (`ok` · `sealed` · `anchored` · `replayed`, or
+  `broken` · `unchained` · `empty` · `unreadable` for the non-ladder
+  verdicts), the `exit` class, the chain facts, one object per leg (`seal` ·
+  `anchor` · `replay`) and the ladder `lines`; several traces stream as
+  NDJSON. A CI gate on « at least SEALED » reads a field, never a prose line.

--- a/crates/nika-cli-host/public-api.txt
+++ b/crates/nika-cli-host/public-api.txt
@@ -167,7 +167,6 @@ impl<T> tracing::instrument::Instrument for nika_cli_host::clients_registry::Reg
 impl<T> tracing::instrument::WithSubscriber for nika_cli_host::clients_registry::RegistryCoverage
 impl<T> typenum::type_operators::Same for nika_cli_host::clients_registry::RegistryCoverage
 pub type nika_cli_host::clients_registry::RegistryCoverage::Output = T
-impl<T> zvariant::optional::NoneValue for nika_cli_host::clients_registry::RegistryCoverage where T: core::default::Default
 pub type nika_cli_host::clients_registry::RegistryCoverage::NoneType = T
 pub fn nika_cli_host::clients_registry::RegistryCoverage::null_value() -> T
 pub const nika_cli_host::clients_registry::PROBE_MECHANISMS: &[&str]
@@ -1325,6 +1324,8 @@ impl<T> tracing::instrument::WithSubscriber for nika_cli_host::help_card::HelpKi
 impl<T> typenum::type_operators::Same for nika_cli_host::help_card::HelpKind
 pub type nika_cli_host::help_card::HelpKind::Output = T
 pub const nika_cli_host::help_card::AFTER_HELP: &str
+pub const nika_cli_host::help_card::CHECK_EXITS: &str
+pub const nika_cli_host::help_card::TEST_EXITS: &str
 pub fn nika_cli_host::help_card::classify_help(argv: &[impl core::convert::AsRef<std::ffi::os_str::OsStr>]) -> core::option::Option<nika_cli_host::help_card::HelpKind>
 pub fn nika_cli_host::help_card::home_looks_like_scratch(home: &str) -> bool
 pub fn nika_cli_host::help_card::human_help() -> &'static str
@@ -1736,7 +1737,6 @@ impl<T> tracing::instrument::Instrument for nika_cli_host::metrics::Facts
 impl<T> tracing::instrument::WithSubscriber for nika_cli_host::metrics::Facts
 impl<T> typenum::type_operators::Same for nika_cli_host::metrics::Facts
 pub type nika_cli_host::metrics::Facts::Output = T
-impl<T> zvariant::optional::NoneValue for nika_cli_host::metrics::Facts where T: core::default::Default
 pub type nika_cli_host::metrics::Facts::NoneType = T
 pub fn nika_cli_host::metrics::Facts::null_value() -> T
 pub fn nika_cli_host::metrics::record(path: &std::path::Path, event: nika_cli_host::metrics::EventKind, facts: nika_cli_host::metrics::Facts) -> core::io::error::Result<()>
@@ -2111,7 +2111,6 @@ impl<T> tracing::instrument::Instrument for nika_cli_host::probe::ImageProbe
 impl<T> tracing::instrument::WithSubscriber for nika_cli_host::probe::ImageProbe
 impl<T> typenum::type_operators::Same for nika_cli_host::probe::ImageProbe
 pub type nika_cli_host::probe::ImageProbe::Output = T
-impl<T> zvariant::optional::NoneValue for nika_cli_host::probe::ImageProbe where T: core::default::Default
 pub type nika_cli_host::probe::ImageProbe::NoneType = T
 pub fn nika_cli_host::probe::ImageProbe::null_value() -> T
 pub struct nika_cli_host::probe::KitProbe
@@ -2217,7 +2216,6 @@ impl<T> tracing::instrument::Instrument for nika_cli_host::probe::PricingProbe
 impl<T> tracing::instrument::WithSubscriber for nika_cli_host::probe::PricingProbe
 impl<T> typenum::type_operators::Same for nika_cli_host::probe::PricingProbe
 pub type nika_cli_host::probe::PricingProbe::Output = T
-impl<T> zvariant::optional::NoneValue for nika_cli_host::probe::PricingProbe where T: core::default::Default
 pub type nika_cli_host::probe::PricingProbe::NoneType = T
 pub fn nika_cli_host::probe::PricingProbe::null_value() -> T
 pub struct nika_cli_host::probe::Probe
@@ -2387,7 +2385,6 @@ impl<T> tracing::instrument::Instrument for nika_cli_host::probe::TtsProbe
 impl<T> tracing::instrument::WithSubscriber for nika_cli_host::probe::TtsProbe
 impl<T> typenum::type_operators::Same for nika_cli_host::probe::TtsProbe
 pub type nika_cli_host::probe::TtsProbe::Output = T
-impl<T> zvariant::optional::NoneValue for nika_cli_host::probe::TtsProbe where T: core::default::Default
 pub type nika_cli_host::probe::TtsProbe::NoneType = T
 pub fn nika_cli_host::probe::TtsProbe::null_value() -> T
 pub fn nika_cli_host::probe::access_probes_with_harness() -> alloc::vec::Vec<nika_providers::probe::ProviderProbe>
@@ -2447,6 +2444,58 @@ impl<T> tracing::instrument::Instrument for nika_cli_host::run_settlement::Local
 impl<T> tracing::instrument::WithSubscriber for nika_cli_host::run_settlement::LocalRunReceipt<'a>
 impl<T> typenum::type_operators::Same for nika_cli_host::run_settlement::LocalRunReceipt<'a>
 pub type nika_cli_host::run_settlement::LocalRunReceipt<'a>::Output = T
+#[non_exhaustive] pub struct nika_cli_host::run_settlement::SettlementError
+pub nika_cli_host::run_settlement::SettlementError::code: alloc::string::String
+pub nika_cli_host::run_settlement::SettlementError::message: alloc::string::String
+pub nika_cli_host::run_settlement::SettlementError::task: alloc::string::String
+impl core::clone::Clone for nika_cli_host::run_settlement::SettlementError
+pub fn nika_cli_host::run_settlement::SettlementError::clone(&self) -> nika_cli_host::run_settlement::SettlementError
+impl core::cmp::Eq for nika_cli_host::run_settlement::SettlementError
+impl core::cmp::PartialEq for nika_cli_host::run_settlement::SettlementError
+pub fn nika_cli_host::run_settlement::SettlementError::eq(&self, other: &nika_cli_host::run_settlement::SettlementError) -> bool
+impl core::fmt::Debug for nika_cli_host::run_settlement::SettlementError
+pub fn nika_cli_host::run_settlement::SettlementError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for nika_cli_host::run_settlement::SettlementError
+impl serde_core::ser::Serialize for nika_cli_host::run_settlement::SettlementError
+pub fn nika_cli_host::run_settlement::SettlementError::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<D> owo_colors::OwoColorize for nika_cli_host::run_settlement::SettlementError
+impl<Q, K> equivalent::Equivalent<K> for nika_cli_host::run_settlement::SettlementError where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn nika_cli_host::run_settlement::SettlementError::equivalent(&self, key: &K) -> bool
+impl<Q, K> hashbrown::Equivalent<K> for nika_cli_host::run_settlement::SettlementError where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn nika_cli_host::run_settlement::SettlementError::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for nika_cli_host::run_settlement::SettlementError where U: core::convert::From<T>
+pub fn nika_cli_host::run_settlement::SettlementError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_cli_host::run_settlement::SettlementError where U: core::convert::Into<T>
+pub type nika_cli_host::run_settlement::SettlementError::Error = core::convert::Infallible
+pub fn nika_cli_host::run_settlement::SettlementError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_cli_host::run_settlement::SettlementError where U: core::convert::TryFrom<T>
+pub type nika_cli_host::run_settlement::SettlementError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_cli_host::run_settlement::SettlementError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_cli_host::run_settlement::SettlementError where T: core::clone::Clone
+pub type nika_cli_host::run_settlement::SettlementError::Owned = T
+pub fn nika_cli_host::run_settlement::SettlementError::clone_into(&self, target: &mut T)
+pub fn nika_cli_host::run_settlement::SettlementError::to_owned(&self) -> T
+impl<T> core::any::Any for nika_cli_host::run_settlement::SettlementError where T: 'static + ?core::marker::Sized
+pub fn nika_cli_host::run_settlement::SettlementError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_cli_host::run_settlement::SettlementError where T: ?core::marker::Sized
+pub fn nika_cli_host::run_settlement::SettlementError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_cli_host::run_settlement::SettlementError where T: ?core::marker::Sized
+pub fn nika_cli_host::run_settlement::SettlementError::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_cli_host::run_settlement::SettlementError where T: core::clone::Clone
+pub unsafe fn nika_cli_host::run_settlement::SettlementError::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_cli_host::run_settlement::SettlementError
+pub fn nika_cli_host::run_settlement::SettlementError::from(t: T) -> T
+impl<T> dyn_clone::DynClone for nika_cli_host::run_settlement::SettlementError where T: core::clone::Clone
+pub fn nika_cli_host::run_settlement::SettlementError::__clone_box(&self, _: dyn_clone::sealed::Private) -> *mut ()
+impl<T> nika_error::traits::AsAny for nika_cli_host::run_settlement::SettlementError where T: 'static
+pub fn nika_cli_host::run_settlement::SettlementError::as_any(&self) -> &(dyn core::any::Any + 'static)
+impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli_host::run_settlement::SettlementError where T: ?core::marker::Sized
+pub fn nika_cli_host::run_settlement::SettlementError::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli_host::run_settlement::SettlementError::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+impl<T> tracing::instrument::Instrument for nika_cli_host::run_settlement::SettlementError
+impl<T> tracing::instrument::WithSubscriber for nika_cli_host::run_settlement::SettlementError
+impl<T> typenum::type_operators::Same for nika_cli_host::run_settlement::SettlementError
+pub type nika_cli_host::run_settlement::SettlementError::Output = T
 pub struct nika_cli_host::run_settlement::TraceProof
 pub nika_cli_host::run_settlement::TraceProof::head: alloc::string::String
 pub nika_cli_host::run_settlement::TraceProof::len: usize
@@ -2483,7 +2532,9 @@ pub fn nika_cli_host::run_settlement::first_failure(outcome: &nika_runtime::RunO
 pub fn nika_cli_host::run_settlement::local_receipt_binding(execution: nika_types::id::ExecutionId, snapshot_digest: &str) -> serde_json::value::Value
 pub fn nika_cli_host::run_settlement::plan_waves(workflow: &nika_schema::raw::workflow::RawWorkflow, report: &nika_check::CheckReport) -> alloc::vec::Vec<alloc::vec::Vec<alloc::string::String>>
 pub fn nika_cli_host::run_settlement::sensitive_journey(report: &nika_check::CheckReport) -> bool
-pub fn nika_cli_host::run_settlement::write_local_run_settlement<T: serde_core::ser::Serialize, W: core::io::write::Write>(writer: &mut nika_dap::journal::JsonSink<W>, outcome: (bool, bool), outputs: &T, execution: nika_types::id::ExecutionId, snapshot_digest: &str, trace: core::option::Option<(&std::path::Path, &nika_cli_host::run_settlement::TraceProof)>) -> core::io::error::Result<()>
+pub fn nika_cli_host::run_settlement::settlement_error(outcome: &nika_runtime::RunOutcome) -> core::option::Option<nika_cli_host::run_settlement::SettlementError>
+pub fn nika_cli_host::run_settlement::write_failed_run_settlement<T: serde_core::ser::Serialize>(writer: &mut impl core::io::write::Write, outputs: &T, receipt: core::option::Option<nika_cli_host::run_settlement::LocalRunReceipt<'_>>, error: core::option::Option<&nika_cli_host::run_settlement::SettlementError>) -> core::io::error::Result<()>
+pub fn nika_cli_host::run_settlement::write_local_run_settlement<T: serde_core::ser::Serialize, W: core::io::write::Write>(writer: &mut nika_dap::journal::JsonSink<W>, outcome: (bool, bool), outputs: &T, execution: nika_types::id::ExecutionId, snapshot_digest: &str, trace: core::option::Option<(&std::path::Path, &nika_cli_host::run_settlement::TraceProof)>, error: core::option::Option<&nika_cli_host::run_settlement::SettlementError>) -> core::io::error::Result<()>
 pub fn nika_cli_host::run_settlement::write_run_settlement<T: serde_core::ser::Serialize>(writer: &mut impl core::io::write::Write, status: &str, outputs: &T, receipt: core::option::Option<nika_cli_host::run_settlement::LocalRunReceipt<'_>>) -> core::io::error::Result<()>
 pub mod nika_cli_host::source
 pub struct nika_cli_host::source::RunSource
@@ -2665,7 +2716,6 @@ impl<T> tracing::instrument::Instrument for nika_cli_host::wire::WireOptions
 impl<T> tracing::instrument::WithSubscriber for nika_cli_host::wire::WireOptions
 impl<T> typenum::type_operators::Same for nika_cli_host::wire::WireOptions
 pub type nika_cli_host::wire::WireOptions::Output = T
-impl<T> zvariant::optional::NoneValue for nika_cli_host::wire::WireOptions where T: core::default::Default
 pub type nika_cli_host::wire::WireOptions::NoneType = T
 pub fn nika_cli_host::wire::WireOptions::null_value() -> T
 pub fn nika_cli_host::wire::run(target: nika_cli_host::wire::WireTarget, dir: &str) -> nika_cli_host::output::VerbOutput

--- a/crates/nika-cli-host/public-api.txt
+++ b/crates/nika-cli-host/public-api.txt
@@ -167,6 +167,7 @@ impl<T> tracing::instrument::Instrument for nika_cli_host::clients_registry::Reg
 impl<T> tracing::instrument::WithSubscriber for nika_cli_host::clients_registry::RegistryCoverage
 impl<T> typenum::type_operators::Same for nika_cli_host::clients_registry::RegistryCoverage
 pub type nika_cli_host::clients_registry::RegistryCoverage::Output = T
+impl<T> zvariant::optional::NoneValue for nika_cli_host::clients_registry::RegistryCoverage where T: core::default::Default
 pub type nika_cli_host::clients_registry::RegistryCoverage::NoneType = T
 pub fn nika_cli_host::clients_registry::RegistryCoverage::null_value() -> T
 pub const nika_cli_host::clients_registry::PROBE_MECHANISMS: &[&str]
@@ -1737,6 +1738,7 @@ impl<T> tracing::instrument::Instrument for nika_cli_host::metrics::Facts
 impl<T> tracing::instrument::WithSubscriber for nika_cli_host::metrics::Facts
 impl<T> typenum::type_operators::Same for nika_cli_host::metrics::Facts
 pub type nika_cli_host::metrics::Facts::Output = T
+impl<T> zvariant::optional::NoneValue for nika_cli_host::metrics::Facts where T: core::default::Default
 pub type nika_cli_host::metrics::Facts::NoneType = T
 pub fn nika_cli_host::metrics::Facts::null_value() -> T
 pub fn nika_cli_host::metrics::record(path: &std::path::Path, event: nika_cli_host::metrics::EventKind, facts: nika_cli_host::metrics::Facts) -> core::io::error::Result<()>
@@ -2111,6 +2113,7 @@ impl<T> tracing::instrument::Instrument for nika_cli_host::probe::ImageProbe
 impl<T> tracing::instrument::WithSubscriber for nika_cli_host::probe::ImageProbe
 impl<T> typenum::type_operators::Same for nika_cli_host::probe::ImageProbe
 pub type nika_cli_host::probe::ImageProbe::Output = T
+impl<T> zvariant::optional::NoneValue for nika_cli_host::probe::ImageProbe where T: core::default::Default
 pub type nika_cli_host::probe::ImageProbe::NoneType = T
 pub fn nika_cli_host::probe::ImageProbe::null_value() -> T
 pub struct nika_cli_host::probe::KitProbe
@@ -2216,6 +2219,7 @@ impl<T> tracing::instrument::Instrument for nika_cli_host::probe::PricingProbe
 impl<T> tracing::instrument::WithSubscriber for nika_cli_host::probe::PricingProbe
 impl<T> typenum::type_operators::Same for nika_cli_host::probe::PricingProbe
 pub type nika_cli_host::probe::PricingProbe::Output = T
+impl<T> zvariant::optional::NoneValue for nika_cli_host::probe::PricingProbe where T: core::default::Default
 pub type nika_cli_host::probe::PricingProbe::NoneType = T
 pub fn nika_cli_host::probe::PricingProbe::null_value() -> T
 pub struct nika_cli_host::probe::Probe
@@ -2385,6 +2389,7 @@ impl<T> tracing::instrument::Instrument for nika_cli_host::probe::TtsProbe
 impl<T> tracing::instrument::WithSubscriber for nika_cli_host::probe::TtsProbe
 impl<T> typenum::type_operators::Same for nika_cli_host::probe::TtsProbe
 pub type nika_cli_host::probe::TtsProbe::Output = T
+impl<T> zvariant::optional::NoneValue for nika_cli_host::probe::TtsProbe where T: core::default::Default
 pub type nika_cli_host::probe::TtsProbe::NoneType = T
 pub fn nika_cli_host::probe::TtsProbe::null_value() -> T
 pub fn nika_cli_host::probe::access_probes_with_harness() -> alloc::vec::Vec<nika_providers::probe::ProviderProbe>
@@ -2716,6 +2721,7 @@ impl<T> tracing::instrument::Instrument for nika_cli_host::wire::WireOptions
 impl<T> tracing::instrument::WithSubscriber for nika_cli_host::wire::WireOptions
 impl<T> typenum::type_operators::Same for nika_cli_host::wire::WireOptions
 pub type nika_cli_host::wire::WireOptions::Output = T
+impl<T> zvariant::optional::NoneValue for nika_cli_host::wire::WireOptions where T: core::default::Default
 pub type nika_cli_host::wire::WireOptions::NoneType = T
 pub fn nika_cli_host::wire::WireOptions::null_value() -> T
 pub fn nika_cli_host::wire::run(target: nika_cli_host::wire::WireTarget, dir: &str) -> nika_cli_host::output::VerbOutput

--- a/crates/nika-cli-host/src/help_card.rs
+++ b/crates/nika-cli-host/src/help_card.rs
@@ -11,6 +11,15 @@ use std::path::Path;
 /// Clap `--help --all` footer · issue 1274: the only non-mock path.
 pub const AFTER_HELP: &str = "a REAL answer needs exactly one of { an API key · a signed-in harness seat (`--access`) · the Gear One pull (`nika model pull`) } — everything else is a mock rehearsal (the run says so out loud) · nika --help --all  the rest of the surface";
 
+/// `nika check --help` footer (#1404): the base exit contract, so CI
+/// can branch on the code alone. The house taxonomy (spec §4 · LOCKED):
+/// 0 the report holds · 1 a workflow ran and failed (`run` only) · 2 the
+/// FILE · 3 the ENVIRONMENT · 4 paused on a human gate (`run` only).
+pub const CHECK_EXITS: &str = "exit codes · 0 the report holds (clean) · 2 the FILE: a grammar refusal or findings (`--json` carries `kind` to tell them apart) · 3 the ENVIRONMENT: the file is missing or unreadable, a registry is unreachable, a flag is misused · never 1 or 4 (those are `run`'s: a failed workflow · a paused gate) · `--profile operational` folds risk ≥ High into 2";
+
+/// `nika test --help` footer (#1404): the golden test's exit ladder.
+pub const TEST_EXITS: &str = "exit codes · 0 the golden matches · 1 the mock run failed or the outputs drifted from the golden · 2 the FILE has findings (`check` dirty) · 3 no golden yet (`--update` writes one) or the file is missing";
+
 /// Human default help · B67 postcard, now naming the two first-run doors
 /// (`try` · `new`), glossing `permits`, and documenting isolation.
 #[must_use]

--- a/crates/nika-cli-host/src/run_settlement.rs
+++ b/crates/nika-cli-host/src/run_settlement.rs
@@ -28,6 +28,40 @@ pub fn sensitive_journey(report: &nika_check::CheckReport) -> bool {
     )
 }
 
+/// The failure a terminal `run_settled` frame carries (#1403): the
+/// first failed task's code, message and id, so the LAST line a machine
+/// reads is the whole verdict — a CI reader that does the natural thing
+/// (`json.loads(last_line)`) learned « failed » and nothing else, the
+/// cause living only on an earlier `task_failed` frame.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[non_exhaustive]
+pub struct SettlementError {
+    /// The refusal's code (`NIKA-BUILTIN-READ-001` · …).
+    pub code: String,
+    /// The refusal's message, as the task recorded it.
+    pub message: String,
+    /// The task that failed.
+    pub task: String,
+}
+
+/// The first failed task's error with its task id, in the runtime's
+/// stable record order — `None` when no task failed (a succeeded or
+/// paused run · a run that never started a task).
+#[must_use]
+pub fn settlement_error(outcome: &nika_runtime::RunOutcome) -> Option<SettlementError> {
+    outcome
+        .records
+        .iter()
+        .find(|(_, record)| record.status == nika_runtime::TaskStatus::Failure)
+        .and_then(|(task, record)| {
+            record.error.as_ref().map(|e| SettlementError {
+                code: e.code.clone(),
+                message: e.message.clone(),
+                task: task.clone(),
+            })
+        })
+}
+
 /// First failed task record, in the runtime's stable record order.
 #[must_use]
 pub fn first_failure(outcome: &nika_runtime::RunOutcome) -> Option<nika_runtime::TaskErrorRecord> {
@@ -121,6 +155,9 @@ struct RunSettlement<'a, T> {
     outputs: &'a T,
     #[serde(skip_serializing_if = "Option::is_none")]
     receipt: Option<LocalRunReceipt<'a>>,
+    /// The cause, when `status` is `failed` and a task failed (#1403).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<&'a SettlementError>,
 }
 
 /// Append exactly one terminal NDJSON document to a machine stream.
@@ -134,7 +171,21 @@ pub fn write_run_settlement<T: Serialize>(
     outputs: &T,
     receipt: Option<LocalRunReceipt<'_>>,
 ) -> std::io::Result<()> {
-    write_run_settlement_bound(writer, status, outputs, None, receipt)
+    write_run_settlement_bound(writer, status, outputs, None, receipt, None)
+}
+
+/// Append the terminal document of a FAILED run with its cause (#1403).
+///
+/// # Errors
+/// Returns the writer or JSON serialization error without changing the run's
+/// execution verdict.
+pub fn write_failed_run_settlement<T: Serialize>(
+    writer: &mut impl Write,
+    outputs: &T,
+    receipt: Option<LocalRunReceipt<'_>>,
+    error: Option<&SettlementError>,
+) -> std::io::Result<()> {
+    write_run_settlement_bound(writer, "failed", outputs, None, receipt, error)
 }
 
 fn write_run_settlement_bound<T: Serialize>(
@@ -143,6 +194,7 @@ fn write_run_settlement_bound<T: Serialize>(
     outputs: &T,
     execution: Option<nika_types::id::ExecutionId>,
     receipt: Option<LocalRunReceipt<'_>>,
+    error: Option<&SettlementError>,
 ) -> std::io::Result<()> {
     serde_json::to_writer(
         &mut *writer,
@@ -152,6 +204,7 @@ fn write_run_settlement_bound<T: Serialize>(
             execution,
             outputs,
             receipt,
+            error,
         },
     )
     .map_err(std::io::Error::from)?;
@@ -170,6 +223,7 @@ pub fn write_local_run_settlement<T: Serialize, W: Write>(
     execution: nika_types::id::ExecutionId,
     snapshot_digest: &str,
     trace: Option<(&Path, &TraceProof)>,
+    error: Option<&SettlementError>,
 ) -> std::io::Result<()> {
     let execution_id = execution.to_string();
     let trace_id = nika_types::id::TraceId::from(execution).to_string();
@@ -198,6 +252,9 @@ pub fn write_local_run_settlement<T: Serialize, W: Write>(
         execution: Some(execution),
         outputs,
         receipt,
+        // A cause rides only a FAILED frame: a paused or succeeded run
+        // has none to claim.
+        error: error.filter(|_| status == "failed"),
     })
 }
 
@@ -205,6 +262,35 @@ pub fn write_local_run_settlement<T: Serialize, W: Write>(
 mod tests {
     use super::*;
     use serde_json::json;
+
+    /// #1403 — the last line a machine reads is the whole verdict: a
+    /// failed settlement names the code, the message and the task; a
+    /// succeeded one carries no `error` key at all.
+    #[test]
+    fn a_failed_settlement_carries_its_cause_and_a_clean_one_does_not() {
+        let cause = SettlementError {
+            code: "NIKA-BUILTIN-READ-001".to_owned(),
+            message: "no such file: ./missing.md".to_owned(),
+            task: "brief".to_owned(),
+        };
+        let mut out = Vec::new();
+        write_failed_run_settlement(&mut out, &json!({"result": null}), None, Some(&cause))
+            .expect("writes");
+        let value: serde_json::Value = serde_json::from_slice(&out).expect("one document");
+        assert_eq!(value["kind"], "run_settled");
+        assert_eq!(value["status"], "failed");
+        assert_eq!(value["error"]["code"], "NIKA-BUILTIN-READ-001");
+        assert_eq!(value["error"]["message"], "no such file: ./missing.md");
+        assert_eq!(value["error"]["task"], "brief");
+
+        let mut clean = Vec::new();
+        write_run_settlement(&mut clean, "succeeded", &json!({"result": 1}), None).expect("writes");
+        let value: serde_json::Value = serde_json::from_slice(&clean).expect("one document");
+        assert!(
+            value.get("error").is_none(),
+            "no cause on a clean run: {value}"
+        );
+    }
 
     #[test]
     fn settlement_keeps_result_and_proof_planes_distinct() {
@@ -253,6 +339,7 @@ mod tests {
                 execution,
                 "snapshot",
                 None,
+                None,
             )
             .expect("settlement writes");
         }
@@ -282,6 +369,7 @@ mod tests {
                 execution,
                 "snapshot",
                 Some((Path::new(".nika/traces/exact.ndjson"), &proof)),
+                None,
             )
             .expect("settlement writes");
         }

--- a/crates/nika-cli/src/main.rs
+++ b/crates/nika-cli/src/main.rs
@@ -140,7 +140,7 @@ enum Command {
     Run(RunArgs),
     /// Golden test: run under the MOCK provider (offline · deterministic)
     /// and compare the typed `outputs:` against `<file>.golden.json`.
-    #[command(hide = true, display_order = 21)]
+    #[command(hide = true, display_order = 21, after_help = help_card::TEST_EXITS)]
     Test {
         /// Workflow file (`*.nika.yaml`).
         file: Option<String>,

--- a/crates/nika-cli/src/verbs/check/mod.rs
+++ b/crates/nika-cli/src/verbs/check/mod.rs
@@ -23,6 +23,7 @@ pub enum Profile {
 
 #[allow(clippy::struct_excessive_bools)]
 #[derive(clap::Args)]
+#[command(after_help = nika_cli_host::help_card::CHECK_EXITS)]
 pub struct CheckArgs {
     /// Workflow file(s), `-`, or `registry:owner/name[@version]`.
     #[arg(num_args = 0..)]

--- a/crates/nika-cli/src/verbs/check/tests.rs
+++ b/crates/nika-cli/src/verbs/check/tests.rs
@@ -810,3 +810,25 @@ fn models_rung_makes_no_claim_over_a_defaultless_run_time_model() {
 /// the exit code must agree (the review-swarm untested-branch gap).
 #[cfg(test)]
 mod verdict_profiles;
+
+/// #1404 — `check --help` carries its exit contract: CI branches on the
+/// code alone, and the FILE/ENVIRONMENT split is spoken (a missing file
+/// is 3, a grammar refusal or findings are 2).
+#[test]
+fn the_check_help_carries_the_exit_contract() {
+    use clap::Args as _;
+    let help = CheckArgs::augment_args(clap::Command::new("check"))
+        .render_long_help()
+        .to_string();
+    assert!(help.contains("exit codes"), "{help}");
+    assert!(
+        help.contains("0 the report holds")
+            && help.contains("2 the FILE")
+            && help.contains("3 the ENVIRONMENT"),
+        "the three classes check can exit with: {help}"
+    );
+    assert!(
+        help.contains("never 1 or 4"),
+        "the run-only classes are named as such: {help}"
+    );
+}

--- a/crates/nika-cli/src/verbs/run/mod.rs
+++ b/crates/nika-cli/src/verbs/run/mod.rs
@@ -1046,6 +1046,9 @@ async fn execute_json_lane(
         return RunVerdict::renderer_failed(trace_path, e.kind());
     }
     let trace_proof = surface.path.as_deref().zip(surface.proof.as_ref());
+    // #1403 — the terminal frame carries the first failure's code,
+    // message and task: the last line a CI reader parses is the verdict.
+    let cause = nika_cli_host::run_settlement::settlement_error(&outcome);
     if let Err(e) = nika_cli_host::run_settlement::write_local_run_settlement(
         &mut sink,
         (outcome.ok, outcome.paused.is_some()),
@@ -1053,6 +1056,7 @@ async fn execute_json_lane(
         identity.0,
         identity.1,
         trace_proof,
+        cause.as_ref(),
     ) {
         eprintln!("nika run: settlement write failed: {e}");
         return RunVerdict::renderer_failed(trace_path, e.kind());

--- a/crates/nika-trace/public-api.txt
+++ b/crates/nika-trace/public-api.txt
@@ -81,7 +81,6 @@ impl<T> tracing::instrument::Instrument for nika_trace::forecast::gather::Gather
 impl<T> tracing::instrument::WithSubscriber for nika_trace::forecast::gather::Gathered
 impl<T> typenum::type_operators::Same for nika_trace::forecast::gather::Gathered
 pub type nika_trace::forecast::gather::Gathered::Output = T
-impl<T> zvariant::optional::NoneValue for nika_trace::forecast::gather::Gathered where T: core::default::Default
 pub type nika_trace::forecast::gather::Gathered::NoneType = T
 pub fn nika_trace::forecast::gather::Gathered::null_value() -> T
 pub struct nika_trace::forecast::gather::RunSample
@@ -282,7 +281,6 @@ impl<T> tracing::instrument::Instrument for nika_trace::forecast::RunCensus
 impl<T> tracing::instrument::WithSubscriber for nika_trace::forecast::RunCensus
 impl<T> typenum::type_operators::Same for nika_trace::forecast::RunCensus
 pub type nika_trace::forecast::RunCensus::Output = T
-impl<T> zvariant::optional::NoneValue for nika_trace::forecast::RunCensus where T: core::default::Default
 pub type nika_trace::forecast::RunCensus::NoneType = T
 pub fn nika_trace::forecast::RunCensus::null_value() -> T
 pub struct nika_trace::forecast::TaskPrior
@@ -388,7 +386,6 @@ impl<T> tracing::instrument::Instrument for nika_trace::forecast::Window
 impl<T> tracing::instrument::WithSubscriber for nika_trace::forecast::Window
 impl<T> typenum::type_operators::Same for nika_trace::forecast::Window
 pub type nika_trace::forecast::Window::Output = T
-impl<T> zvariant::optional::NoneValue for nika_trace::forecast::Window where T: core::default::Default
 pub type nika_trace::forecast::Window::NoneType = T
 pub fn nika_trace::forecast::Window::null_value() -> T
 pub struct nika_trace::forecast::WorkflowIdentity
@@ -516,6 +513,7 @@ pub nika_trace::trace::action::TraceAction::Session::workflow: alloc::string::St
 pub nika_trace::trace::action::TraceAction::Show(nika_trace::trace::action::TraceArgs)
 pub nika_trace::trace::action::TraceAction::Verify
 pub nika_trace::trace::action::TraceAction::Verify::anchored: bool
+pub nika_trace::trace::action::TraceAction::Verify::json: bool
 pub nika_trace::trace::action::TraceAction::Verify::key: core::option::Option<std::path::PathBuf>
 pub nika_trace::trace::action::TraceAction::Verify::replay: core::option::Option<std::path::PathBuf>
 pub nika_trace::trace::action::TraceAction::Verify::sealed: bool
@@ -688,6 +686,7 @@ pub nika_trace::trace::TraceAction::Session::workflow: alloc::string::String
 pub nika_trace::trace::TraceAction::Show(nika_trace::trace::action::TraceArgs)
 pub nika_trace::trace::TraceAction::Verify
 pub nika_trace::trace::TraceAction::Verify::anchored: bool
+pub nika_trace::trace::TraceAction::Verify::json: bool
 pub nika_trace::trace::TraceAction::Verify::key: core::option::Option<std::path::PathBuf>
 pub nika_trace::trace::TraceAction::Verify::replay: core::option::Option<std::path::PathBuf>
 pub nika_trace::trace::TraceAction::Verify::sealed: bool
@@ -781,6 +780,7 @@ pub fn nika_trace::trace_reproduce::reproduce(recorded: &str, fresh: &str) -> ni
 pub mod nika_trace::trace_verify
 pub struct nika_trace::trace_verify::VerifyOptions
 pub nika_trace::trace_verify::VerifyOptions::anchored: bool
+pub nika_trace::trace_verify::VerifyOptions::json: bool
 pub nika_trace::trace_verify::VerifyOptions::key: core::option::Option<std::path::PathBuf>
 pub nika_trace::trace_verify::VerifyOptions::replay: core::option::Option<std::path::PathBuf>
 pub nika_trace::trace_verify::VerifyOptions::sealed: bool
@@ -824,9 +824,9 @@ impl<T> tracing::instrument::Instrument for nika_trace::trace_verify::VerifyOpti
 impl<T> tracing::instrument::WithSubscriber for nika_trace::trace_verify::VerifyOptions
 impl<T> typenum::type_operators::Same for nika_trace::trace_verify::VerifyOptions
 pub type nika_trace::trace_verify::VerifyOptions::Output = T
-impl<T> zvariant::optional::NoneValue for nika_trace::trace_verify::VerifyOptions where T: core::default::Default
 pub type nika_trace::trace_verify::VerifyOptions::NoneType = T
 pub fn nika_trace::trace_verify::VerifyOptions::null_value() -> T
+pub const nika_trace::trace_verify::VERIFY_VERSION: u32
 pub fn nika_trace::trace_verify::verify(trace: &str) -> nika_cli_host::output::VerbOutput
 pub fn nika_trace::trace_verify::verify_many(traces: &[std::path::PathBuf]) -> nika_cli_host::output::VerbOutput
 pub fn nika_trace::trace_verify::verify_many_with(traces: &[std::path::PathBuf], opts: &nika_trace::trace_verify::VerifyOptions) -> nika_cli_host::output::VerbOutput

--- a/crates/nika-trace/public-api.txt
+++ b/crates/nika-trace/public-api.txt
@@ -81,6 +81,7 @@ impl<T> tracing::instrument::Instrument for nika_trace::forecast::gather::Gather
 impl<T> tracing::instrument::WithSubscriber for nika_trace::forecast::gather::Gathered
 impl<T> typenum::type_operators::Same for nika_trace::forecast::gather::Gathered
 pub type nika_trace::forecast::gather::Gathered::Output = T
+impl<T> zvariant::optional::NoneValue for nika_trace::forecast::gather::Gathered where T: core::default::Default
 pub type nika_trace::forecast::gather::Gathered::NoneType = T
 pub fn nika_trace::forecast::gather::Gathered::null_value() -> T
 pub struct nika_trace::forecast::gather::RunSample
@@ -281,6 +282,7 @@ impl<T> tracing::instrument::Instrument for nika_trace::forecast::RunCensus
 impl<T> tracing::instrument::WithSubscriber for nika_trace::forecast::RunCensus
 impl<T> typenum::type_operators::Same for nika_trace::forecast::RunCensus
 pub type nika_trace::forecast::RunCensus::Output = T
+impl<T> zvariant::optional::NoneValue for nika_trace::forecast::RunCensus where T: core::default::Default
 pub type nika_trace::forecast::RunCensus::NoneType = T
 pub fn nika_trace::forecast::RunCensus::null_value() -> T
 pub struct nika_trace::forecast::TaskPrior
@@ -386,6 +388,7 @@ impl<T> tracing::instrument::Instrument for nika_trace::forecast::Window
 impl<T> tracing::instrument::WithSubscriber for nika_trace::forecast::Window
 impl<T> typenum::type_operators::Same for nika_trace::forecast::Window
 pub type nika_trace::forecast::Window::Output = T
+impl<T> zvariant::optional::NoneValue for nika_trace::forecast::Window where T: core::default::Default
 pub type nika_trace::forecast::Window::NoneType = T
 pub fn nika_trace::forecast::Window::null_value() -> T
 pub struct nika_trace::forecast::WorkflowIdentity
@@ -824,6 +827,7 @@ impl<T> tracing::instrument::Instrument for nika_trace::trace_verify::VerifyOpti
 impl<T> tracing::instrument::WithSubscriber for nika_trace::trace_verify::VerifyOptions
 impl<T> typenum::type_operators::Same for nika_trace::trace_verify::VerifyOptions
 pub type nika_trace::trace_verify::VerifyOptions::Output = T
+impl<T> zvariant::optional::NoneValue for nika_trace::trace_verify::VerifyOptions where T: core::default::Default
 pub type nika_trace::trace_verify::VerifyOptions::NoneType = T
 pub fn nika_trace::trace_verify::VerifyOptions::null_value() -> T
 pub const nika_trace::trace_verify::VERIFY_VERSION: u32

--- a/crates/nika-trace/src/dispatch.rs
+++ b/crates/nika-trace/src/dispatch.rs
@@ -108,6 +108,7 @@ pub fn trace_verb(
             anchored,
             sealed,
             replay,
+            json,
         } => verify_verb(
             traces,
             &trace_verify::VerifyOptions {
@@ -115,6 +116,7 @@ pub fn trace_verb(
                 anchored,
                 sealed,
                 replay,
+                json,
             },
         ),
         trace::TraceAction::Anchor {

--- a/crates/nika-trace/src/trace/action.rs
+++ b/crates/nika-trace/src/trace/action.rs
@@ -105,6 +105,11 @@ pub enum TraceAction {
         /// line) is exit 3 (a forged seal is exit 2 either way).
         #[arg(long)]
         sealed: bool,
+        /// One JSON document instead of the prose ladder (`verify_version`
+        /// 1 · `tier` · `exit` · `chain` · `seal` · `anchor` · `replay` ·
+        /// `lines`) — one document per line when several traces are named.
+        #[arg(long)]
+        json: bool,
         /// The REPLAYED tier: a FRESH journal of the same workflow to
         /// compare against (verify never re-executes).
         #[arg(long)]

--- a/crates/nika-trace/src/trace_verify.rs
+++ b/crates/nika-trace/src/trace_verify.rs
@@ -61,6 +61,10 @@ use nika_dap::anchor::tier;
 
 use super::VerbOutput;
 
+mod json;
+pub use json::VERIFY_VERSION;
+use json::{finish, ladder_doc};
+
 /// The verify surface's knobs — the tier ladder's explicit asks.
 #[derive(Clone, Debug, Default)]
 pub struct VerifyOptions {
@@ -76,6 +80,11 @@ pub struct VerifyOptions {
     pub sealed: bool,
     /// A fresh journal of the same workflow for the REPLAYED tier.
     pub replay: Option<PathBuf>,
+    /// One JSON document instead of the prose ladder (#1405 · `--json`):
+    /// the attained tier, the exit class, the chain facts, one object
+    /// per leg, and the ladder lines — so a CI gate on « at least
+    /// SEALED » is a field read, never a grep on prose.
+    pub json: bool,
 }
 
 /// `nika trace verify <trace>` — today's byte-stable surface: the
@@ -91,23 +100,11 @@ pub fn verify(trace: &str) -> VerbOutput {
 pub fn verify_with(trace: &str, opts: &VerifyOptions) -> VerbOutput {
     let candidates = match crate::seal::candidate_pubkeys(opts.key.as_deref()) {
         Ok(candidates) => candidates,
-        Err(e) => return VerbOutput::env(e),
+        Err(e) => return finish(opts, trace, "refused", VerbOutput::env(e)),
     };
-    // NEP-0012 law 1 · the journal is untrusted input: bound the total
-    // read BEFORE it happens (the per-line cap rides `chain.rs` · this
-    // is the whole-file half).
-    if let Ok(meta) = std::fs::metadata(trace)
-        && meta.len() > nika_dap::bounded::MAX_JOURNAL_BYTES as u64
-    {
-        return VerbOutput::env(format!(
-            "{trace}: {} bytes — over the journal bound ({} bytes · NEP-0012 law 1 · a file beyond it is not a run this engine produced)",
-            meta.len(),
-            nika_dap::bounded::MAX_JOURNAL_BYTES
-        ));
-    }
-    let raw = match std::fs::read_to_string(trace) {
+    let raw = match read_journal(trace, opts) {
         Ok(raw) => raw,
-        Err(e) => return VerbOutput::env(format!("cannot read {trace}: {e}")),
+        Err(refusal) => return refusal,
     };
     match walk(&raw) {
         Verdict::Intact { events, head, .. } => tiered(
@@ -142,32 +139,91 @@ pub fn verify_with(trace: &str, opts: &VerifyOptions) -> VerbOutput {
             recorded,
             computed,
             ..
-        } => VerbOutput::file(format!(
-            "BROKEN at line {line} — recorded chain {} · computed {}\n  every line from here on is unverified (edited, inserted, dropped or reordered)",
-            short(&recorded),
-            short(&computed),
-        )),
+        } => finish(
+            opts,
+            trace,
+            "broken",
+            VerbOutput::file(format!(
+                "BROKEN at line {line} — recorded chain {} · computed {}\n  every line from here on is unverified (edited, inserted, dropped or reordered)",
+                short(&recorded),
+                short(&computed),
+            )),
+        ),
         // F-P1 · the fortress line bound: beyond the verifier's bounds
         // is a FILE refusal (a 100 MB line is a DoS vector, never a
         // journal line — recognized, never partially read).
-        Verdict::LineOverLong { line, got, .. } => VerbOutput::file(format!(
-            "line {line} is {got} bytes — beyond the verifier's line bound ({} bytes)\n  a journal line is small (the seal's covers included); an oversized line is\n  the DoS class, refused before any parse (F-P1)",
-            nika_dap::chain::MAX_LINE_BYTES,
-        )),
-        Verdict::Unchained => VerbOutput::env(format!(
-            "unchained — {trace} predates the chain (pre-0.96 journal): nothing to verify, nothing to distrust"
-        )),
-        Verdict::Empty => VerbOutput::env(format!("{trace}: no events")),
-        Verdict::Unreadable { line, .. } => VerbOutput::env(format!(
-            "{trace}:{line}: not a journal — the line is not valid JSON"
-        )),
+        Verdict::LineOverLong { line, got, .. } => finish(
+            opts,
+            trace,
+            "line-over-long",
+            VerbOutput::file(format!(
+                "line {line} is {got} bytes — beyond the verifier's line bound ({} bytes)\n  a journal line is small (the seal's covers included); an oversized line is\n  the DoS class, refused before any parse (F-P1)",
+                nika_dap::chain::MAX_LINE_BYTES,
+            )),
+        ),
+        Verdict::Unchained => finish(
+            opts,
+            trace,
+            "unchained",
+            VerbOutput::env(format!(
+                "unchained — {trace} predates the chain (pre-0.96 journal): nothing to verify, nothing to distrust"
+            )),
+        ),
+        Verdict::Empty => finish(
+            opts,
+            trace,
+            "empty",
+            VerbOutput::env(format!("{trace}: no events")),
+        ),
+        Verdict::Unreadable { line, .. } => finish(
+            opts,
+            trace,
+            "unreadable",
+            VerbOutput::env(format!(
+                "{trace}:{line}: not a journal — the line is not valid JSON"
+            )),
+        ),
         // The verdict is #[non_exhaustive]: a NEWER forensics crate may
         // learn classes this CLI cannot render — refuse honestly,
         // never mis-render one.
-        _ => VerbOutput::env(format!(
-            "{trace}: unknown verdict class — the forensics library is newer than this CLI"
-        )),
+        _ => finish(
+            opts,
+            trace,
+            "unknown",
+            VerbOutput::env(format!(
+                "{trace}: unknown verdict class — the forensics library is newer than this CLI"
+            )),
+        ),
     }
+}
+
+/// The bounded read of one journal. NEP-0012 law 1 · the journal is
+/// untrusted input: bound the total read BEFORE it happens (the per-line
+/// cap rides `chain.rs` · this is the whole-file half). A refusal is
+/// already the verb's output (the `--json` envelope included).
+fn read_journal(trace: &str, opts: &VerifyOptions) -> Result<String, VerbOutput> {
+    if let Ok(meta) = std::fs::metadata(trace)
+        && meta.len() > nika_dap::bounded::MAX_JOURNAL_BYTES as u64
+    {
+        return Err(finish(
+            opts,
+            trace,
+            "refused",
+            VerbOutput::env(format!(
+                "{trace}: {} bytes — over the journal bound ({} bytes · NEP-0012 law 1 · a file beyond it is not a run this engine produced)",
+                meta.len(),
+                nika_dap::bounded::MAX_JOURNAL_BYTES
+            )),
+        ));
+    }
+    std::fs::read_to_string(trace).map_err(|e| {
+        finish(
+            opts,
+            trace,
+            "unreadable",
+            VerbOutput::env(format!("cannot read {trace}: {e}")),
+        )
+    })
 }
 
 /// The variadic form (`nika trace verify .nika/traces/*.ndjson` — the
@@ -189,6 +245,13 @@ pub fn verify_many_with(traces: &[std::path::PathBuf], opts: &VerifyOptions) -> 
     for path in traces {
         let resolved = super::trace::manage::resolve_store_handle(path);
         let out = verify_with(&resolved.to_string_lossy(), opts);
+        worst = worst.max(out.code);
+        // `--json`: one document per trace, one per line (NDJSON) — each
+        // already names its `trace`, so no prose header rides above it.
+        if opts.json {
+            blocks.push(format!("{}\n", out.text.trim_end()));
+            continue;
+        }
         let mut block = format!("{}\n", resolved.display());
         for line in out.text.lines() {
             block.push_str("  ");
@@ -196,10 +259,13 @@ pub fn verify_many_with(traces: &[std::path::PathBuf], opts: &VerifyOptions) -> 
             block.push('\n');
         }
         blocks.push(block);
-        worst = worst.max(out.code);
     }
     VerbOutput {
-        text: blocks.join("\n"),
+        text: if opts.json {
+            blocks.concat()
+        } else {
+            blocks.join("\n")
+        },
         code: worst,
     }
 }
@@ -291,7 +357,12 @@ fn tiered(
     // a plain « OK · chain intact ». Both readings pointed away from the
     // tampering; the class states itself here (the ladder lines carry why).
     if let tier::SealTier::Buried { .. } = report.seal {
-        return tampered_verdict(events, head, &report.lines);
+        return finish(
+            opts,
+            trace,
+            "buried-seal",
+            tampered_verdict(events, head, &report.lines),
+        );
     }
     let mut out = match headline {
         ChainHeadline::Torn => format!(
@@ -309,13 +380,11 @@ fn tiered(
             "INCOMPLETE — {events} events · chain intact · head {head}\n  the journal never reached a terminal frame (no workflow_completed · workflow_failed ·\n  workflow_paused · workflow_cancelled · run_sealed) — the run was killed or crashed:\n  the chain attests every complete line; the lifecycle end is unattested, a finding\n  the verifier carries (the dying run can attest nothing)"
         ),
     };
-    for line in &report.lines {
-        use std::fmt::Write as _;
-        let _ = write!(out, "\n{line}");
-    }
+    // Every ladder line is collected once: the prose appends them, the
+    // JSON projection carries them under `lines`.
+    let mut lines: Vec<String> = report.lines.clone();
     if let Some(finding) = witness_finding(raw) {
-        use std::fmt::Write as _;
-        let _ = write!(out, "\n{finding}");
+        lines.push(finding.to_owned());
     }
     // F-P18 · the cost-replay leg (NEP-0017 · la table de prix DANS le
     // pin): a SCOPED STATED VERDICT — it rides after the ladder and the
@@ -332,10 +401,7 @@ fn tiered(
             snapshot.source_sha256_16,
         ),
     );
-    for line in &leg.lines {
-        use std::fmt::Write as _;
-        let _ = write!(out, "\n{line}");
-    }
+    lines.extend(leg.lines.iter().cloned());
     let code = match report.exit {
         tier::TierExit::Ok => super::exit::OK,
         tier::TierExit::File => super::exit::FILE,
@@ -343,6 +409,19 @@ fn tiered(
         // an era answer (ENV), never a guessed forgery.
         _ => super::exit::ENV,
     };
+    if opts.json {
+        return VerbOutput {
+            text: format!(
+                "{}\n",
+                ladder_doc(trace, events, head, headline, &report, code, &lines)
+            ),
+            code,
+        };
+    }
+    for line in &lines {
+        use std::fmt::Write as _;
+        let _ = write!(out, "\n{line}");
+    }
     VerbOutput { text: out, code }
 }
 
@@ -531,6 +610,7 @@ mod tests {
 
     fn opts_with_key(key: std::path::PathBuf) -> VerifyOptions {
         VerifyOptions {
+            json: false,
             key: Some(key),
             ..VerifyOptions::default()
         }
@@ -823,6 +903,86 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
+    /// #1405 — `--json` projects the ladder the prose prints: the
+    /// attained tier as a field, the exit class, one object per leg, and
+    /// the lines. A CI gate on « at least SEALED » reads `tier`.
+    #[test]
+    fn verify_json_projects_the_ladder_of_the_frozen_fixture() {
+        let dir = std::env::temp_dir().join(format!("nika-a4-json-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("dir");
+        let trace = dir.join("fixture.ndjson");
+        std::fs::write(&trace, FIXTURE_JOURNAL).expect("journal");
+        std::fs::write(
+            crate::anchor::sidecar_path(&trace.to_string_lossy()),
+            FIXTURE_SIDECAR,
+        )
+        .expect("sidecar");
+        let key = dir.join("run.pub");
+        std::fs::write(&key, FIXTURE_PUBLIC_BOX).expect("key");
+        let mut opts = opts_with_key(key);
+        opts.json = true;
+
+        let out = verify_with(&trace.to_string_lossy(), &opts);
+        assert_eq!(out.code, super::super::exit::OK, "{}", out.text);
+        let doc: serde_json::Value = serde_json::from_str(out.text.trim()).expect("one document");
+        assert_eq!(doc["verify_version"], 1);
+        assert_eq!(doc["tier"], "anchored", "{doc}");
+        assert_eq!(doc["exit"], 0);
+        assert_eq!(doc["chain"]["headline"], "intact");
+        assert_eq!(doc["seal"]["tier"], "sealed");
+        assert_eq!(doc["seal"]["key_id"], "1e772a7b922d7be3");
+        assert_eq!(doc["anchor"]["tier"], "anchored");
+        assert_eq!(doc["anchor"]["log_index"], "34612959");
+        assert_eq!(doc["replay"]["tier"], "not-asked");
+        assert!(
+            doc["lines"].as_array().is_some_and(|l| l
+                .iter()
+                .any(|x| { x.as_str().is_some_and(|s| s.starts_with("SEALED")) })),
+            "the prose ladder rides `lines`: {doc}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// #1405 — the non-ladder verdicts project too: a broken chain is
+    /// `tier: broken` at the FILE exit, and several traces are NDJSON.
+    #[test]
+    fn verify_json_names_a_broken_chain_and_streams_many() {
+        let intact = stage(
+            "json-intact.ndjson",
+            &chained(&["workflow_started", "workflow_completed"]),
+        );
+        let mut tampered_raw =
+            chained(&["workflow_started", "task_completed", "workflow_completed"]);
+        tampered_raw = tampered_raw.replacen("task_completed", "task_failedxx", 1);
+        let tampered = stage("json-tampered.ndjson", &tampered_raw);
+        let opts = VerifyOptions {
+            json: true,
+            ..VerifyOptions::default()
+        };
+        let one = verify_with(&tampered.to_string_lossy(), &opts);
+        assert_eq!(one.code, super::super::exit::FILE);
+        let doc: serde_json::Value = serde_json::from_str(one.text.trim()).expect("document");
+        assert_eq!(doc["tier"], "broken", "{doc}");
+        assert_eq!(doc["exit"], 2);
+        assert!(
+            doc["lines"][0]
+                .as_str()
+                .is_some_and(|s| s.starts_with("BROKEN at line")),
+            "{doc}"
+        );
+
+        let many = verify_many_with(&[intact, tampered], &opts);
+        assert_eq!(many.code, super::super::exit::FILE);
+        let docs: Vec<serde_json::Value> = many
+            .text
+            .lines()
+            .map(|l| serde_json::from_str(l).expect("each line is a document"))
+            .collect();
+        assert_eq!(docs.len(), 2, "one document per trace: {}", many.text);
+        assert_eq!(docs[0]["tier"], "ok");
+        assert_eq!(docs[1]["tier"], "broken");
+    }
+
     /// Tier demotion honesty: a forged anchor over a GOOD seal reports
     /// SEALED, never ANCHORED — and is the FILE (forgery) class.
     #[test]
@@ -857,6 +1017,7 @@ mod tests {
         let trace = stage("required.ndjson", &journal);
         let key = stage_key("required.pub", &pk_box);
         let opts = VerifyOptions {
+            json: false,
             key: Some(key.clone()),
             anchored: true,
             sealed: false,
@@ -879,6 +1040,7 @@ mod tests {
         let journal = chained_with(&[("workflow_completed", &[])]);
         let trace = stage("unsealed-required.ndjson", &journal);
         let opts = VerifyOptions {
+            json: false,
             key: None,
             anchored: true,
             sealed: false,
@@ -902,6 +1064,7 @@ mod tests {
         let key = dir.join("run.pub");
         std::fs::write(&key, FIXTURE_PUBLIC_BOX).expect("key");
         let opts = VerifyOptions {
+            json: false,
             key: Some(key),
             anchored: false,
             sealed: false,
@@ -1229,6 +1392,7 @@ mod tests {
         let journal = chained_with(&[("workflow_completed", &[])]);
         let trace = stage("unsealed-seal-required.ndjson", &journal);
         let opts = VerifyOptions {
+            json: false,
             key: None,
             anchored: false,
             sealed: true,
@@ -1250,6 +1414,7 @@ mod tests {
         let trace = stage("sealed-required.ndjson", &journal);
         let key = stage_key("sealed-required.pub", &pk_box);
         let opts = VerifyOptions {
+            json: false,
             key: Some(key.clone()),
             anchored: false,
             sealed: true,

--- a/crates/nika-trace/src/trace_verify/json.rs
+++ b/crates/nika-trace/src/trace_verify/json.rs
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! `nika trace verify --json` (#1405) — the machine projection of the
+//! tier ladder: one document per trace, `verify_version` 1, additive.
+//! Split from `trace_verify.rs` at the 1500-line file wall.
+
+use nika_dap::anchor::tier;
+
+use super::{ChainHeadline, VerbOutput, VerifyOptions};
+
+/// The machine projection's schema version (additive, like `check --json`).
+pub const VERIFY_VERSION: u32 = 1;
+
+/// Wrap a non-ladder verdict (a broken chain · an unchained or empty
+/// journal · a refused read) as the one JSON document when `--json` was
+/// asked; the prose rides `lines`, the class rides `tier`.
+pub(super) fn finish(opts: &VerifyOptions, trace: &str, tier: &str, out: VerbOutput) -> VerbOutput {
+    if !opts.json {
+        return out;
+    }
+    let lines: Vec<&str> = out.text.lines().collect();
+    let doc = serde_json::json!({
+        "verify_version": VERIFY_VERSION,
+        "trace": trace,
+        "tier": tier,
+        "exit": out.code,
+        "lines": lines,
+    });
+    VerbOutput {
+        text: format!("{doc}\n"),
+        code: out.code,
+    }
+}
+
+/// The ladder's JSON projection: `tier` is the attained tier (the word
+/// the prose ladder prints in capitals), `exit` the class it maps to,
+/// one object per leg with the facts the prose carries.
+pub(super) fn ladder_doc(
+    trace: &str,
+    events: usize,
+    head: &str,
+    headline: ChainHeadline,
+    report: &tier::TierReport,
+    code: u8,
+    lines: &[String],
+) -> String {
+    let seal = match &report.seal {
+        tier::SealTier::Unsealed => serde_json::json!({"tier": "unsealed"}),
+        tier::SealTier::Sealed(v) => {
+            serde_json::json!({"tier": "sealed", "key_id": v.key_id, "source": v.source})
+        }
+        tier::SealTier::Forged(reason) => serde_json::json!({"tier": "forged", "reason": reason}),
+        tier::SealTier::Buried { line, trailing } => {
+            serde_json::json!({"tier": "buried", "line": line, "trailing": trailing})
+        }
+        tier::SealTier::Unattributable(reason) => {
+            serde_json::json!({"tier": "unattributable", "reason": reason})
+        }
+    };
+    let anchor = match &report.anchor {
+        tier::AnchorTier::NotPresent => serde_json::json!({"tier": "not-present"}),
+        tier::AnchorTier::Required => serde_json::json!({"tier": "required"}),
+        tier::AnchorTier::Anchored(a) => serde_json::json!({
+            "tier": "anchored",
+            "log_index": a.log_index,
+            "tree_size": a.tree_size,
+            "gen_time": a.gen_time,
+        }),
+        tier::AnchorTier::Gap(reason) => serde_json::json!({"tier": "gap", "reason": reason}),
+    };
+    let replay = match &report.replay {
+        tier::ReplayTier::NotAsked => serde_json::json!({"tier": "not-asked"}),
+        tier::ReplayTier::Replayed => serde_json::json!({"tier": "replayed"}),
+        tier::ReplayTier::Diverged(reason) => {
+            serde_json::json!({"tier": "diverged", "reason": reason})
+        }
+        tier::ReplayTier::NotAttempted(reason) => {
+            serde_json::json!({"tier": "not-attempted", "reason": reason})
+        }
+        _ => serde_json::json!({"tier": "unknown"}),
+    };
+    let attained = match report.attained {
+        tier::AttainedTier::Ok => "ok",
+        tier::AttainedTier::Sealed => "sealed",
+        tier::AttainedTier::Anchored => "anchored",
+        tier::AttainedTier::Replayed => "replayed",
+        _ => "unknown",
+    };
+    let headline = match headline {
+        ChainHeadline::Intact => "intact",
+        ChainHeadline::Torn => "torn",
+        ChainHeadline::Incomplete => "incomplete",
+    };
+    serde_json::json!({
+        "verify_version": VERIFY_VERSION,
+        "trace": trace,
+        "tier": attained,
+        "exit": code,
+        "chain": {"events": events, "head": head, "headline": headline},
+        "seal": seal,
+        "anchor": anchor,
+        "replay": replay,
+        "lines": lines,
+    })
+    .to_string()
+}


### PR DESCRIPTION
Closes #1403
Closes #1404
Closes #1405

Three CI-engineer findings from the gauntlet, one batch.

- **#1403** · the terminal `run_settled` frame of a failed `run --json` carries `error: { code, message, task }` (the first failed task), so the last line a machine reads is the verdict; a succeeded or paused run carries no `error` key.
- **#1404** · `check --help` and `test --help` carry their exit-code table: the house taxonomy spoken on the verb (a missing file is 3, a grammar refusal or findings are 2, never 1 or 4 on `check`).
- **#1405** · `trace verify --json`: one JSON document per trace (`verify_version` 1 · `tier` · `exit` · `chain` · `seal` · `anchor` · `replay` · `lines`), NDJSON over several traces, so a CI gate on « at least SEALED » reads a field instead of grepping prose.

## Proof

Unit tests in `nika-cli-host` (the settlement with and without a cause), `nika-cli` (the help footer), `nika-trace` (the ladder of the frozen fixture as JSON · a broken chain · two traces as NDJSON).

proven_by: rust

🤖 Generated with [Claude Code](https://claude.com/claude-code)