### PR TITLE
fix(providers): one provider count on every surface · moonshot wired

### DIFF
--- a/changelog.d/1398.fixed.md
+++ b/changelog.d/1398.fixed.md
@@ -1,0 +1,6 @@
+- **One provider count, every surface.** The card, the catalog header and
+  the check refusal now speak the same wired facet, split the same way
+  (« 16 wired in this build (5 local · 11 cloud · plus mock) ») instead of
+  15, 15 and 16 for one binary. `moonshot` (Kimi K2 · K2.5, the international
+  endpoint, `MOONSHOT_API_KEY`) is wired, so the canon's seventeen and the
+  binary's seventeen are the same list.

--- a/crates/nika-cli-host/public-api.txt
+++ b/crates/nika-cli-host/public-api.txt
@@ -1336,10 +1336,12 @@ pub mod nika_cli_host::machine_truth
 pub struct nika_cli_host::machine_truth::MachineTruth
 pub nika_cli_host::machine_truth::MachineTruth::catalog_entries: usize
 pub nika_cli_host::machine_truth::MachineTruth::cloud_key_slots: usize
+pub nika_cli_host::machine_truth::MachineTruth::local: usize
 pub nika_cli_host::machine_truth::MachineTruth::wired: usize
 impl nika_cli_host::machine_truth::MachineTruth
 pub fn nika_cli_host::machine_truth::MachineTruth::from_probes(probes: &[nika_providers::probe::ProviderProbe]) -> Self
 pub fn nika_cli_host::machine_truth::MachineTruth::from_registry(registry: &nika_providers::registry::ProviderRegistry) -> Self
+pub fn nika_cli_host::machine_truth::MachineTruth::wired_facet(&self) -> alloc::string::String
 impl core::clone::Clone for nika_cli_host::machine_truth::MachineTruth
 pub fn nika_cli_host::machine_truth::MachineTruth::clone(&self) -> nika_cli_host::machine_truth::MachineTruth
 impl core::cmp::Eq for nika_cli_host::machine_truth::MachineTruth

--- a/crates/nika-cli-host/src/catalog.rs
+++ b/crates/nika-cli-host/src/catalog.rs
@@ -100,8 +100,8 @@ fn listing_header(theme: Theme, truth: MachineTruth, models: usize) -> String {
     let facets = theme.paint(
         Role::Dim,
         &format!(
-            "  {wired} wired in this build · {slots} take a key — nika doctor shows their state",
-            wired = truth.wired,
+            "  {facet} · {slots} take a key — nika doctor shows their state",
+            facet = truth.wired_facet(),
             slots = truth.cloud_key_slots,
         ),
     );
@@ -403,6 +403,7 @@ mod tests {
             catalog_entries: export.providers.len(),
             wired: 7,
             cloud_key_slots: 3,
+            local: 4,
         }
     }
 
@@ -421,8 +422,8 @@ mod tests {
             "the header states the model count",
         );
         assert!(
-            text.contains("7 wired in this build"),
-            "the wired facet is named under the header:\n{text}",
+            text.contains("7 wired in this build (4 local · 3 cloud · plus mock)"),
+            "the wired facet is named under the header, split included:\n{text}",
         );
         assert!(
             text.contains("3 take a key"),

--- a/crates/nika-cli-host/src/machine_truth.rs
+++ b/crates/nika-cli-host/src/machine_truth.rs
@@ -36,6 +36,8 @@ pub struct MachineTruth {
     /// The wired providers that take an API key — the doctor's cloud
     /// rows, the welcome's « of N clouds » denominator.
     pub cloud_key_slots: usize,
+    /// The keyless local servers among the wired (#1398 · the facet's split).
+    pub local: usize,
 }
 
 impl MachineTruth {
@@ -47,7 +49,15 @@ impl MachineTruth {
             catalog_entries: nika_catalog::all_providers().len(),
             wired: probes.len(),
             cloud_key_slots: probes.iter().filter(|p| p.requires_key).count(),
+            local: probes.iter().filter(|p| !p.requires_key).count(),
         }
+    }
+
+    /// The one wired-facet sentence (#1398): the same words, the same
+    /// numbers, on the card, the catalog header and the check refusal.
+    #[must_use]
+    pub fn wired_facet(&self) -> String {
+        nika_providers::wired_facet(self.wired, self.local)
     }
 
     /// Derive from a registry — the catalog verb's path (it composes

--- a/crates/nika-cli-host/src/welcome.rs
+++ b/crates/nika-cli-host/src/welcome.rs
@@ -844,6 +844,14 @@ fn binary_section(
         counts.examples,
         counts.templates
     );
+    // #1398 — the facet's split on its own line (the card keeps its
+    // eighty columns): the same sentence the catalog header and the
+    // check refusal print, so the three surfaces cannot disagree.
+    let _ = writeln!(
+        s,
+        "  {}",
+        nika_providers::wired_facet(counts.locals + counts.clouds, counts.locals)
+    );
     let _ = writeln!(s);
     // The stranger's moment is gated on a COMPLETE zero (P0-4) — a
     // partial scan cannot know the workspace is empty. Chat-only holds

--- a/crates/nika-cli/tests/catalog_family.rs
+++ b/crates/nika-cli/tests/catalog_family.rs
@@ -265,10 +265,12 @@ fn the_refusal_names_the_runnable_count_and_where_to_get_the_list() {
         "the refusal names the provider the user typed: {}",
         out.text
     );
-    let runnable = nika_providers::CANONICAL_IDS.len();
+    // #1398 — the refusal speaks the ONE wired facet every surface prints
+    // (the card · the catalog header · here), split the same way.
+    let facet = nika_providers::wired_facet_of_this_build();
     assert!(
-        out.text.contains(&format!("{runnable} runnable")),
-        "the refusal counts the seats this binary actually carries ({runnable}): {}",
+        out.text.contains(&facet),
+        "the refusal counts the seats this binary actually carries ({facet}): {}",
         out.text
     );
     assert!(

--- a/crates/nika-cli/tests/catalog_family.rs
+++ b/crates/nika-cli/tests/catalog_family.rs
@@ -97,7 +97,6 @@ const UNWIRED: &[&str] = &[
     "fireworks",
     "hyperbolic",
     "minimax",
-    "moonshot",
     "native",
     "perplexity",
     "qwen",

--- a/crates/nika-cli/tests/machine_truth_surfaces.rs
+++ b/crates/nika-cli/tests/machine_truth_surfaces.rs
@@ -133,7 +133,7 @@ fn check_refusal_speaks_the_wired_facet() {
     let facet = line
         .split("wired in this build")
         .next()
-        .and_then(|head| head.rsplit(|c: char| !c.is_ascii_digit()).next())
+        .and_then(|head| head.trim_end().rsplit(|c: char| !c.is_ascii_digit()).next())
         .and_then(|digits| digits.parse::<usize>().ok());
     assert_eq!(
         facet,

--- a/crates/nika-cli/tests/machine_truth_surfaces.rs
+++ b/crates/nika-cli/tests/machine_truth_surfaces.rs
@@ -112,6 +112,36 @@ fn welcome_speaks_the_wired_facet() {
     );
 }
 
+/// #1398 — the check refusal for a cataloged-but-unwired provider spoke
+/// its own count (« 16 runnable ») while the card said 15 and the canon
+/// 17. It now speaks the wired facet, the same number as the card and
+/// the catalog header, split the same way.
+#[test]
+fn check_refusal_speaks_the_wired_facet() {
+    let scratch = scratch_dir("mt-check");
+    let file = scratch.join("azure.nika.yaml");
+    std::fs::write(
+        &file,
+        "nika: azure-seat\nmodel: azure/gpt-4o\npermits: {}\ntasks:\n  t:\n    infer: { prompt: hi, max_tokens: 5 }\n",
+    )
+    .expect("plant");
+    let text = surface(&scratch, &["check", "azure.nika.yaml"]);
+    let line = text
+        .lines()
+        .find(|l| l.contains("wired in this build"))
+        .expect("the refusal speaks the wired facet");
+    let facet = line
+        .split("wired in this build")
+        .next()
+        .and_then(|head| head.rsplit(|c: char| !c.is_ascii_digit()).next())
+        .and_then(|digits| digits.parse::<usize>().ok());
+    assert_eq!(
+        facet,
+        Some(expected().wired),
+        "the refusal's number IS the wired facet the card prints. Line: {line}"
+    );
+}
+
 #[test]
 fn doctor_rows_are_the_wired_and_key_slot_facets() {
     let scratch = scratch_dir("mt-doctor");

--- a/crates/nika-providers/public-api.txt
+++ b/crates/nika-providers/public-api.txt
@@ -512,7 +512,7 @@ impl<T> core::convert::From<T> for nika_providers::profile::ResolveRefusal
 pub fn nika_providers::profile::ResolveRefusal::from(t: T) -> T
 impl<T> nika_error::traits::AsAny for nika_providers::profile::ResolveRefusal where T: 'static
 pub fn nika_providers::profile::ResolveRefusal::as_any(&self) -> &(dyn core::any::Any + 'static)
-pub const nika_providers::profile::CANONICAL_IDS: [&str; 16]
+pub const nika_providers::profile::CANONICAL_IDS: [&str; 17]
 pub const nika_providers::profile::PREFIX_REFUSAL_CODE: &str
 pub fn nika_providers::profile::access_class_for(provider: &str) -> nika_types::access::AccessClass
 pub fn nika_providers::profile::canonical_provider(id: &str) -> &str
@@ -520,6 +520,8 @@ pub fn nika_providers::profile::catalog_warning(model: &str) -> core::option::Op
 pub fn nika_providers::profile::resolve_refusal(model: &str) -> core::option::Option<nika_providers::profile::ResolveRefusal>
 pub fn nika_providers::profile::seed() -> alloc::vec::Vec<nika_providers::profile::Profile>
 pub fn nika_providers::profile::server_backed_local(provider: &str) -> bool
+pub fn nika_providers::profile::wired_facet(wired: usize, local: usize) -> alloc::string::String
+pub fn nika_providers::profile::wired_facet_of_this_build() -> alloc::string::String
 pub mod nika_providers::registry
 pub struct nika_providers::registry::NoHttp
 impl core::clone::Clone for nika_providers::registry::NoHttp
@@ -1357,7 +1359,7 @@ impl<T> core::convert::From<T> for nika_providers::census::SeatFact
 pub fn nika_providers::census::SeatFact::from(t: T) -> T
 impl<T> nika_error::traits::AsAny for nika_providers::census::SeatFact where T: 'static
 pub fn nika_providers::census::SeatFact::as_any(&self) -> &(dyn core::any::Any + 'static)
-pub const nika_providers::CANONICAL_IDS: [&str; 16]
+pub const nika_providers::CANONICAL_IDS: [&str; 17]
 pub const nika_providers::PREFIX_REFUSAL_CODE: &str
 pub fn nika_providers::access_plan_map(models: &[alloc::string::String], probes: &[nika_providers::probe::ProviderProbe], pin: core::option::Option<&str>) -> alloc::collections::btree::map::BTreeMap<alloc::string::String, nika_types::access::AccessPlan>
 pub fn nika_providers::candidates_for(probes: &[nika_providers::probe::ProviderProbe], provider: &str) -> alloc::vec::Vec<nika_providers::resolve_access::AccessCandidate>
@@ -1373,3 +1375,5 @@ pub fn nika_providers::resolve_access(model: &str, candidates: &[nika_providers:
 pub fn nika_providers::resolve_refusal(model: &str) -> core::option::Option<nika_providers::profile::ResolveRefusal>
 pub fn nika_providers::seed() -> alloc::vec::Vec<nika_providers::profile::Profile>
 pub fn nika_providers::server_backed_local(provider: &str) -> bool
+pub fn nika_providers::wired_facet(wired: usize, local: usize) -> alloc::string::String
+pub fn nika_providers::wired_facet_of_this_build() -> alloc::string::String

--- a/crates/nika-providers/src/lib.rs
+++ b/crates/nika-providers/src/lib.rs
@@ -55,7 +55,8 @@ pub use census::{AccessCensus, AccessPath, SeatFact};
 pub use probe::{KeyAuth, classify_http_status, classify_key_value};
 pub use profile::{
     CANONICAL_IDS, PREFIX_REFUSAL_CODE, Profile, ResolveRefusal, WireFormat, canonical_provider,
-    catalog_warning, resolve_refusal, seed, server_backed_local,
+    catalog_warning, resolve_refusal, seed, server_backed_local, wired_facet,
+    wired_facet_of_this_build,
 };
 pub use registry::{NoHttp, ProviderRegistry, ProvidersConfig, ResolvedProvider};
 #[cfg(feature = "access-harness")]

--- a/crates/nika-providers/src/profile.rs
+++ b/crates/nika-providers/src/profile.rs
@@ -162,8 +162,8 @@ impl Profile {
     }
 }
 
-/// The canonical provider ids, in canon order (10 cloud · 5 local · 1 test).
-pub const CANONICAL_IDS: [&str; 16] = [
+/// The canonical provider ids, in canon order (11 cloud · 5 local · 1 test).
+pub const CANONICAL_IDS: [&str; 17] = [
     "anthropic",
     "openai",
     "gemini",
@@ -174,6 +174,7 @@ pub const CANONICAL_IDS: [&str; 16] = [
     "openrouter",
     "huggingface",
     "nvidia",
+    "moonshot",
     "ollama",
     "lmstudio",
     "llamacpp",
@@ -277,9 +278,9 @@ pub fn resolve_refusal(model: &str) -> Option<ResolveRefusal> {
                 ),
                 None => format!(
                     "`{model}` is a bare model id — the contract is `<provider>/<model>` \
-                     (pick the provider that serves it; `nika catalog` names the \
-                     {} runnable providers under LOCAL and CLOUD)",
-                    CANONICAL_IDS.len()
+                     (pick the provider that serves it; `nika catalog` names them under \
+                     LOCAL and CLOUD — {})",
+                    wired_facet_of_this_build()
                 ),
             };
             Some(ResolveRefusal::new(why).with_code(PREFIX_REFUSAL_CODE))
@@ -305,15 +306,15 @@ pub fn resolve_refusal(model: &str) -> Option<ResolveRefusal> {
                 .unwrap_or_default();
             let why = format!(
                 "provider `{provider}` does not resolve in THIS binary \
-                 ({} runnable — `nika catalog` names them under LOCAL and \
+                 ({} — `nika catalog` names them under LOCAL and \
                  CLOUD, this one under CATALOG ONLY); a cataloged vendor \
                  is not a runnable one{guess}",
-                CANONICAL_IDS.len()
+                wired_facet_of_this_build()
             );
             let mut refusal = ResolveRefusal::new(why);
             // Spec claim: the prefix is not a known vendor at all.
             // Engine-local: the vendor is cataloged but this binary
-            // cannot drive it (azure · moonshot-until-wired).
+            // cannot drive it (azure).
             if nika_catalog::find_provider(provider).is_none() {
                 refusal = refusal.with_code(PREFIX_REFUSAL_CODE);
             }
@@ -447,7 +448,7 @@ fn pricing_provider_matches(row_provider: &str, query: &str) -> bool {
 /// gemini's `base_url` is a STEM (`…/v1beta`) — the s8.6 adapter appends
 /// `/models/{model}:generateContent` per request (unlike the other wires,
 /// whose `base_url` is the complete endpoint).
-const CATALOG_WIRED: [(&str, WireFormat, &str); 11] = [
+const CATALOG_WIRED: [(&str, WireFormat, &str); 12] = [
     (
         "anthropic",
         WireFormat::Anthropic,
@@ -506,8 +507,38 @@ const CATALOG_WIRED: [(&str, WireFormat, &str); 11] = [
         WireFormat::OpenAiCompat,
         "https://integrate.api.nvidia.com/v1/chat/completions",
     ),
+    // moonshot · Kimi K2 / K2.5 over the international endpoint
+    // (api.moonshot.ai · openai-chat dialect · `MOONSHOT_API_KEY` per the
+    // catalog row). Canonical since the 17-provider canon (#1398: the
+    // canon listed it, the binary refused it as CATALOG ONLY, and three
+    // surfaces printed three provider counts).
+    (
+        "moonshot",
+        WireFormat::OpenAiCompat,
+        "https://api.moonshot.ai/v1/chat/completions",
+    ),
     ("mock", WireFormat::Mock, ""),
 ];
+
+/// ONE sentence for the wired facet, every surface (#1398 — the card said
+/// 15, check said 16, the catalog header 15, the canon 17): `wired` is
+/// what this build can drive without the test lane, `local` the keyless
+/// servers, the cloud count derived, and `mock` named as the plus-one.
+#[must_use]
+pub fn wired_facet(wired: usize, local: usize) -> String {
+    format!(
+        "{wired} wired in this build ({local} local · {} cloud · plus mock)",
+        wired.saturating_sub(local)
+    )
+}
+
+/// The wired facet of THIS build from the canonical table alone (no
+/// probes): the same numbers the registry-derived probes carry, by
+/// construction — both read the tables above.
+#[must_use]
+pub fn wired_facet_of_this_build() -> String {
+    wired_facet(CANONICAL_IDS.len().saturating_sub(1), LOCAL.len())
+}
 
 /// The 5 local OpenAI-compatible servers — endpoints and keyless-ness are
 /// const RUNTIME facts (loopback defaults · operator-overridable); their
@@ -524,10 +555,10 @@ const LOCAL: [(&str, &str); 5] = [
     ("vllm", "http://127.0.0.1:8000/v1/chat/completions"),
 ];
 
-/// Build the canonical 16 profiles (catalog-joined where rows exist).
+/// Build the canonical 17 profiles (catalog-joined where rows exist).
 #[must_use]
 pub fn seed() -> Vec<Profile> {
-    let mut out = Vec::with_capacity(16);
+    let mut out = Vec::with_capacity(CANONICAL_IDS.len());
     for (id, wire, base_url) in CATALOG_WIRED {
         let catalog = nika_catalog::find_provider(id);
         out.push(Profile {
@@ -559,7 +590,14 @@ mod tests {
     fn resolve_refusal_names_the_two_classes_and_clears_the_runnable() {
         // bare id — teaches the contract
         let bare = resolve_refusal("gpt-5-turbo").expect("bare id refused");
-        assert!(bare.why.contains("bare model id") && bare.why.contains("16 runnable"));
+        assert!(
+            bare.why.contains("bare model id")
+                && bare
+                    .why
+                    .contains("16 wired in this build (5 local · 11 cloud · plus mock)"),
+            "{}",
+            bare.why
+        );
         // cataloged-but-unresolvable provider — the azure class
         let azure = resolve_refusal("azure/gpt-4o").expect("azure refused");
         assert!(azure.why.contains("`azure`") && azure.why.contains("not a runnable one"));
@@ -708,9 +746,19 @@ mod tests {
     use super::*;
 
     #[test]
-    fn seed_yields_the_canonical_fourteen() {
+    fn seed_yields_the_canonical_seventeen() {
         let profiles = seed();
-        assert_eq!(profiles.len(), 16);
+        assert_eq!(
+            profiles.len(),
+            17,
+            "11 cloud · 5 local · mock (#1398 wired moonshot)"
+        );
+        assert!(
+            profiles
+                .iter()
+                .any(|p| p.id == "moonshot" && p.requires_key),
+            "moonshot is a keyed cloud seat"
+        );
         let mut ids: Vec<&str> = profiles.iter().map(|p| p.id).collect();
         ids.sort_unstable();
         let mut canon = CANONICAL_IDS.to_vec();

--- a/crates/nika-providers/src/registry.rs
+++ b/crates/nika-providers/src/registry.rs
@@ -351,9 +351,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn profiles_view_exposes_the_canonical_fourteen() {
+    async fn profiles_view_exposes_the_canonical_seventeen() {
         let reg = ProviderRegistry::new(Arc::new(NoHttp), hermetic());
-        assert_eq!(reg.profiles().len(), 16);
+        assert_eq!(reg.profiles().len(), 17);
     }
 
     #[test]

--- a/crates/nika-providers/src/wire/mod.rs
+++ b/crates/nika-providers/src/wire/mod.rs
@@ -192,8 +192,8 @@ pub(crate) fn gen_ai_system(provider_id: &str) -> GenAiSystem {
         // groq · openrouter · huggingface (Inference Providers router) ·
         // nvidia (integrate.api.nvidia.com / NIM) · the 5 local servers all
         // speak the OpenAI-compatible dialect; mock is Unknown by design.
-        "groq" | "openrouter" | "huggingface" | "nvidia" | "ollama" | "lmstudio" | "llamacpp"
-        | "localai" | "vllm" => GenAiSystem::OpenAiCompatible,
+        "groq" | "openrouter" | "huggingface" | "nvidia" | "moonshot" | "ollama" | "lmstudio"
+        | "llamacpp" | "localai" | "vllm" => GenAiSystem::OpenAiCompatible,
         _ => GenAiSystem::Unknown,
     }
 }


### PR DESCRIPTION
Closes #1398

Three surfaces of one binary printed three provider counts (the card 15 · the catalog header 15 · the check refusal 16) and the canon a fourth (17, with `moonshot` listed as a provider this engine speaks).

- One derived sentence, every surface: « 16 wired in this build (5 local · 11 cloud · plus mock) » on the card (its own line, the card keeps eighty columns), under the catalog header, and in the check refusal for a cataloged-but-unwired provider.
- `moonshot` (Kimi K2 · K2.5 · `api.moonshot.ai` · `MOONSHOT_API_KEY` per the catalog row) is wired over the openai-chat dialect, so the canon's seventeen and the binary's seventeen are the same list.
- The machine-truth surface gate now also pins the check refusal's number to the wired facet.

## Proof

`nika-providers` (the seed and the refusal sentence) · `nika-cli-host` (the card under eighty columns, the header) · the `machine_truth_surfaces` and `catalog_family` binary gates.

proven_by: rust

🤖 Generated with [Claude Code](https://claude.com/claude-code)