### PR TITLE
refactor(check): the silent-literal scan moves under the analyzer's budget

### DIFF
--- a/crates/nika-check-analyzer/public-api.txt
+++ b/crates/nika-check-analyzer/public-api.txt
@@ -197,6 +197,8 @@ pub fn nika_check_analyzer::edges::task_refs_in_value(value: &serde_json::value:
 pub mod nika_check_analyzer::native_first
 pub fn nika_check_analyzer::native_first::classify(command: &nika_schema::raw::action::RawCommand) -> core::option::Option<(&'static str, alloc::string::String)>
 pub fn nika_check_analyzer::native_first::classify_all(command: &nika_schema::raw::action::RawCommand) -> alloc::vec::Vec<(&'static str, alloc::string::String)>
+pub mod nika_check_analyzer::silent_literal
+pub fn nika_check_analyzer::silent_literal::scan(wf: &nika_schema::raw::workflow::RawWorkflow) -> alloc::vec::Vec<(alloc::string::String, alloc::string::String)>
 pub mod nika_check_analyzer::types_contract
 pub fn nika_check_analyzer::types_contract::lowered_returns(wf: &nika_schema::raw::workflow::RawWorkflow) -> alloc::collections::btree::map::BTreeMap<alloc::string::String, serde_json::value::Value>
 pub fn nika_check_analyzer::types_contract::returns_type(task: &nika_schema::raw::task::RawTask, wf: &nika_schema::raw::workflow::RawWorkflow) -> core::option::Option<nika_types::types::NikaType>

--- a/crates/nika-check-analyzer/src/lib.rs
+++ b/crates/nika-check-analyzer/src/lib.rs
@@ -48,6 +48,7 @@ pub mod native_first;
 mod scan;
 mod schema_lint;
 mod schema_paths;
+pub mod silent_literal;
 mod static_ref;
 mod thinking;
 pub mod types_contract;

--- a/crates/nika-check-analyzer/src/silent_literal.rs
+++ b/crates/nika-check-analyzer/src/silent_literal.rs
@@ -72,11 +72,13 @@ fn effect_fields(action: &RawAction) -> Vec<&str> {
             .unwrap_or_default(),
         RawAction::Infer(a) => prompt_system(a.prompt.value.as_str(), a.system.as_ref()),
         RawAction::Agent(a) => prompt_system(a.prompt.value.as_str(), a.system.as_ref()),
+        // The variant is not printed: an action carries prompts and args
+        // that may hold resolved secrets, and a panic line is a log.
         #[allow(
             clippy::unreachable,
             reason = "non_exhaustive future variant — enum and analyzer ship together; fail loud beats silently-wrong output"
         )]
-        other => unreachable!("unknown action: {other:?}"),
+        _ => unreachable!("unknown action variant"),
     }
 }
 

--- a/crates/nika-check-analyzer/src/silent_literal.rs
+++ b/crates/nika-check-analyzer/src/silent_literal.rs
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! A value that LOOKS like a reference and is not one (#1395). The
+//! mustache island « {{ inputs.topic }} » (Jinja · Airflow · GitHub
+//! Actions) and the shell sigil « $name » as a whole `with:` value are
+//! neither refused nor resolved: the engine sends the literal text, so
+//! `topic=boundaries` reached a model as « {{ inputs.topic }} » under a
+//! green check. The scan names the literal and the one reference form;
+//! the parent ladder wraps each row into its `silent-literal` hint.
+//!
+//! Carved into the analysis substrate at the parent's 15k wall: the rule
+//! reads the AST alone.
+
+use nika_schema::raw::{RawAction, RawTask, RawWorkflow};
+
+/// Every silent literal of the workflow: `(task id, advice)` rows in
+/// declaration order — effect fields first, then the `with:` bindings.
+#[must_use]
+pub fn scan(wf: &RawWorkflow) -> Vec<(String, String)> {
+    let mut out = Vec::new();
+    for task in &wf.tasks {
+        scan_task(&task.value, &mut out);
+    }
+    out
+}
+
+fn scan_task(t: &RawTask, out: &mut Vec<(String, String)>) {
+    let id = t.id.value.as_str();
+    for text in effect_fields(&t.action) {
+        for island in mustache_refs(text) {
+            out.push((id.to_owned(), format!(
+                "`{{{{ {island} }}}}` in `{id}` is literal text here (a mustache island, not a reference) — the reference form is `${{{{ {island} }}}}`"
+            )));
+        }
+    }
+    for (name, v) in &t.with {
+        let bound = name.value.as_str();
+        for text in json_strings(&v.value) {
+            for island in mustache_refs(text) {
+                out.push((id.to_owned(), format!(
+                    "`{{{{ {island} }}}}` bound to `with.{bound}` of `{id}` is literal text (a mustache island, not a reference) — the reference form is `${{{{ {island} }}}}`"
+                )));
+            }
+            if let Some(ident) = shell_sigil(text) {
+                out.push((id.to_owned(), format!(
+                    "`${ident}` bound to `with.{bound}` of `{id}` is literal text (a shell sigil, not a reference) — a binding reads `${{{{ tasks.{ident}.output }}}}` (an upstream output) or `${{{{ inputs.{ident} }}}}`"
+                )));
+            }
+        }
+    }
+}
+
+/// The text fields an action sends somewhere: a prompt (+ system), an
+/// argv / shell line (+ stdin · env values), an invoke's args strings.
+fn effect_fields(action: &RawAction) -> Vec<&str> {
+    match action {
+        RawAction::Exec(a) => {
+            let mut fields = a.command.text_fragments();
+            if let Some(stdin) = &a.stdin {
+                fields.push(stdin.value.as_str());
+            }
+            for (_, v) in &a.env {
+                fields.push(v.value.as_str());
+            }
+            fields
+        }
+        RawAction::Invoke(a) => a
+            .args
+            .as_ref()
+            .map(|args| json_strings(&args.value))
+            .unwrap_or_default(),
+        RawAction::Infer(a) => prompt_system(a.prompt.value.as_str(), a.system.as_ref()),
+        RawAction::Agent(a) => prompt_system(a.prompt.value.as_str(), a.system.as_ref()),
+        #[allow(
+            clippy::unreachable,
+            reason = "non_exhaustive future variant — enum and analyzer ship together; fail loud beats silently-wrong output"
+        )]
+        other => unreachable!("unknown action: {other:?}"),
+    }
+}
+
+fn prompt_system<'a>(
+    prompt: &'a str,
+    system: Option<&'a nika_schema::Spanned<String>>,
+) -> Vec<&'a str> {
+    let mut fields = vec![prompt];
+    if let Some(system) = system {
+        fields.push(system.value.as_str());
+    }
+    fields
+}
+
+/// Every string inside a JSON value, depth-first.
+fn json_strings(value: &serde_json::Value) -> Vec<&str> {
+    match value {
+        serde_json::Value::String(s) => vec![s.as_str()],
+        serde_json::Value::Array(items) => items.iter().flat_map(json_strings).collect(),
+        serde_json::Value::Object(map) => map.values().flat_map(json_strings).collect(),
+        _ => Vec::new(),
+    }
+}
+
+/// The reference-shaped mustache islands of one string: « {{ inputs.x }} »
+/// whose head is one of the five namespaces or a loop local, and which
+/// is NOT the « ${{ » island (the dollar in front is the whole difference).
+fn mustache_refs(text: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut rest = text;
+    while let Some(at) = rest.find("{{") {
+        let sigil = at > 0 && rest.as_bytes()[at - 1] == b'$';
+        let after = &rest[at + 2..];
+        let Some(end) = after.find("}}") else {
+            break;
+        };
+        let inner = after[..end].trim();
+        if !sigil && reference_shaped(inner) {
+            out.push(inner.to_owned());
+        }
+        rest = &after[end + 2..];
+    }
+    out
+}
+
+/// « inputs.x » · « tasks.a.output » · « item » · « index » — a head from
+/// the reference vocabulary, then dotted identifiers (or nothing).
+fn reference_shaped(inner: &str) -> bool {
+    let (head, tail) = inner.split_once('.').unwrap_or((inner, ""));
+    let head_ok = matches!(
+        head,
+        "inputs" | "const" | "secrets" | "with" | "tasks" | "item" | "index" | "group"
+    );
+    head_ok
+        && tail
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '.' | '[' | ']' | '-'))
+}
+
+/// A whole value that is a shell sigil — « $a » · « $tasks.a.output » —
+/// and nothing else (a « ${{ » island starts with a brace, a « $100 »
+/// with a digit: neither is a sigil). Returns the bare identifier.
+fn shell_sigil(text: &str) -> Option<&str> {
+    let ident = text.strip_prefix('$')?;
+    let first = ident.chars().next()?;
+    (first.is_ascii_alphabetic() || first == '_')
+        .then_some(ident)
+        .filter(|i| {
+            i.chars()
+                .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '.'))
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn islands_and_sigils_are_recognized_edge_by_edge() {
+        assert_eq!(
+            mustache_refs("Write about {{ inputs.topic }}"),
+            ["inputs.topic"]
+        );
+        assert!(mustache_refs("real ${{ inputs.topic }} island").is_empty());
+        assert!(mustache_refs("{{ not a ref }}").is_empty());
+        assert_eq!(
+            mustache_refs("{{tasks.a.output}} and {{ item }}"),
+            ["tasks.a.output", "item"]
+        );
+        assert_eq!(shell_sigil("$a"), Some("a"));
+        assert_eq!(shell_sigil("$tasks.a.output"), Some("tasks.a.output"));
+        assert_eq!(shell_sigil("$100 budget"), None);
+        assert_eq!(shell_sigil("${{ inputs.x }}"), None);
+        assert_eq!(shell_sigil("plain"), None);
+    }
+}

--- a/crates/nika-check/src/hints.rs
+++ b/crates/nika-check/src/hints.rs
@@ -106,7 +106,6 @@
 
 use std::collections::BTreeSet;
 
-use crate::flow::{action_effect_fields, collect_json_strings};
 use crate::walk::{consumed_outputs, deeply_referenced, envelope_bound_outputs};
 use nika_schema::expression::scan_templates;
 use nika_schema::raw::{RawAction, RawTask, RawWorkflow};
@@ -297,8 +296,8 @@ pub(super) fn scan_hints(wf: &RawWorkflow) -> Vec<Hint> {
             other => unreachable!("unknown action: {other:?}"),
         }
         push_retry_effects_hint(&mut hints, t);
-        push_silent_literal_hints(&mut hints, t);
     }
+    push_silent_literal_hints(&mut hints, wf);
 
     // F-O8 · the old « no `permits:` boundary declared » advisory is
     // RETIRED: absent + effects is the NIKA-AUTH-006 ERROR now (the
@@ -1344,85 +1343,14 @@ fn value_mentions_tasks(v: &serde_json::Value, ids: &BTreeSet<&str>) -> bool {
         .any(|id| ids.contains(id.as_str()))
 }
 
-/// #1395 — a value that LOOKS like a reference and is not one. The
-/// mustache island `{{ inputs.topic }}` (Jinja · Airflow · GitHub
-/// Actions) and the shell sigil `$name` as a whole `with:` value are
-/// neither refused nor resolved: the engine sends the literal text, so
-/// `topic=boundaries` reached a model as « {{ inputs.topic }} » under a
-/// green check. The hint names the literal and the one reference form.
-fn push_silent_literal_hints(hints: &mut Vec<Hint>, t: &RawTask) {
-    let id = t.id.value.as_str();
-    for text in action_effect_fields(&t.action) {
-        for island in mustache_refs(text) {
-            hints.push(hint("silent-literal", id, format!(
-                "`{{{{ {island} }}}}` in `{id}` is literal text here (a mustache island, not a reference) — the reference form is `${{{{ {island} }}}}`"
-            )));
-        }
+/// #1395 — a value that LOOKS like a reference and is not one: the
+/// mustache island and the shell sigil, each named with its one reference
+/// form. The scan lives in the analysis substrate (its own budget); this
+/// is the wrap into the ladder's hint.
+fn push_silent_literal_hints(hints: &mut Vec<Hint>, wf: &RawWorkflow) {
+    for (task, advice) in nika_check_analyzer::silent_literal::scan(wf) {
+        hints.push(hint("silent-literal", &task, advice));
     }
-    for (name, v) in &t.with {
-        let bound = name.value.as_str();
-        for text in collect_json_strings(&v.value) {
-            for island in mustache_refs(text) {
-                hints.push(hint("silent-literal", id, format!(
-                    "`{{{{ {island} }}}}` bound to `with.{bound}` of `{id}` is literal text (a mustache island, not a reference) — the reference form is `${{{{ {island} }}}}`"
-                )));
-            }
-            if let Some(ident) = shell_sigil(text) {
-                hints.push(hint("silent-literal", id, format!(
-                    "`${ident}` bound to `with.{bound}` of `{id}` is literal text (a shell sigil, not a reference) — a binding reads `${{{{ tasks.{ident}.output }}}}` (an upstream output) or `${{{{ inputs.{ident} }}}}`"
-                )));
-            }
-        }
-    }
-}
-
-/// The reference-shaped mustache islands of one string: `{{ inputs.x }}`
-/// whose head is one of the five namespaces or a loop local, and which
-/// is NOT the `${{` island (the `$` in front is the whole difference).
-fn mustache_refs(text: &str) -> Vec<String> {
-    let mut out = Vec::new();
-    let mut rest = text;
-    while let Some(at) = rest.find("{{") {
-        let sigil = at > 0 && rest.as_bytes()[at - 1] == b'$';
-        let after = &rest[at + 2..];
-        let Some(end) = after.find("}}") else {
-            break;
-        };
-        let inner = after[..end].trim();
-        if !sigil && reference_shaped(inner) {
-            out.push(inner.to_owned());
-        }
-        rest = &after[end + 2..];
-    }
-    out
-}
-
-/// `inputs.x` · `tasks.a.output` · `item` · `index` — a head from the
-/// reference vocabulary, then dotted identifiers (or nothing).
-fn reference_shaped(inner: &str) -> bool {
-    let (head, tail) = inner.split_once('.').unwrap_or((inner, ""));
-    let head_ok = matches!(
-        head,
-        "inputs" | "const" | "secrets" | "with" | "tasks" | "item" | "index" | "group"
-    );
-    head_ok
-        && tail
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '.' | '[' | ']' | '-'))
-}
-
-/// A whole value that is a shell sigil — `$a` · `$tasks.a.output` — and
-/// nothing else (a `${{` island starts with `{`, a `$100` with a digit:
-/// neither is a sigil). Returns the bare identifier.
-fn shell_sigil(text: &str) -> Option<&str> {
-    let ident = text.strip_prefix('$')?;
-    let first = ident.chars().next()?;
-    (first.is_ascii_alphabetic() || first == '_')
-        .then_some(ident)
-        .filter(|i| {
-            i.chars()
-                .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '.'))
-        })
 }
 
 pub(super) fn hint(kind: &'static str, task: &str, advice: String) -> Hint {


### PR DESCRIPTION
`nika-check` crossed the 15k production-line wall by three lines once #1411 and #1412 landed (the `ratchet (crate-size)` job is red on `main` and on every open PR). The #1395 scan reads the AST alone, so it moves into `nika-check-analyzer` (the substrate carved out at the same wall); `nika-check` keeps the wrap into its `silent-literal` hint. Same rows, same tests, one crate back under the wall.

proven_by: rust

🤖 Generated with [Claude Code](https://claude.com/claude-code)