### PR TITLE
fix(release): the pre-tag projection asks the estate question (#1421)

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -98,6 +98,13 @@ without an explicit operator decision.
    the same shape as the version-match guard above, and for the same
    reason.
 
+   The manifest goes into the **last** commit before the tag. `v0.117.1`
+   regenerated it in the prep commit, then one more commit moved a tracked
+   file, and all four build legs refused the tag. Step 4 now asks this
+   question too (`next-tag-project.sh --check` counts a stale manifest as
+   a claim without proof), so a tag cut after a red step 4 is the only way
+   to meet the guard again.
+
 4. **Project the next tag (the anti-08-08 question).** Before the tag
    exists, ask what it would actually contain and what it would claim
    without proof. The command reads `release.yml`, `wiring.yaml`, the

--- a/changelog.d/1421.fixed.md
+++ b/changelog.d/1421.fixed.md
@@ -1,0 +1,1 @@
+- **The pre-tag projection asks the estate question.** `scripts/ci/next-tag-project.sh --check` refuses a stale estate manifest, the same question the release workflow asks on every build leg after the tag exists: `v0.117.1` regenerated the manifest one commit too early and died there. The ceremony now hears it before the tag.

--- a/scripts/ci/next-tag-project.sh
+++ b/scripts/ci/next-tag-project.sh
@@ -10,6 +10,7 @@
 #   wiring.yaml          declared capabilities + proven_by job keys
 #   CHANGELOG.md         the [Unreleased] section
 #   .github/workflows    CI job keys (the judge that would prove a claim)
+#   estate.yaml          the manifest the tag gate will compare the tree to
 #
 # Prints four columns · IN THE BINARY · CLAIMED · PROVEN · UNPROVEN.
 # Exit 0 always for the human projection. --check exits 1 when UNPROVEN
@@ -167,6 +168,22 @@ if printf '%s\n' "$UNRELEASED" | grep -qiE 'access-harness|harness access|access
   fi
 fi
 
+# The estate manifest. release.yml refuses a tag whose tree its manifest
+# does not describe ("The estate manifest is true of the tagged tree"), and
+# that refusal fires on every build leg, AFTER the tag exists. v0.117.1 died
+# there: the manifest was regenerated in the prep commit, one more commit
+# moved a tracked file, and nothing on the operator's path asked again. The
+# projection asks the tag gate's question BEFORE the tag, as one more claim
+# without proof.
+ESTATE_STALE=0
+if [ -f "$ENGINE/estate.yaml" ] && [ -f "$ENGINE/scripts/estate.py" ]; then
+  if ! (cd "$ENGINE" && python3 scripts/estate.py --check >/dev/null 2>&1); then
+    ESTATE_STALE=1
+    UNPROVEN=$((UNPROVEN + 1))
+    UNPROVEN_ROWS="${UNPROVEN_ROWS}estate.yaml does not describe the tree · python3 scripts/estate.py --write && git add estate.yaml · in the LAST commit before the tag"$'\n'
+  fi
+fi
+
 FEAT_CSV="$(printf '%s' "$RELEASE_FEATURES" | paste -sd, - || true)"
 JOB_N="$(printf '%s\n' "$JOBS" | grep -c . || true)"
 CAP_N="$(printf '%s\n' "$CAP_IDS" | grep -c . || true)"
@@ -180,11 +197,11 @@ if [ "$JSON" -eq 1 ]; then
     printf '%s"%s"' "$sep" "$f"
     sep=","
   done <<<"$RELEASE_FEATURES"
-  printf '],"changelog_unreleased":%s,"ledger_rows":%s,"ci_jobs":%s,"unproven":%s}\n' \
-    "$CLAIM_N" "$CAP_N" "$JOB_N" "$UNPROVEN"
+  printf '],"changelog_unreleased":%s,"ledger_rows":%s,"ci_jobs":%s,"estate_stale":%s,"unproven":%s}\n' \
+    "$CLAIM_N" "$CAP_N" "$JOB_N" "$ESTATE_STALE" "$UNPROVEN"
 else
   printf 'next-tag-project · %s\n' "$ENGINE"
-  printf 'scope · release.yml build line · wiring.yaml · CHANGELOG [Unreleased] · CI job keys\n'
+  printf 'scope · release.yml build line · wiring.yaml · CHANGELOG [Unreleased] · CI job keys · estate.yaml\n'
   printf 'NOT covered · G5/G6 source drops · website · docs\n\n'
   printf 'IN THE BINARY     %s\n' "${FEAT_CSV:-NONE}"
   printf 'CHANGELOG claims  %s Unreleased bullet(s)\n' "$CLAIM_N"
@@ -192,7 +209,7 @@ else
   printf 'CI job keys       %s\n' "$JOB_N"
   printf '\n'
   if [ "$UNPROVEN" -eq 0 ]; then
-    printf 'UNPROVEN          none · every ledger row names a live job · changelog does not promise a dark feature\n'
+    printf 'UNPROVEN          none · every ledger row names a live job · changelog does not promise a dark feature · the estate manifest describes the tree\n'
   else
     printf 'UNPROVEN          %s claim(s) without proof\n' "$UNPROVEN"
     printf '%s' "$UNPROVEN_ROWS" | sed 's/^/  · /'

--- a/scripts/release/tests/next-tag-estate.test.sh
+++ b/scripts/release/tests/next-tag-estate.test.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# next-tag-project asks the tag gate's estate question BEFORE the tag.
+#
+# v0.117.1 was tagged on a tree whose estate.yaml described the commit before
+# it; every build leg refused the tag at "The estate manifest is true of the
+# tagged tree". This proves --check goes red on a stale manifest and green
+# again once it is regenerated, on a throwaway copy of the real tree (the
+# real rules, so coverage is never the reason the check speaks).
+set -euo pipefail
+
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_PREFIX GIT_COMMON_DIR \
+  GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_NAMESPACE \
+  GIT_QUARANTINE_PATH
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+COPY="$(mktemp -d)"
+trap 'rm -rf "$COPY"' EXIT
+
+fail() {
+  printf 'next-tag-estate.test: %s\n' "$1" >&2
+  exit 1
+}
+
+# The tracked tree only, at HEAD: the copy is a repository of its own, so the
+# manifest it carries describes ITS index, never the caller's.
+git -C "$ROOT" archive --format=tar HEAD | tar -x -C "$COPY"
+git -C "$COPY" init -q
+# estate.py derives the repo slug from the origin remote; the copy names the real one.
+git -C "$COPY" remote add origin https://github.com/supernovae-st/nika.git
+git -C "$COPY" -c user.name=t -c user.email=t@t add -A
+git -C "$COPY" -c user.name=t -c user.email=t@t -c commit.gpgsign=false \
+  commit -q -m fixture
+(cd "$COPY" && python3 scripts/estate.py --write >/dev/null)
+git -C "$COPY" add estate.yaml
+
+project() {
+  bash "$ROOT/scripts/ci/next-tag-project.sh" --repo "$COPY" --check
+}
+
+out="$(project 2>&1)" || fail "a fresh manifest reads UNPROVEN: $out"
+printf '%s\n' "$out" | grep -q 'estate manifest describes the tree' \
+  || fail 'the green line does not say the manifest describes the tree'
+
+# Move one tracked file after the manifest was written: the v0.117.1 shape.
+printf '\n# moved after the manifest\n' >>"$COPY/Cargo.toml"
+git -C "$COPY" add Cargo.toml
+if out="$(project 2>&1)"; then
+  fail 'a stale manifest passed --check'
+fi
+printf '%s\n' "$out" | grep -q 'estate.yaml does not describe the tree' \
+  || fail "the stale row is not named: $out"
+printf '%s\n' "$out" | grep -q 'LAST commit before the tag' \
+  || fail 'the stale row does not say where the regeneration belongs'
+
+json="$(bash "$ROOT/scripts/ci/next-tag-project.sh" --repo "$COPY" --json)"
+printf '%s\n' "$json" | grep -q '"estate_stale":1' \
+  || fail "the JSON face does not carry estate_stale: $json"
+
+(cd "$COPY" && python3 scripts/estate.py --write >/dev/null)
+git -C "$COPY" add estate.yaml
+project >/dev/null 2>&1 || fail 'a regenerated manifest still reads UNPROVEN'
+
+echo 'next-tag-estate.test: PASS'

--- a/scripts/release/tests/release-tooling.test.sh
+++ b/scripts/release/tests/release-tooling.test.sh
@@ -685,6 +685,8 @@ bash "$ROOT/scripts/release/tests/publication-barrier.test.sh" >/dev/null \
   || fail 'the cross-registry publication barrier regression failed'
 bash "$ROOT/scripts/release/tests/finalize-release.test.sh" >/dev/null \
   || fail 'the write-only finalizer barrier regression failed'
+bash "$ROOT/scripts/release/tests/next-tag-estate.test.sh" >/dev/null \
+  || fail 'the pre-tag estate question regression failed'
 grep -q 'TAP_DEPLOY_KEY' "$ROOT/docs/RELEASING.md" \
   || fail 'the operator guide does not name the release workflow deploy key'
 if grep -q 'HOMEBREW_TAP_TOKEN' "$ROOT/docs/RELEASING.md"; then


### PR DESCRIPTION
Cherry-pick of `1c75cabe` from the parked `release/0.117.2` branch: v0.117.1 died on every build leg at « the estate manifest is true of the tagged tree » because one more commit moved a tracked file after the manifest was regenerated. `next-tag-project.sh --check` now counts a stale manifest as a claim without proof and says where the regeneration belongs, so step 4 of the ceremony hears the tag gate before the tag exists.

Proof: `scripts/release/tests/next-tag-estate.test.sh` (green fresh · red after one moved file · green once regenerated) · the tooling self-test lists it.

One Door · OD-F0 · the release lane must be true before v0.118.0.

proven_by: rust

🤖 Generated with [Claude Code](https://claude.com/claude-code)