### PR TITLE
fix: preserve project discovery failures in check

### DIFF
--- a/.github/workflows/diamond-ci.yml
+++ b/.github/workflows/diamond-ci.yml
@@ -306,6 +306,19 @@ jobs:
       - uses: Swatinem/rust-cache@f0d9c3887740aee45f6153b24b3a6b815192ec16 # v2
         with:
           shared-key: diamond-access-harness
+      # Same runner as the tests leg: one PROCESS per test. `cargo test` runs a
+      # crate's tests as threads of one process, and the process's current
+      # directory is one global — a test that enters a temp project (the
+      # check/project_context fixtures) moves the ground under every test that
+      # reads the cwd, whichever lock the writer holds. Measured 2026-09-06 on
+      # PR #1494: 6 verbs::check tests red under `cargo test`, green under the
+      # tests leg's nextest on byte-identical source. The isolation is the
+      # runner's to own; a production mutex to pass a test would be the wrong
+      # owner, and `--test-threads=1` would serialize 1039 tests to hide one.
+      - name: Install cargo-nextest (the process-per-test runner)
+        uses: taiki-e/install-action@1ed6d7be6168f6c9046541087ff549b6bc581fdf # v2
+        with:
+          tool: cargo-nextest
       # Same install as the rust tests/funnel legs. This job runs nika-cli
       # --lib, which includes permits+exec workflows (measured 2026-08-23 on
       # PR #1157: answer_without_resume_preseeds_the_gate → NIKA-1710 exit 3
@@ -321,7 +334,7 @@ jobs:
         env:
           NIKA_KEYCHAIN: "off"
         run: >
-          cargo test --lib
+          cargo nextest run --lib
           -p nika-cli -p nika-cli-host -p nika-runtime -p nika-verb-agent
           --features access-harness
 

--- a/changelog.d/access-harness-nextest.fixed.md
+++ b/changelog.d/access-harness-nextest.fixed.md
@@ -1,0 +1,1 @@
+- **The access-harness CI leg runs one process per test.** The feature battery now uses cargo-nextest like the tests leg, so a fixture that enters a temporary project cannot change the ambient context of a concurrent `check` test; the selection and `--lib` scope are unchanged.

--- a/changelog.d/check-project-context.fixed.md
+++ b/changelog.d/check-project-context.fixed.md
@@ -1,0 +1,4 @@
+- **Check reports invalid ambient project configuration.** Workflow checks
+  retain the nearest project's diagnostic and exit 3, including scaffold
+  and snapshot export callers. Valid project budgets and direct project
+  checks keep their existing behavior.

--- a/changelog.d/check-test-isolation.fixed.md
+++ b/changelog.d/check-test-isolation.fixed.md
@@ -1,0 +1,1 @@
+- **Isolate the local test fallback.** Without cargo-nextest, run library tests serially so temporary project directories cannot change a concurrent test's ambient context. Nextest and the required CI test scope remain unchanged.

--- a/changelog.d/pre-push-test-owner.fixed.md
+++ b/changelog.d/pre-push-test-owner.fixed.md
@@ -1,0 +1,1 @@
+- **Share the isolated test runner with pre-push.** The local push gate now uses the same nextest selection and serial fallback as the test script, preserving its library-only scope and refusing failed tests before publication.

--- a/changelog.d/project-json-escaping.fixed.md
+++ b/changelog.d/project-json-escaping.fixed.md
@@ -1,0 +1,1 @@
+- **Keep project verdicts valid JSON.** Escape project paths, names and diagnostic strings with the JSON serializer, including control characters in filesystem paths. Preserve the compact envelope and field order for existing project verdicts.

--- a/crates/nika-cli/src/verbs/check/budget.rs
+++ b/crates/nika-cli/src/verbs/check/budget.rs
@@ -14,6 +14,8 @@
 use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
 
+use nika_vocab::project::ProjectError;
+
 use crate::display::theme::{Role, Theme};
 
 /// A project-file ceiling that `nika run` from this CWD would honour.
@@ -25,27 +27,29 @@ pub(super) struct AmbientCeiling {
 }
 
 /// Walk from `start` the same way `run::ceiling::ladder` does.
-#[must_use]
-pub(super) fn at(start: &Path) -> Option<AmbientCeiling> {
-    let (path, project) = nika_vocab::project::discover(start).ok().flatten()?;
-    let usd = project.ceiling?;
+pub(super) fn at(start: &Path) -> Result<Option<AmbientCeiling>, ProjectError> {
+    let Some((path, project)) = nika_vocab::project::discover(start)? else {
+        return Ok(None);
+    };
+    let Some(usd) = project.ceiling else {
+        return Ok(None);
+    };
     let line = ceiling_line(&path);
-    Some(AmbientCeiling { usd, path, line })
+    Ok(Some(AmbientCeiling { usd, path, line }))
 }
 
 /// The CWD door — identical start to `nika run` with no flag.
-#[must_use]
-pub(super) fn from_cwd() -> Option<AmbientCeiling> {
+pub(super) fn from_cwd() -> Result<Option<AmbientCeiling>, ProjectError> {
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
     at(&cwd)
 }
 
 /// Human footnote. Presence-gated: silence when no file governs spend.
-pub(super) fn footnote(text: &mut String, theme: Theme) {
-    let Some(c) = from_cwd() else {
+pub(super) fn footnote(text: &mut String, theme: Theme, ceiling: Option<&AmbientCeiling>) {
+    let Some(c) = ceiling else {
         return;
     };
-    let where_ = provenance(&c);
+    let where_ = provenance(c);
     let _ = writeln!(
         text,
         " {} {}   ${} ← {where_} · the run's spend cap when `--max-cost-usd` is omitted",
@@ -56,8 +60,11 @@ pub(super) fn footnote(text: &mut String, theme: Theme) {
 }
 
 /// Presence-gated `--json` object. `clean` does not read it.
-pub(super) fn stamp_json(obj: &mut serde_json::Map<String, serde_json::Value>) {
-    let Some(c) = from_cwd() else {
+pub(super) fn stamp_json(
+    obj: &mut serde_json::Map<String, serde_json::Value>,
+    ceiling: Option<&AmbientCeiling>,
+) {
+    let Some(c) = ceiling else {
         return;
     };
     let mut v = serde_json::json!({
@@ -120,7 +127,7 @@ mod tests {
         let child = root.join("sub");
         std::fs::create_dir_all(&child).expect("mkdir");
         std::fs::write(root.join("nika.yaml"), "nika: proj\nceiling: 0.01\n").expect("seed");
-        let c = at(&child).expect("walks up");
+        let c = at(&child).expect("valid project").expect("walks up");
         assert_eq!(c.usd.to_bits(), 0.01f64.to_bits());
         assert_eq!(c.line, Some(2));
         assert!(c.path.ends_with("nika.yaml"), "{:?}", c.path);
@@ -131,7 +138,10 @@ mod tests {
     fn a_file_without_ceiling_is_silence() {
         let dir = fresh("none");
         std::fs::write(dir.join("nika.yaml"), "nika: proj\n").expect("seed");
-        assert!(at(&dir).is_none(), "no ceiling → check stays silent");
+        assert!(
+            at(&dir).expect("valid project").is_none(),
+            "no ceiling → check stays silent"
+        );
         let _ = std::fs::remove_dir_all(&dir);
     }
 
@@ -142,7 +152,7 @@ mod tests {
         // ancestor ceiling.
         let dir = fresh("boundary");
         std::fs::write(dir.join("nika.yaml"), "nika: boundary\n").expect("seed");
-        assert!(at(&dir).is_none());
+        assert!(at(&dir).expect("valid boundary").is_none());
         let _ = std::fs::remove_dir_all(&dir);
     }
 
@@ -153,13 +163,63 @@ mod tests {
         std::fs::create_dir_all(&child).expect("mkdir");
         std::fs::write(root.join("nika.yaml"), "nika: root\nceiling: 9.99\n").expect("root");
         std::fs::write(child.join("nika.yaml"), "nika: leaf\nceiling: 0.25\n").expect("leaf");
-        let c = at(&child).expect("leaf");
+        let c = at(&child).expect("valid project").expect("leaf");
         assert_eq!(
             c.usd.to_bits(),
             0.25f64.to_bits(),
             "the first file on the walk governs"
         );
         let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn an_invalid_nearest_project_preserves_its_error_instead_of_inheriting() {
+        let room = tempfile::tempdir().expect("room");
+        let child = room.path().join("child");
+        std::fs::create_dir(&child).expect("child");
+        std::fs::write(room.path().join("nika.yaml"), "nika: root\nceiling: 0.50\n")
+            .expect("ancestor");
+        let path = child.join("nika.yaml");
+        for yaml in [
+            "nika: child\nceiling: 0\n",
+            "nika: child\nceiling: -1\n",
+            "nika: child\nceiling: \"0.01\"\n",
+            "nika: child\nceiling: [\n",
+        ] {
+            std::fs::write(&path, yaml).expect("invalid nearest project");
+            let expected = nika_vocab::project::parse(yaml).expect_err("parser refusal");
+            let err = at(&child).expect_err("present invalid project is not absence");
+            assert_eq!(err.path(), Some(path.as_path()));
+            assert_eq!(err.kind(), expected.kind());
+            assert_eq!(err.line(), expected.line());
+            assert_eq!(err.detail(), expected.detail());
+            assert_eq!(err.remedy(), expected.remedy());
+        }
+    }
+
+    #[test]
+    fn an_unreadable_nearest_project_is_not_absence() {
+        let room = tempfile::tempdir().expect("room");
+        let path = room.path().join("nika.yaml");
+        std::fs::create_dir(&path).expect("directory in place of project");
+        let err = at(room.path()).expect_err("unreadable project");
+        assert_eq!(
+            err.kind(),
+            nika_vocab::project::ProjectErrorKind::Unreadable
+        );
+        assert_eq!(err.path(), Some(path.as_path()));
+        assert_eq!(err.line(), None);
+    }
+
+    #[test]
+    fn a_valid_bare_project_does_not_inherit_an_ancestor_ceiling() {
+        let room = tempfile::tempdir().expect("room");
+        let child = room.path().join("child");
+        std::fs::create_dir(&child).expect("child");
+        std::fs::write(room.path().join("nika.yaml"), "nika: root\nceiling: 0.50\n")
+            .expect("ancestor");
+        std::fs::write(child.join("nika.yaml"), "nika: child\n").expect("boundary");
+        assert!(at(&child).expect("valid boundary").is_none());
     }
 
     #[test]
@@ -170,7 +230,8 @@ mod tests {
         let prev = std::env::current_dir().expect("cwd");
         std::env::set_current_dir(&dir).expect("chdir");
         let mut text = String::new();
-        footnote(&mut text, Theme::new(false, true, false));
+        let ceiling = from_cwd().expect("valid project");
+        footnote(&mut text, Theme::new(false, true, false), ceiling.as_ref());
         let _ = std::env::set_current_dir(prev);
         assert!(
             text.contains("BUDGET") && text.contains("0.0100") && text.contains("nika.yaml:2"),
@@ -227,7 +288,8 @@ mod tests {
         let prev = std::env::current_dir().expect("cwd");
         std::env::set_current_dir(&dir).expect("chdir");
         let mut obj = serde_json::Map::new();
-        stamp_json(&mut obj);
+        let ceiling = from_cwd().expect("valid project");
+        stamp_json(&mut obj, ceiling.as_ref());
         let _ = std::env::set_current_dir(&prev);
         let v = obj.get("run_budget").expect("present");
         assert_eq!(v["max_cost_usd"], 0.01);
@@ -243,7 +305,8 @@ mod tests {
         std::fs::write(empty.join("nika.yaml"), "nika: boundary\n").expect("boundary");
         std::env::set_current_dir(&empty).expect("chdir empty");
         let mut silent = serde_json::Map::new();
-        stamp_json(&mut silent);
+        let ceiling = from_cwd().expect("valid boundary");
+        stamp_json(&mut silent, ceiling.as_ref());
         let _ = std::env::set_current_dir(prev);
         assert!(silent.is_empty(), "{silent:?}");
         let _ = std::fs::remove_dir_all(&dir);

--- a/crates/nika-cli/src/verbs/check/mod.rs
+++ b/crates/nika-cli/src/verbs/check/mod.rs
@@ -426,7 +426,7 @@ fn run_source_with_profile_and_slots(
         && thinking_findings(&wf).is_empty()
         && capacity_findings(&wf).is_empty()
         && skills.findings.is_empty();
-    let out = render_checked_with_profile(
+    let out = match render_checked_with_profile(
         source.source(),
         path,
         source.repair_target(),
@@ -438,7 +438,10 @@ fn run_source_with_profile_and_slots(
         profile,
         access_pin,
         theme,
-    );
+    ) {
+        Ok(out) => out,
+        Err(err) => return project::ambient_refusal(&err, json),
+    };
     if slot_only {
         VerbOutput::ok(out.text)
     } else {
@@ -460,7 +463,7 @@ pub(crate) fn run_admitted_pair(
     json: bool,
     theme: Theme,
 ) -> VerbOutput {
-    render_checked_with_profile(
+    match render_checked_with_profile(
         source,
         path,
         repair_target,
@@ -472,7 +475,10 @@ pub(crate) fn run_admitted_pair(
         Profile::Advisory,
         None,
         theme,
-    )
+    ) {
+        Ok(out) => out,
+        Err(err) => project::ambient_refusal(&err, json),
+    }
 }
 
 /// Emit the normal machine check report plus its exact execution snapshot.
@@ -530,6 +536,9 @@ pub fn run_snapshot_export(path: &str, theme: Theme) -> VerbOutput {
         true,
         theme,
     );
+    if out.code == crate::verbs::exit::ENV {
+        return out;
+    }
     attach_execution_snapshot(out, encoded)
 }
 
@@ -701,7 +710,8 @@ fn render_checked_with_profile(
     profile: Profile,
     access_pin: Option<&str>,
     theme: Theme,
-) -> VerbOutput {
+) -> Result<VerbOutput, nika_vocab::project::ProjectError> {
+    let ceiling = budget::from_cwd()?;
     let native_hints = nika_cli_host::oracle::native_hints(report);
     let lanes = nika_cli_host::oracle::Lanes::new(native_strict, profile == Profile::Operational);
     let verdict = fold_verdicts(wf, report, skills, access_pin);
@@ -718,7 +728,14 @@ fn render_checked_with_profile(
     }
 
     if json {
-        return json_verdict(wf, report, skills, &verdict, lanes);
+        return Ok(json_verdict(
+            wf,
+            report,
+            skills,
+            &verdict,
+            lanes,
+            ceiling.as_ref(),
+        ));
     }
 
     let mut text = render(
@@ -751,12 +768,12 @@ fn render_checked_with_profile(
         verdict.grade,
     );
     naming_note(&mut text, theme, path, wf);
-    budget::footnote(&mut text, theme);
-    if strict_clean {
+    budget::footnote(&mut text, theme, ceiling.as_ref());
+    Ok(if strict_clean {
         VerbOutput::ok(nika_display::vocab::sober(theme, &text))
     } else {
         VerbOutput::file(nika_display::vocab::sober(theme, &text))
-    }
+    })
 }
 
 fn naming_note(text: &mut String, theme: Theme, path: &str, wf: &nika_schema::raw::RawWorkflow) {
@@ -835,12 +852,13 @@ fn json_verdict(
     skills: &nika_schema::ResolvedSkills,
     verdict: &nika_cli_host::oracle::Verdict,
     lanes: nika_cli_host::oracle::Lanes,
+    ceiling: Option<&budget::AmbientCeiling>,
 ) -> VerbOutput {
     let mut obj = match nika_cli_host::oracle::audit_json(wf, report, skills, verdict, lanes) {
         Ok(obj) => obj,
         Err(why) => return VerbOutput::env(why),
     };
-    budget::stamp_json(&mut obj);
+    budget::stamp_json(&mut obj, ceiling);
     let text = format!("{:#}", serde_json::Value::Object(obj));
     if verdict.strict_clean(report, lanes) {
         VerbOutput::ok(text)

--- a/crates/nika-cli/src/verbs/check/project.rs
+++ b/crates/nika-cli/src/verbs/check/project.rs
@@ -35,25 +35,27 @@ pub(super) fn judge(path: &str, yaml: &str, json: bool) -> VerbOutput {
             );
             VerbOutput::ok(nika_display::project_render::verdict(path, name, &governs))
         }
-        Err(err) => {
-            let slug = err.kind().spec_code();
-            if json {
-                let text =
-                    nika_display::project_render::json(path, false, None, slug, err.detail());
-                return VerbOutput {
-                    text,
-                    code: nika_cli_host::output::exit::FILE,
-                };
-            }
-            VerbOutput::file(nika_display::project_render::refusal(
-                path,
-                err.line(),
-                slug,
-                err.detail(),
-                err.remedy(),
-            ))
-        }
+        Err(err) => VerbOutput::file(refusal(path, &err, json, err.detail())),
     }
+}
+
+/// A workflow cannot be judged under an invalid ambient project.
+#[must_use]
+pub(super) fn ambient_refusal(err: &project::ProjectError, json: bool) -> VerbOutput {
+    let path = err
+        .path()
+        .unwrap_or_else(|| std::path::Path::new(project::FILE_NAME))
+        .display()
+        .to_string();
+    VerbOutput::env(refusal(&path, err, json, &err.to_string()))
+}
+
+fn refusal(path: &str, err: &project::ProjectError, json: bool, message: &str) -> String {
+    let slug = err.kind().spec_code();
+    if json {
+        return nika_display::project_render::json(path, false, None, slug, message);
+    }
+    nika_display::project_render::refusal(path, err.line(), slug, err.detail(), err.remedy())
 }
 
 #[cfg(test)]

--- a/crates/nika-cli/src/verbs/check/tests.rs
+++ b/crates/nika-cli/src/verbs/check/tests.rs
@@ -1,6 +1,8 @@
 use super::*;
 use nika_cli_host::models_rung::pricing_section;
 
+mod project_context;
+
 /// `run_many`: every file audits even after an earlier failure (the
 /// broken file sits in the MIDDLE), each report keeps its own header,
 /// and the worst spec-§4 exit survives.

--- a/crates/nika-cli/src/verbs/check/tests/project_context.rs
+++ b/crates/nika-cli/src/verbs/check/tests/project_context.rs
@@ -1,0 +1,279 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+use super::*;
+use nika_cli_host::output::exit;
+
+const WORKFLOW: &str = "nika: value\npermits: { tools: [\"nika:jq\"] }\ntasks:\n  value:\n    invoke: { tool: \"nika:jq\", args: { input: 1, expression: \".\" } }\n";
+const INVALID_PROJECT: &str = "nika: project\nceiling: -1\n";
+
+fn theme() -> Theme {
+    Theme::new(false, true, false)
+}
+
+fn assert_ambient_refusal(out: &VerbOutput, json: bool, err: &nika_vocab::project::ProjectError) {
+    assert_eq!(out.code, exit::ENV, "{}", out.text);
+    let path = err.path().expect("discovery binds the project path");
+    if json {
+        let payload: serde_json::Value = serde_json::from_str(&out.text).expect("project json");
+        assert_eq!(payload["report_version"], 1, "{payload}");
+        assert_eq!(payload["kind"], "project", "{payload}");
+        assert_eq!(payload["file"], path.display().to_string(), "{payload}");
+        assert_eq!(payload["clean"], false, "{payload}");
+        let findings = payload["findings"].as_array().expect("findings");
+        assert_eq!(findings.len(), 1, "{payload}");
+        assert_eq!(findings[0]["code"], err.kind().spec_code(), "{payload}");
+        assert_eq!(findings[0]["message"], err.to_string(), "{payload}");
+        assert!(payload.get("run_budget").is_none(), "{payload}");
+        assert!(payload.get("execution_snapshot").is_none(), "{payload}");
+    } else {
+        assert!(
+            out.text.contains(&path.display().to_string()),
+            "{}",
+            out.text
+        );
+        assert!(out.text.contains(err.kind().spec_code()), "{}", out.text);
+        assert!(out.text.contains(err.detail()), "{}", out.text);
+        assert!(out.text.contains(err.remedy()), "{}", out.text);
+        if let Some(line) = err.line() {
+            assert!(
+                out.text.contains(&format!("{}:{line}", path.display())),
+                "{}",
+                out.text
+            );
+        }
+        assert!(!out.text.contains("BUDGET"), "{}", out.text);
+    }
+}
+
+#[test]
+fn ambient_refusals_survive_json_strict_and_operational_routes() {
+    let room = tempfile::tempdir().expect("room");
+    std::fs::write(room.path().join("value.nika.yaml"), WORKFLOW).expect("workflow");
+    let _cwd = crate::cwd::enter(room.path()).expect("cwd lease");
+    for yaml in [
+        "nika: project\nceiling: 0\n",
+        INVALID_PROJECT,
+        "nika: project\nceiling: \"0.01\"\n",
+        "nika: project\nceiling: [\n",
+    ] {
+        std::fs::write("nika.yaml", yaml).expect("invalid project");
+        let err = nika_vocab::project::discover_from_cwd().expect_err("project refusal");
+        for json in [false, true] {
+            for strict in [false, true] {
+                for profile in [Profile::Advisory, Profile::Operational] {
+                    let out = run_with_profile(
+                        "value.nika.yaml",
+                        json,
+                        strict,
+                        profile,
+                        (None, None),
+                        theme(),
+                    );
+                    assert_ambient_refusal(&out, json, &err);
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn an_unreadable_ambient_project_names_the_project_in_both_routes() {
+    let room = tempfile::tempdir().expect("room");
+    std::fs::write(room.path().join("value.nika.yaml"), WORKFLOW).expect("workflow");
+    std::fs::create_dir(room.path().join("nika.yaml")).expect("unreadable project");
+    let _cwd = crate::cwd::enter(room.path()).expect("cwd lease");
+    let err = nika_vocab::project::discover_from_cwd().expect_err("project refusal");
+    assert_eq!(err.kind().spec_code(), "project.unreadable");
+    for json in [false, true] {
+        assert_ambient_refusal(
+            &run("value.nika.yaml", json, false, None, theme()),
+            json,
+            &err,
+        );
+    }
+}
+
+#[test]
+fn scaffold_slot_admission_cannot_promote_an_ambient_refusal() {
+    let room = tempfile::tempdir().expect("room");
+    std::fs::write(
+        room.path().join("draft.nika.yaml"),
+        "nika: draft\nmodel: mock/echo\ntasks:\n  think:\n    infer:\n      prompt: \"<SLOT: the one model job>\"\n      max_tokens: 10\n",
+    )
+    .expect("unfilled scaffold");
+    std::fs::write(room.path().join("nika.yaml"), "nika: project\n").expect("valid boundary");
+    let _cwd = crate::cwd::enter(room.path()).expect("cwd lease");
+    let ordinary = run("draft.nika.yaml", false, false, None, theme());
+    assert_eq!(ordinary.code, exit::FILE, "{}", ordinary.text);
+    let scaffold = run_scaffold("draft.nika.yaml", theme());
+    assert_eq!(
+        scaffold.code,
+        exit::OK,
+        "slot-only control: {}",
+        scaffold.text
+    );
+    std::fs::write("nika.yaml", INVALID_PROJECT).expect("invalid project");
+    let err = nika_vocab::project::discover_from_cwd().expect_err("project refusal");
+    assert_ambient_refusal(&run_scaffold("draft.nika.yaml", theme()), false, &err);
+}
+
+#[test]
+fn admitted_pair_preserves_the_ambient_refusal_for_its_callers() {
+    let room = tempfile::tempdir().expect("room");
+    std::fs::write(room.path().join("nika.yaml"), INVALID_PROJECT).expect("invalid project");
+    let _cwd = crate::cwd::enter(room.path()).expect("cwd lease");
+    let wf = parse_wf(WORKFLOW);
+    let report = nika_check::check(&wf);
+    let skills = crate::verbs::resolve_workflow_skills(&wf, room.path());
+    let target = CheckTarget::workspace("value.nika.yaml");
+    let err = nika_vocab::project::discover_from_cwd().expect_err("project refusal");
+    for json in [false, true] {
+        let out = run_admitted_pair(
+            WORKFLOW,
+            &target.path,
+            target.repair_target,
+            &wf,
+            &report,
+            &skills,
+            json,
+            theme(),
+        );
+        assert_ambient_refusal(&out, json, &err);
+    }
+}
+
+#[test]
+fn snapshot_export_returns_the_ambient_refusal_without_snapshot_bytes() {
+    let room = tempfile::tempdir().expect("room");
+    std::fs::write(room.path().join("value.nika.yaml"), WORKFLOW).expect("workflow");
+    std::fs::write(room.path().join("nika.yaml"), "nika: project\n").expect("valid boundary");
+    let _cwd = crate::cwd::enter(room.path()).expect("cwd lease");
+    let control = run_snapshot_export("value.nika.yaml", theme());
+    assert_eq!(control.code, exit::OK, "{}", control.text);
+    let payload: serde_json::Value = serde_json::from_str(&control.text).expect("snapshot json");
+    assert!(payload["execution_snapshot"].is_string(), "{payload}");
+    std::fs::write("nika.yaml", INVALID_PROJECT).expect("invalid project");
+    let err = nika_vocab::project::discover_from_cwd().expect_err("project refusal");
+    assert_ambient_refusal(&run_snapshot_export("value.nika.yaml", theme()), true, &err);
+}
+
+#[test]
+fn multifile_check_keeps_the_ambient_environment_exit() {
+    let room = tempfile::tempdir().expect("room");
+    for name in ["a.nika.yaml", "b.nika.yaml"] {
+        std::fs::write(room.path().join(name), WORKFLOW).expect("workflow");
+    }
+    std::fs::write(room.path().join("nika.yaml"), INVALID_PROJECT).expect("invalid project");
+    let _cwd = crate::cwd::enter(room.path()).expect("cwd lease");
+    let paths = ["a.nika.yaml".to_owned(), "b.nika.yaml".to_owned()];
+    let out = run_many(&paths, true, Profile::Operational, None, theme());
+    assert_eq!(out.code, exit::ENV, "{}", out.text);
+    assert_eq!(
+        out.text.matches("project.bad-value").count(),
+        2,
+        "{}",
+        out.text
+    );
+}
+
+#[test]
+fn valid_ambient_budget_and_bare_boundary_keep_their_existing_projections() {
+    let room = tempfile::tempdir().expect("room");
+    let child = room.path().join("child");
+    std::fs::create_dir(&child).expect("child");
+    std::fs::write(room.path().join("nika.yaml"), "nika: root\nceiling: 0.50\n").expect("ancestor");
+    std::fs::write(child.join("value.nika.yaml"), WORKFLOW).expect("workflow");
+    let _cwd = crate::cwd::enter(&child).expect("cwd lease");
+    for (yaml, amount) in [
+        ("nika: child\nceiling: 0.01\n", Some(0.01)),
+        ("nika: child\n", None),
+    ] {
+        std::fs::write("nika.yaml", yaml).expect("valid project");
+        for profile in [Profile::Advisory, Profile::Operational] {
+            let human = run_with_profile(
+                "value.nika.yaml",
+                false,
+                true,
+                profile,
+                (None, None),
+                theme(),
+            );
+            assert_eq!(human.code, exit::OK, "{}", human.text);
+            assert_eq!(
+                human.text.contains("BUDGET"),
+                amount.is_some(),
+                "{}",
+                human.text
+            );
+            let out = run_with_profile(
+                "value.nika.yaml",
+                true,
+                true,
+                profile,
+                (None, None),
+                theme(),
+            );
+            assert_eq!(out.code, exit::OK, "{}", out.text);
+            let payload: serde_json::Value = serde_json::from_str(&out.text).expect("check json");
+            assert_eq!(payload["clean"], true, "{payload}");
+            if let Some(amount) = amount {
+                assert_eq!(payload["run_budget"]["max_cost_usd"], amount, "{payload}");
+                assert_eq!(payload["run_budget"]["line"], 2, "{payload}");
+                let path = std::env::current_dir().expect("cwd").join("nika.yaml");
+                assert_eq!(payload["run_budget"]["source"], path.display().to_string());
+                assert_eq!(payload["run_budget"]["via"], "project", "{payload}");
+            } else {
+                assert!(payload.get("run_budget").is_none(), "{payload}");
+            }
+        }
+    }
+}
+
+#[test]
+fn direct_project_refusal_keeps_its_file_exit_and_existing_message() {
+    let room = tempfile::tempdir().expect("room");
+    std::fs::write(room.path().join("nika.yaml"), INVALID_PROJECT).expect("invalid project");
+    let _cwd = crate::cwd::enter(room.path()).expect("cwd lease");
+    let err = nika_vocab::project::parse(INVALID_PROJECT).expect_err("parser refusal");
+    for json in [false, true] {
+        let out = run("nika.yaml", json, false, None, theme());
+        assert_eq!(out.code, exit::FILE, "{}", out.text);
+        if json {
+            let payload: serde_json::Value = serde_json::from_str(&out.text).expect("project json");
+            assert_eq!(payload["file"], "nika.yaml", "{payload}");
+            assert_eq!(payload["kind"], "project", "{payload}");
+            assert_eq!(payload["clean"], false, "{payload}");
+            assert_eq!(payload["findings"][0]["code"], err.kind().spec_code());
+            assert_eq!(payload["findings"][0]["message"], err.detail());
+        } else {
+            assert_eq!(
+                out.text,
+                nika_display::project_render::refusal(
+                    "nika.yaml",
+                    err.line(),
+                    err.kind().spec_code(),
+                    err.detail(),
+                    err.remedy(),
+                )
+            );
+        }
+    }
+}
+
+#[test]
+fn an_ambient_path_with_control_characters_stays_machine_readable() {
+    let room = tempfile::tempdir().expect("room");
+    let child = room.path().join("project\u{1b}context");
+    std::fs::create_dir(&child).expect("project directory");
+    std::fs::write(child.join("value.nika.yaml"), WORKFLOW).expect("workflow");
+    std::fs::write(child.join("nika.yaml"), INVALID_PROJECT).expect("invalid project");
+    let _cwd = crate::cwd::enter(&child).expect("cwd lease");
+    let err = nika_vocab::project::discover_from_cwd().expect_err("project refusal");
+    assert_ambient_refusal(
+        &run("value.nika.yaml", true, false, None, theme()),
+        true,
+        &err,
+    );
+    assert_ambient_refusal(&run_snapshot_export("value.nika.yaml", theme()), true, &err);
+}

--- a/crates/nika-display/src/project_render.rs
+++ b/crates/nika-display/src/project_render.rs
@@ -63,14 +63,15 @@ pub fn governs(ceiling: Option<f64>, traces: bool, registry: bool, beats: usize)
 /// grammar judged it.
 #[must_use]
 pub fn json(path: &str, clean: bool, name: Option<&str>, code: &str, message: &str) -> String {
-    let head = format!("{{\"report_version\":1,\"file\":{path:?},\"kind\":\"project\"");
+    let path = serde_json::json!(path);
+    let head = format!("{{\"report_version\":1,\"file\":{path},\"kind\":\"project\"");
     if clean {
-        let name = name.unwrap_or("<unnamed>");
-        format!("{head},\"clean\":true,\"name\":{name:?},\"findings\":[]}}")
+        let name = serde_json::json!(name.unwrap_or("<unnamed>"));
+        format!("{head},\"clean\":true,\"name\":{name},\"findings\":[]}}")
     } else {
-        format!(
-            "{head},\"clean\":false,\"findings\":[{{\"code\":{code:?},\"message\":{message:?}}}]}}"
-        )
+        let code = serde_json::json!(code);
+        let message = serde_json::json!(message);
+        format!("{head},\"clean\":false,\"findings\":[{{\"code\":{code},\"message\":{message}}}]}}")
     }
 }
 
@@ -118,6 +119,46 @@ mod tests {
             assert_eq!(v["kind"], "project", "{wire}");
             assert!(v["findings"].is_array(), "{wire}");
         }
+    }
+
+    #[test]
+    fn json_strings_round_trip_control_characters() {
+        let characters = (0..32)
+            .filter_map(char::from_u32)
+            .chain(['\u{7f}', '\u{85}', '\u{a0}', '"', '\\', 'é', '🦋']);
+        for ch in characters {
+            let value = format!("before{ch}after");
+            for clean in [true, false] {
+                let wire = json(&value, clean, Some(&value), &value, &value);
+                let parsed: serde_json::Value =
+                    serde_json::from_str(&wire).expect("JSON string escaping");
+                assert_eq!(parsed["file"], value);
+                if clean {
+                    assert_eq!(parsed["name"], value);
+                } else {
+                    assert_eq!(parsed["findings"][0]["code"], value);
+                    assert_eq!(parsed["findings"][0]["message"], value);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn ordinary_machine_verdicts_keep_their_compact_bytes() {
+        assert_eq!(
+            json("nika.yaml", true, Some("my-project"), "", ""),
+            r#"{"report_version":1,"file":"nika.yaml","kind":"project","clean":true,"name":"my-project","findings":[]}"#,
+        );
+        assert_eq!(
+            json(
+                "nika.yaml",
+                false,
+                None,
+                "project.unknown-key",
+                "unknown field `celing`"
+            ),
+            r#"{"report_version":1,"file":"nika.yaml","kind":"project","clean":false,"findings":[{"code":"project.unknown-key","message":"unknown field `celing`"}]}"#,
+        );
     }
 
     #[test]

--- a/docs/crate-specs/nika-cli.md
+++ b/docs/crate-specs/nika-cli.md
@@ -33,7 +33,7 @@ without a temporary file or a world-less compatibility path.
 | Verb | Does | Exit codes |
 |---|---|---|
 | `nika run <file>` | execute a workflow · live render (§3) | 0 ok · 1 workflow failed · 2 file findings · 3 env · 4 paused (ADR-099) |
-| `nika check <file>` | the ADR-092 static ladder (schema→DAG→CEL→effects→permits→cost) | 0 clean · 2 findings |
+| `nika check <file>` | the ADR-092 static ladder (schema→DAG→CEL→effects→permits→cost) | 0 clean · 2 file findings · 3 invalid ambient project |
 | `nika init` | scaffold a repo (.vscode schema wiring · AGENTS.md templates) · bare on a terminal it then OFFERS the guided first workflow (`--yes`/pipe/CI = the classic non-interactive shape byte-for-byte · prompts never appear off-terminal) | 0 · 3 env |
 | `nika inspect <file>` | static anatomy: tasks · verbs · DAG (ASCII §6) · permits · cost interval | 0 · 2 |
 | `nika inspect <file> --format json\|mermaid\|dot\|ascii` | the ONE graph projector (§6) | 0 · 2 |
@@ -44,6 +44,13 @@ without a temporary file or a world-less compatibility path.
 | `nika spec` (`--schema` prints the JSON Schema) / `nika try [slug]` | the embedded self-contained surface — bare = the showroom list · a slug runs it offline by default (`--model` opts into a real seat · V5) | 0 |
 | `nika lsp` | the in-binary language server (stdio) | — |
 | `nika mcp` | the in-binary MCP server | — |
+
+A workflow check resolves its ambient project once. An invalid nearest
+project is an ENV refusal, including JSON, scaffold and snapshot-export
+routes; it cannot become a clean verdict or inherit an ancestor ceiling.
+A direct check of an invalid project document remains a FILE refusal.
+Valid project budgets retain their existing provenance, and a valid project
+without a ceiling stops the ancestor walk without adding a budget.
 
 ### v0.82 wave-2 (proposed 2026-06-11 · additive)
 

--- a/docs/crate-specs/nika-display.md
+++ b/docs/crate-specs/nika-display.md
@@ -61,3 +61,8 @@ pub mod demo     { deterministic §3.3 storyboard streams (success · failure ·
   ride the meter).
 - **One-voice rendering** — the surface formats upstream codes and never
   mints its own.
+
+The project verdict renderer accepts primitive fields from its caller. Its
+machine envelope uses JSON string escaping for paths, names and diagnostics,
+including control characters, while preserving the compact field order.
+It does not parse projects or choose the caller's exit code.

--- a/estate.yaml
+++ b/estate.yaml
@@ -18,11 +18,11 @@ classes:
   testimonial: "captured evidence — fixtures, corpora, traces, receipts: proves behavior; neither shipped source nor regenerable output"
   foreign: "pointer to a third-party sovereign source"
 summary:
-  classified_files: 4871
+  classified_files: 4872
   file_rows: 11
   pattern_rows: 24
   by_class:
-    authored: 1891
+    authored: 1892
     authored-pin: 2
     generated: 127
     pinned-copy: 146
@@ -188,7 +188,7 @@ patterns:
 - glob: "scripts/**"
   class: authored
   match_count: 205
-  aggregate_sha256: e84a0484c9e8f0be9db20b3e9566032f69000883445a7e248d93b09e4af0f9a4
+  aggregate_sha256: 45c4675c8fdd39a31f4adc5a3e2e3ea093b9c2cf8f521944a82f4032e35a3219
   evidence: "hand-written gates · hooks · hygiene vectors · media lanes; the ratchet baselines (scripts/ci/*-baseline.txt · scripts/hygiene/baselines/) are hand-kept monotonic floors ('Never remove a line by hand')"
 - glob: ".github/workflows/**"
   class: authored
@@ -242,8 +242,8 @@ patterns:
   evidence: "examples/README.md — a pointer README (the runnable examples live in the vendored pack + the spec repo)"
 - glob: "changelog.d/**"
   class: authored
-  match_count: 5
-  aggregate_sha256: 984d5ec5832be74436b70c77aa224ea2a1fc271b72ebd2bccf9059f4f2ca08ff
+  match_count: 6
+  aggregate_sha256: 116001639977c07671c4a3f529fa5f978ba85f2320b38fb8248e21b288367c4a
   evidence: "changelog.d/README.md — one hand-written bullet per change, authored by whoever makes the change; scripts/release/changelog-assemble.sh only CONSUMES them (--fold splices and deletes) and never writes one"
   note: "the README is permanent by design: a rule matching nothing is a coverage hole, and every fragment is deleted at fold time"
 - glob: "*"

--- a/estate.yaml
+++ b/estate.yaml
@@ -18,11 +18,11 @@ classes:
   testimonial: "captured evidence — fixtures, corpora, traces, receipts: proves behavior; neither shipped source nor regenerable output"
   foreign: "pointer to a third-party sovereign source"
 summary:
-  classified_files: 4867
+  classified_files: 4871
   file_rows: 11
   pattern_rows: 24
   by_class:
-    authored: 1887
+    authored: 1891
     authored-pin: 2
     generated: 127
     pinned-copy: 146
@@ -151,8 +151,8 @@ patterns:
     - "cargo-public-api 0.51.0"
 - glob: "crates/**/src/**"
   class: authored
-  match_count: 966
-  aggregate_sha256: b3d2cb65b362b767709078d668fa4aea6edc7bb16a0cede721ecb56869e93d83
+  match_count: 967
+  aggregate_sha256: db1c8bbbc7ddab8f3acfa5b5de6c3f52a54a175715d5efa4dd0079755898fb45
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored
@@ -183,12 +183,12 @@ patterns:
 - glob: "docs/**"
   class: authored
   match_count: 123
-  aggregate_sha256: 66a06d01c479bb999579b6d86b148c0d553a5960537ac3484be5fb99943fc086
+  aggregate_sha256: c517314ffab71b0789188d1f9e5177bcad7fca9fb06e1ecf4645be527bf5feba
   evidence: "crate-specs · architecture prose · perf notes — no generation markers at file heads"
 - glob: "scripts/**"
   class: authored
   match_count: 205
-  aggregate_sha256: a635039e86e27e2b83933a331a30e37f14cdbe3153a7091be9647d7cfade6cf3
+  aggregate_sha256: e84a0484c9e8f0be9db20b3e9566032f69000883445a7e248d93b09e4af0f9a4
   evidence: "hand-written gates · hooks · hygiene vectors · media lanes; the ratchet baselines (scripts/ci/*-baseline.txt · scripts/hygiene/baselines/) are hand-kept monotonic floors ('Never remove a line by hand')"
 - glob: ".github/workflows/**"
   class: authored
@@ -242,8 +242,8 @@ patterns:
   evidence: "examples/README.md — a pointer README (the runnable examples live in the vendored pack + the spec repo)"
 - glob: "changelog.d/**"
   class: authored
-  match_count: 2
-  aggregate_sha256: 8c568ac4a0e925842d19f7199d9bc0c07372d9059ae4992f6e68473543a35f2f
+  match_count: 5
+  aggregate_sha256: 984d5ec5832be74436b70c77aa224ea2a1fc271b72ebd2bccf9059f4f2ca08ff
   evidence: "changelog.d/README.md — one hand-written bullet per change, authored by whoever makes the change; scripts/release/changelog-assemble.sh only CONSUMES them (--fold splices and deletes) and never writes one"
   note: "the README is permanent by design: a rule matching nothing is a coverage hole, and every fragment is deleted at fold time"
 - glob: "*"

--- a/scripts/ci/check-tests.sh
+++ b/scripts/ci/check-tests.sh
@@ -43,9 +43,12 @@ if command -v cargo-nextest >/dev/null 2>&1; then
   exec cargo nextest run --workspace --lib
 fi
 
-# Local, no nextest: the fallback stays, but it says what it is NOT running.
+# Local, no nextest: the fallback serializes tests within each process.
+# CLI fixtures borrow the process-global cwd; readers cannot safely run beside
+# a test that enters an invalid project. Nextest isolates these by process.
 # A reduced scope that announces itself is a choice; one that does not is a
 # false green.
-echo "WARN  cargo-nextest absent — running 'cargo test --workspace --lib'." >&2
+echo "WARN  cargo-nextest absent — running 'cargo test --workspace --lib -- --test-threads=1'." >&2
 echo "      LIB TARGETS ONLY: the tests/ integration suites are NOT executed." >&2
-exec cargo test --workspace --lib
+echo "      SERIAL TESTS: isolate process-global cwd fixtures from concurrent readers." >&2
+exec cargo test --workspace --lib -- --test-threads=1

--- a/scripts/hooks/run-ci-ratchets.sh
+++ b/scripts/hooks/run-ci-ratchets.sh
@@ -11,9 +11,8 @@
 # never named `credential-headers`, which is. A prose list beside the real
 # one is a claim nothing checks.
 #
-# Note: check-tests.sh is deliberately not in that array (cargo test runs
-# separately at pre-push to keep the --lib flag and avoid --test, which
-# triggers the keychain popup on macOS).
+# Note: check-tests.sh is deliberately not in that array: pre-push invokes
+# it as a separate local-only leg, preserving --lib and process isolation.
 #
 # Exit: 0 = all pass | 1 = one or more failed
 #

--- a/scripts/hooks/test-pre-push-dispatch.py
+++ b/scripts/hooks/test-pre-push-dispatch.py
@@ -29,24 +29,28 @@ class PushDispatch(unittest.TestCase):
         self.repo = self.root / "repo"
         self.remote = self.root / "remote.git"
         self.repo.mkdir()
-        home = self.root / "home"
-        home.mkdir()
         fake_bin = self.root / "bin"
         fake_bin.mkdir()
         cargo = fake_bin / "cargo"
-        cargo.write_text("#!/bin/sh\nprintf 'cargo reached\\n' > gate-observed\nexit 17\n")
+        cargo.write_text(
+            "#!/bin/sh\nprintf '%s\\n' \"$*\" >> cargo-commands\n"
+            "case \"$1\" in test|nextest)\n"
+            "printf 'cargo reached\\n' > gate-observed\n"
+            "printf '%s\\n' \"$*\" > gate-command\n;; esac\nexit 17\n"
+        )
         cargo.chmod(0o755)
         # An allowlist prevents inherited Git configuration, credentials or gate
         # opt-outs from changing the fixture's authority or expected verdict.
         self.env = {
             "PATH": str(fake_bin) + os.pathsep + os.environ.get("PATH", ""),
-            "HOME": str(home),
             "TMPDIR": str(self.root),
             "GIT_CONFIG_NOSYSTEM": "1",
             "GIT_CONFIG_GLOBAL": os.devnull,
             "GIT_TERMINAL_PROMPT": "0",
             "NO_COLOR": "1",
         }
+        if "HOME" in os.environ:
+            self.env["HOME"] = os.environ["HOME"]
         self.run_command("git", "init", "--bare", str(self.remote))
         self.run_command("git", "init", "-b", "main")
         self.run_command("git", "config", "user.name", "Nika Hook Test")
@@ -55,7 +59,10 @@ class PushDispatch(unittest.TestCase):
         shutil.copytree(ROOT / "scripts/hooks", self.repo / "scripts/hooks")
         if (ROOT / "scripts/pre-push").is_dir():
             shutil.copytree(ROOT / "scripts/pre-push", self.repo / "scripts/pre-push")
-        self.run_command("git", "add", "lefthook.yml", "scripts")
+        (self.repo / "scripts/ci").mkdir()
+        shutil.copyfile(ROOT / "scripts/ci/check-tests.sh", self.repo / "scripts/ci/check-tests.sh")
+        (self.repo / "Cargo.toml").write_text('[workspace]\nmembers = ["crates/fixture"]\n')
+        self.run_command("git", "add", "lefthook.yml", "scripts", "Cargo.toml")
         self.run_command("git", "commit", "-m", "fixture initial tree")
         self.run_command("git", "remote", "add", "origin", str(self.remote))
         self.run_command("git", "push", "-u", "origin", "main")
@@ -82,7 +89,20 @@ class PushDispatch(unittest.TestCase):
     def assert_gate_refused(self, result):
         self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
         self.assertEqual((self.repo / "gate-observed").read_text(), "cargo reached\n")
+        command = (self.repo / "gate-command").read_text().split()
+        self.assertIn("--lib", command)
+        if command[0] == "test":
+            self.assertIn("--test-threads=1", command)
+        else:
+            self.assertEqual(command[:2], ["nextest", "run"])
+        commands = (self.repo / "cargo-commands").read_text().splitlines()
+        self.assertFalse(any(line.split()[0] == "clippy" for line in commands), commands)
         self.assertFalse((self.repo / ".git/nika-pre-push.lock").exists())
+
+    def test_pre_push_keeps_local_scope_when_caller_exports_ci(self):
+        self.env["CI"] = "1"
+        result = self.run_command(LEFTHOOK, "run", "pre-push", success=False, stdin="")
+        self.assert_gate_refused(result)
 
     def test_tag_only_push_reaches_gate_and_refuses_failed_cargo(self):
         self.run_command("git", "tag", "test-candidate")

--- a/scripts/pre-push/gate.sh
+++ b/scripts/pre-push/gate.sh
@@ -69,7 +69,9 @@ set -e
 # Measured 2026-07-27: a whole run at 0.4s of cargo CPU was healthy, and
 # every test binary was stalled pre-main in _dyld_start waiting on
 # Gatekeeper to scan it. That is a machine setting, not a bug in here.
-cargo test --workspace --lib --quiet </dev/null
+# Share the runner's nextest isolation and serial fallback. Pre-push is the
+# local lane even when its caller exports CI: keep its absolute --lib scope.
+CI='' bash scripts/ci/check-tests.sh </dev/null
 # `--lib` is a house absolute (a `--test` run pops the macOS Keychain), so
 # this leg CANNOT see the integration tier. It is a real platform limit,
 # not a bug — but a gate that stays silent about what it did not look at


### PR DESCRIPTION
`nika check` could discard a project discovery error and report a successful workflow check, including through scaffold promotion or snapshot export. Preserve the typed project error until the CLI emits the environment failure. Direct project checks retain their existing file-error behavior. Use the JSON serializer so verdict paths containing control characters remain valid JSON.

The CLI fixtures exposed process-wide working-directory interference in the local test runner. Route pre-push through the existing test owner: nextest isolates each test process, and the local Cargo fallback runs library tests serially. CI retains its full nextest scope. Pre-push still refuses a failed battery before clippy or later gates.

Validation: 806 library tests passed serially and under nextest, plus Clippy. The native comparison against published 0.118.7 executed 32 checks with all fixed-protocol expectations met. That binary was built from 233cce4c; the follow-up changes only hook/runner tests, changelog and generated estate metadata. The initial 28/32 native result is retained: four human-card expectations incorrectly asserted a low risk grade for an explicit tool grant, whose established grade is supervised.

Six local Git dispatch tests and eight scope checks pass. Two deliberate mutations—restoring the parallel Cargo command and swallowing test failure—each fail four targeted checks; the gate was restored exactly. The first push attempt was refused by the old parallel dispatch (323 CLI tests passed, 26 failed). Full hygiene after the repair reports 38 green, 9 yellow, no red; normal commit hooks pass.

The repaired pre-push completed successfully: 7,251 workspace library tests passed (3 skipped), workspace Clippy and the remaining local gates passed.
