### PR TITLE
fix(fs): preserve files created during a guarded write

### DIFF
--- a/.agents/plugins/nika/skills/nika-operating/SKILL.md
+++ b/.agents/plugins/nika/skills/nika-operating/SKILL.md
@@ -60,6 +60,16 @@ composed from a cleared slate — the runner floor ∪ the names in
 `permits: { env: [NAME] }` ∪ the task's own `env:` map. A workflow
 that leaned on an ambient variable must now name it.
 
+## File creation and uncertain results
+
+Use `nika:write` with `overwrite: false` to preserve an occupied destination,
+including one created concurrently before publication. An existing destination
+returns `NIKA-BUILTIN-WRITE-002`; a backend unable to publish exclusively refuses
+instead of falling back to replacement. Keep the required filesystem permits.
+After a lost response or cancellation, inspect the file and trace before retry:
+publication may already have completed. Atomic visibility does not promise
+fsync durability or that a detached write has stopped.
+
 ## Secrets (masked, declared, sunk)
 
 - Every credential rides `${{ secrets.X }}`, declared in the

--- a/changelog.d/write-exclusive-publication.fixed.md
+++ b/changelog.d/write-exclusive-publication.fixed.md
@@ -1,0 +1,1 @@
+- **Preserve concurrently created files.** `nika:write` with `overwrite: false` now refuses a destination created after its initial absence check. Existing filesystem adapters compile with a refusing default and can implement exclusive publication; ordinary replacement writes retain their behavior.

--- a/crates/nika-builtin/Cargo.toml
+++ b/crates/nika-builtin/Cargo.toml
@@ -64,7 +64,7 @@ nika-fs          = { path = "../nika-fs", version = "0.118.7" }
 # our own sniffer accepts).
 png              = { workspace = true }
 proptest         = { workspace = true }
-tokio            = { workspace = true }
+tokio            = { workspace = true, features = ["sync"] }
 
 [package.metadata.lore]
 daemon        = "forgeron"

--- a/crates/nika-builtin/src/file.rs
+++ b/crates/nika-builtin/src/file.rs
@@ -12,6 +12,9 @@ use nika_kernel::io::fs::{FsError, FsListDyn, FsReadDyn, FsWriteDyn};
 use crate::permits::{FsAccess, FsBoundary};
 use crate::{Args, BuiltinFailure, BuiltinOutcome, req_str, strict_bool, strict_u64};
 
+#[cfg(test)]
+mod write_tests;
+
 /// `nika:read` — text (default) or binary. Returns the file content.
 pub(crate) async fn read<F: FsReadDyn>(fs: &F, args: &Args) -> BuiltinOutcome {
     const C1: &str = "NIKA-BUILTIN-READ-001";
@@ -99,9 +102,17 @@ pub(crate) async fn write<F: FsReadDyn + FsWriteDyn>(fs: &F, args: &Args) -> Bui
             ));
         }
     }
-    fs.write(Path::new(path), &content)
-        .await
-        .map_err(|e| BuiltinFailure::new(C1, format!("write failed: {e}")))?;
+    let written = if overwrite {
+        fs.write(Path::new(path), &content).await
+    } else {
+        fs.write_new(Path::new(path), &content).await
+    };
+    written.map_err(|e| match e {
+        FsError::AlreadyExists { .. } if !overwrite => {
+            BuiltinFailure::new(C2, format!("`{path}` exists and overwrite: false"))
+        }
+        other => BuiltinFailure::new(C1, format!("write failed: {other}")),
+    })?;
     Ok(serde_json::Value::String(path.to_owned()))
 }
 

--- a/crates/nika-builtin/src/file/write_tests.rs
+++ b/crates/nika-builtin/src/file/write_tests.rs
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+use std::path::{Path, PathBuf};
+
+use bytes::Bytes;
+use nika_fs::TokioFs;
+use nika_kernel::fs::{FsError, FsReadDyn, FsWriteDyn};
+use tokio::sync::Barrier;
+
+struct ObservedAbsence {
+    target: PathBuf,
+    observed: Barrier,
+    created: Barrier,
+}
+
+impl FsReadDyn for ObservedAbsence {
+    async fn read(&self, path: &Path) -> Result<Bytes, FsError> {
+        TokioFs.read(path).await
+    }
+
+    async fn read_to_string(&self, path: &Path) -> Result<String, FsError> {
+        TokioFs.read_to_string(path).await
+    }
+
+    async fn exists(&self, path: &Path) -> bool {
+        let exists = TokioFs.exists(path).await;
+        if path == self.target {
+            assert!(!exists, "the precheck must really observe an absent target");
+            self.observed.wait().await;
+            self.created.wait().await;
+        }
+        exists
+    }
+
+    async fn canonicalize(&self, path: &Path) -> Result<PathBuf, FsError> {
+        TokioFs.canonicalize(path).await
+    }
+}
+
+impl FsWriteDyn for ObservedAbsence {
+    async fn write_new(&self, path: &Path, contents: &[u8]) -> Result<(), FsError> {
+        TokioFs.write_new(path, contents).await
+    }
+
+    async fn write(&self, path: &Path, contents: &[u8]) -> Result<(), FsError> {
+        TokioFs.write(path, contents).await
+    }
+
+    async fn create_dir_all(&self, path: &Path) -> Result<(), FsError> {
+        TokioFs.create_dir_all(path).await
+    }
+
+    async fn remove_file(&self, path: &Path) -> Result<(), FsError> {
+        TokioFs.remove_file(path).await
+    }
+}
+
+struct Scratch(PathBuf);
+
+#[tokio::test]
+async fn mock_exclusive_write_preserves_an_implicit_directory() -> std::io::Result<()> {
+    let fs = nika_kernel_mock::MockFs::new().with_file("dir/child", b"peer");
+    let refused = fs.write_new(Path::new("dir"), b"replacement").await;
+    assert!(matches!(refused, Err(FsError::AlreadyExists { .. })));
+    assert_eq!(
+        fs.read(Path::new("dir/child"))
+            .await
+            .map_err(std::io::Error::other)?
+            .as_ref(),
+        b"peer"
+    );
+    assert!(fs.read(Path::new("dir")).await.is_err());
+    Ok(())
+}
+
+impl Drop for Scratch {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0); // seam-bypass-ok: test owns and observes its real filesystem scratch.
+    }
+}
+
+#[tokio::test]
+async fn write_preserves_a_target_created_after_absence_check() -> std::io::Result<()> {
+    write_race(false).await
+}
+
+#[tokio::test]
+async fn judged_write_preserves_a_target_created_after_absence_check() -> std::io::Result<()> {
+    write_race(true).await
+}
+
+async fn write_race(through_judged: bool) -> std::io::Result<()> {
+    let root = std::env::temp_dir().join(format!("nika-write-race-{}", uuid::Uuid::new_v4())); // seam-bypass-ok: unique test scratch name, not workflow entropy.
+    std::fs::create_dir(&root).map_err(std::io::Error::other)?; // seam-bypass-ok: test owns and observes its real filesystem scratch.
+    let scratch = Scratch(root);
+    let fs = ObservedAbsence {
+        target: scratch.0.join("target.txt"),
+        observed: Barrier::new(2),
+        created: Barrier::new(2),
+    };
+    let args = serde_json::from_value(serde_json::json!({
+        "path": fs.target, "content": "first-writer", "overwrite": false
+    }))
+    .map_err(std::io::Error::other)?;
+    let peer = async {
+        fs.observed.wait().await;
+        let written = tokio::fs::write(&fs.target, b"peer-complete").await;
+        fs.created.wait().await;
+        written
+    };
+    let boundary = crate::FsBoundary::unbounded();
+    let judged = crate::judged_fs::JudgedFs::new(&fs, &boundary);
+    let write = async {
+        if through_judged {
+            super::write(&judged, &args).await
+        } else {
+            super::write(&fs, &args).await
+        }
+    };
+    let (result, peer_result) = tokio::time::timeout(std::time::Duration::from_secs(10), async {
+        tokio::join!(write, peer)
+    })
+    .await
+    .map_err(std::io::Error::other)?;
+    peer_result.map_err(std::io::Error::other)?;
+    let observed = tokio::fs::read(&fs.target)
+        .await
+        .map_err(std::io::Error::other)?;
+    assert_eq!(observed, b"peer-complete", "write result: {result:?}");
+    assert!(matches!(result, Err(failure) if failure.code == "NIKA-BUILTIN-WRITE-002"));
+    Ok(())
+}
+
+#[tokio::test]
+async fn exclusive_write_uses_the_dispatch_guard_and_judged_backend() -> std::io::Result<()> {
+    use std::sync::Arc;
+
+    use nika_kernel::runtime::tool_executor::{ToolCall, ToolExecuteDyn};
+    use nika_kernel_mock::{MockClock, MockHttp};
+
+    let root = std::env::temp_dir().join(format!("nika-write-guard-{}", uuid::Uuid::new_v4())); // seam-bypass-ok: unique test scratch name, not workflow entropy.
+    std::fs::create_dir(&root).map_err(std::io::Error::other)?; // seam-bypass-ok: test owns and observes its real filesystem scratch.
+    let scratch = Scratch(root);
+    let boundary =
+        crate::FsBoundary::declared(vec![], vec![format!("{}/allowed/**", scratch.0.display())]);
+    let dispatcher = crate::BuiltinDispatcher::new(
+        Arc::new(TokioFs),
+        Arc::new(MockHttp::new()),
+        Arc::new(MockClock::new()),
+        Arc::new(crate::NullEmitter),
+        Arc::new(crate::NonInteractive),
+        Arc::new(crate::NoWorkflow),
+    )
+    .with_fs_boundary(boundary);
+    let target = scratch.0.join("allowed/new/file.bin");
+    let call = |path: &Path| {
+        ToolCall::new(
+            "write",
+            "nika:write",
+            serde_json::json!({
+                "path": path, "content": {"bytes_base64": "AP8="}, "overwrite": false
+            }),
+        )
+    };
+    let created = dispatcher
+        .execute(call(&target))
+        .await
+        .map_err(std::io::Error::other)?;
+    assert!(!created.is_error, "{}", created.content);
+    assert_eq!(std::fs::read(&target)?, [0, 255]); // seam-bypass-ok: independent test observation.
+    let refused = dispatcher
+        .execute(call(&target))
+        .await
+        .map_err(std::io::Error::other)?;
+    assert!(refused.is_error && refused.content.starts_with("NIKA-BUILTIN-WRITE-002"));
+    assert_eq!(std::fs::read(&target)?, [0, 255]); // seam-bypass-ok: independent test observation.
+    let outside = scratch.0.join("denied/new/file.bin");
+    let denied = dispatcher
+        .execute(call(&outside))
+        .await
+        .map_err(std::io::Error::other)?;
+    assert!(denied.is_error && denied.content.starts_with("NIKA-SEC-004"));
+    assert!(!scratch.0.join("denied").exists());
+    Ok(())
+}

--- a/crates/nika-builtin/src/judged_fs.rs
+++ b/crates/nika-builtin/src/judged_fs.rs
@@ -290,6 +290,10 @@ impl<F: FsWriteDyn> FsWriteDyn for JudgedFs<'_, F> {
         self.inner.write(path, contents).await
     }
 
+    async fn write_new(&self, path: &Path, contents: &[u8]) -> Result<(), FsError> {
+        self.inner.write_new(path, contents).await
+    }
+
     async fn create_dir_all(&self, path: &Path) -> Result<(), FsError> {
         self.inner.create_dir_all(path).await
     }

--- a/crates/nika-fs/README.md
+++ b/crates/nika-fs/README.md
@@ -11,7 +11,7 @@ use nika_fs::TokioFs;
 use nika_kernel::{FsRead, FsWrite, FsList};
 use std::path::Path;
 
-# async fn example() -> std::io::Result<()> {
+# async fn example() -> Result<(), nika_kernel::fs::FsError> {
 let fs = TokioFs;                       // zero-size, Copy
 fs.write(Path::new("out/report.md"), b"# done").await?;   // atomic temp+rename · parents auto-created
 let text = fs.read_to_string(Path::new("out/report.md")).await?;
@@ -25,7 +25,7 @@ let workflows = fs.glob(Path::new("."), "**/*.nika.yaml").await?;  // sorted · 
 | trait | methods | backed by |
 |---|---|---|
 | `FsRead` | `read` · `read_to_string` · `exists` · `canonicalize` | `tokio::fs` |
-| `FsWrite` | `write` (atomic) · `create_dir_all` · `remove_file` | temp + `rename` |
+| `FsWrite` | `write` (replaces) · `write_new` (exclusive) · `create_dir_all` · `remove_file` | `write`: temp + `rename`; `write_new`: temp + exclusive hard link |
 | `FsMeta` | `metadata` | `tokio::fs::metadata` |
 | `FsList` | `list_dir` (sorted) · `glob` (globset · `literal_separator`) | iterative walk |
 
@@ -33,7 +33,9 @@ Implements the `*Dyn` (`Send`-future) kernel companions — the base traits
 and the `Fs` umbrella arrive via the `trait_variant` blanket impls, and
 futures are `tokio::spawn`-able.
 
-No error enum — the kernel fs contract speaks `std::io::Result`.
+Filesystem trait errors use `nika_kernel::fs::FsError`; no crate-owned
+error enum. See the [kernel backend migration contract](../../docs/crate-specs/nika-kernel-core.md#4-filesystem-backend-migration)
+and [TokioFs publication and cancellation limits](../../docs/crate-specs/nika-fs.md#exclusive-publication-and-backend-migration).
 Policy (sandbox roots, allow-lists) lives in `nika-policy` (L1.5), not here.
 
 ---

--- a/crates/nika-fs/public-api.txt
+++ b/crates/nika-fs/public-api.txt
@@ -62,6 +62,7 @@ impl nika_kernel_core::io::fs::FsWriteDyn for nika_fs::TokioFs
 pub async fn nika_fs::TokioFs::create_dir_all(&self, path: &std::path::Path) -> core::result::Result<(), nika_kernel_core::io::fs::FsError>
 pub async fn nika_fs::TokioFs::remove_file(&self, path: &std::path::Path) -> core::result::Result<(), nika_kernel_core::io::fs::FsError>
 pub async fn nika_fs::TokioFs::write(&self, path: &std::path::Path, contents: &[u8]) -> core::result::Result<(), nika_kernel_core::io::fs::FsError>
+pub async fn nika_fs::TokioFs::write_new(&self, path: &std::path::Path, contents: &[u8]) -> core::result::Result<(), nika_kernel_core::io::fs::FsError>
 impl<D> owo_colors::OwoColorize for nika_fs::TokioFs
 impl<T, U> core::convert::Into<U> for nika_fs::TokioFs where U: core::convert::From<T>
 pub fn nika_fs::TokioFs::into(self) -> U
@@ -102,3 +103,4 @@ impl<TraitVariantBlanketType> nika_kernel_core::io::fs::FsWrite for nika_fs::Tok
 pub async fn nika_fs::TokioFs::create_dir_all(&self, path: &std::path::Path) -> core::result::Result<(), nika_kernel_core::io::fs::FsError>
 pub async fn nika_fs::TokioFs::remove_file(&self, path: &std::path::Path) -> core::result::Result<(), nika_kernel_core::io::fs::FsError>
 pub async fn nika_fs::TokioFs::write(&self, path: &std::path::Path, contents: &[u8]) -> core::result::Result<(), nika_kernel_core::io::fs::FsError>
+pub fn nika_fs::TokioFs::write_new(&self, path: &std::path::Path, contents: &[u8]) -> impl core::future::future::Future<Output = core::result::Result<(), nika_kernel_core::io::fs::FsError>> + core::marker::Send

--- a/crates/nika-fs/src/lib.rs
+++ b/crates/nika-fs/src/lib.rs
@@ -36,7 +36,7 @@
 //! in the destination directory, then a single `rename` makes them
 //! visible (POSIX guarantees rename atomicity within one filesystem).
 //! Readers never observe a half-written file. A future dropped between
-//! the temp write and the rename may leave a stale `.nika-tmp.*` file —
+//! the temp write and the rename may leave a stale `.nika-tmp.*` or `..nika-tmp.*` file —
 //! exactly the failure mode the kernel trait documents — and the error
 //! path cleans its temp file best-effort. Durability (`fsync`) is
 //! intentionally NOT provided at this layer; callers needing
@@ -72,6 +72,10 @@ use nika_kernel::fs::{FileMetadata, FsError, FsListDyn, FsMetaDyn, FsReadDyn, Fs
 
 mod owned_dir;
 pub use owned_dir::OwnedDir;
+mod write_new;
+
+#[cfg(test)]
+mod write_new_tests;
 
 /// Monotonic discriminator for temp-file names: two concurrent writes to
 /// the same destination must never collide on the same temp path.
@@ -128,6 +132,22 @@ impl FsReadDyn for TokioFs {
 }
 
 impl FsWriteDyn for TokioFs {
+    /// Publish a completed sibling file with an exclusive hard link.
+    /// No fsync is added. The owned blocking operation can finish after its
+    /// future is dropped; cleanup of the temporary name is best-effort.
+    async fn write_new(&self, path: &Path, contents: &[u8]) -> Result<(), FsError> {
+        let path = path.to_path_buf();
+        let contents = contents.to_vec();
+        tokio::task::spawn_blocking(move || {
+            let staged = write_new::StagedFile::create(&path, &contents)?;
+            staged.publish(&path)
+        })
+        .await
+        .map_err(|error| FsError::Io {
+            reason: format!("exclusive write worker failed: {error}"),
+        })?
+    }
+
     /// Write contents to a file atomically (creates or overwrites).
     ///
     /// Parent directories are created automatically (brouillon parity).
@@ -145,7 +165,7 @@ impl FsWriteDyn for TokioFs {
     ///
     /// CANCEL SAFETY: `tokio::fs` operations detach (not abort) on drop —
     /// a cancelled write may still complete in the background, either
-    /// leaving a stale `.nika-tmp.*` file or fully publishing the
+    /// leaving a stale `.nika-tmp.*` or `..nika-tmp.*` file or fully publishing the
     /// destination, but NEVER a partial destination (the
     /// kernel-documented trade).
     async fn write(&self, path: &Path, contents: &[u8]) -> Result<(), FsError> {
@@ -274,12 +294,20 @@ impl FsListDyn for TokioFs {
 fn tmp_sibling(path: &Path) -> (Option<&Path>, PathBuf) {
     let parent = path.parent().filter(|p| !p.as_os_str().is_empty());
     let dir = parent.unwrap_or_else(|| Path::new("."));
-    // Purely discriminator-derived temp name: embedding the file name
+    // Discriminator-derived temp name: embedding the file name
     // would risk ENAMETOOLONG near the 255-byte limit and lossy
     // collisions on non-UTF-8 names — pid+counter alone guarantees
     // in-process uniqueness (review swarm P2 · 2026-06-10).
+    // A destination may itself look like a temporary name. Distinguish it
+    // with punctuation, so case folding cannot alias staging to destination.
+    let name = path.file_name().map(std::ffi::OsStr::as_encoded_bytes);
+    let prefix = if name.is_some_and(|name| name.starts_with(b".") && !name.starts_with(b"..")) {
+        "..nika-tmp"
+    } else {
+        ".nika-tmp"
+    };
     let tmp = dir.join(format!(
-        ".nika-tmp.{}.{}",
+        "{prefix}.{}.{}",
         std::process::id(),
         TMP_COUNTER.fetch_add(1, Ordering::Relaxed),
     ));

--- a/crates/nika-fs/src/write_new.rs
+++ b/crates/nika-fs/src/write_new.rs
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use nika_kernel::fs::FsError;
+
+/// A complete, privately named file awaiting exclusive publication.
+pub(super) struct StagedFile {
+    path: PathBuf,
+}
+
+impl StagedFile {
+    pub(super) fn create(destination: &Path, contents: &[u8]) -> Result<Self, FsError> {
+        if destination.file_name().is_none() {
+            return Err(FsError::InvalidData {
+                path: destination.display().to_string(),
+                reason: "write path has no file name".to_owned(),
+            });
+        }
+        let (parent, path) = super::tmp_sibling(destination);
+        if let Some(parent) = parent {
+            std::fs::create_dir_all(parent).map_err(|error| FsError::from_io(&error, parent))?;
+        }
+        // Construct the cleanup owner only after exclusive creation succeeds:
+        // a collision must never remove somebody else's temporary file.
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&path)
+            .map_err(|error| {
+                if error.kind() == std::io::ErrorKind::AlreadyExists {
+                    FsError::Io {
+                        reason: format!(
+                            "exclusive staging file already exists: {}",
+                            path.display()
+                        ),
+                    }
+                } else {
+                    FsError::from_io(&error, &path)
+                }
+            })?;
+        let staged = Self { path };
+        let written = file
+            .write_all(contents)
+            .map_err(|error| FsError::from_io(&error, &staged.path));
+        drop(file);
+        written?;
+        Ok(staged)
+    }
+
+    pub(super) fn publish(&self, destination: &Path) -> Result<(), FsError> {
+        // The name is claimed atomically; existing files, directories and
+        // symlinks survive. Unsupported filesystems fail without a rename fallback.
+        std::fs::hard_link(&self.path, destination)
+            .map_err(|error| FsError::from_io(&error, destination))
+    }
+}
+
+impl Drop for StagedFile {
+    fn drop(&mut self) {
+        // Publication has already committed when cleanup follows a successful
+        // link. A cleanup failure cannot undo it or turn it into a failed write.
+        let _ = std::fs::remove_file(&self.path);
+    }
+}

--- a/crates/nika-fs/src/write_new_tests.rs
+++ b/crates/nika-fs/src/write_new_tests.rs
@@ -1,0 +1,317 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Barrier};
+
+use nika_kernel::fs::{FsError, FsWriteDyn};
+
+use crate::TokioFs;
+use crate::write_new::StagedFile;
+
+type TestResult = std::io::Result<()>;
+
+#[test]
+fn temporary_names_stay_distinct_under_ascii_case_folding() {
+    for name in ["file", ".nika-tmp.1.0", ".NIKA-TMP.1.0", "..nika-tmp.1.0"] {
+        let destination = Path::new("parent").join(name);
+        let (_, temporary) = crate::tmp_sibling(&destination);
+        let temporary_name = temporary.file_name().map(std::ffi::OsStr::as_encoded_bytes);
+        assert!(
+            temporary_name
+                .is_some_and(|value| { !value[..2].eq_ignore_ascii_case(&name.as_bytes()[..2]) })
+        );
+        assert_eq!(temporary.parent(), destination.parent());
+    }
+}
+
+#[test]
+fn staging_name_cannot_be_the_requested_destination() -> TestResult {
+    use std::sync::atomic::Ordering;
+
+    let directory = tempfile::tempdir()?;
+    let next = crate::TMP_COUNTER.load(Ordering::Relaxed);
+    let destination = directory
+        .path()
+        .join(format!(".nika-tmp.{}.{}", std::process::id(), next));
+    let staged = StagedFile::create(&destination, b"complete").map_err(std::io::Error::other)?;
+    assert!(
+        matches!(
+            std::fs::symlink_metadata(&destination),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound
+        ),
+        "staging must use a distinct name"
+    );
+    staged
+        .publish(&destination)
+        .map_err(std::io::Error::other)?;
+    drop(staged);
+    assert_eq!(std::fs::read(&destination)?, b"complete");
+    let names = std::fs::read_dir(directory.path())?
+        .map(|entry| entry.map(|entry| entry.file_name()))
+        .collect::<std::io::Result<Vec<_>>>()?;
+    assert_eq!(
+        names,
+        vec![
+            destination
+                .file_name()
+                .ok_or_else(|| std::io::Error::other("missing name"))?
+                .to_os_string()
+        ]
+    );
+    Ok(())
+}
+
+fn assert_names(directory: &Path, expected: &[&str]) -> std::io::Result<()> {
+    let mut actual = std::fs::read_dir(directory)?
+        .map(|entry| entry.map(|entry| entry.file_name()))
+        .collect::<std::io::Result<Vec<_>>>()?;
+    actual.sort();
+    let mut expected: Vec<_> = expected.iter().map(|name| OsString::from(*name)).collect();
+    expected.sort();
+    assert_eq!(
+        actual, expected,
+        "all directory entries, including temporaries"
+    );
+    Ok(())
+}
+
+#[allow(
+    clippy::disallowed_methods,
+    reason = "two real filesystem writers start at one barrier on independent OS threads"
+)]
+fn start_writer(
+    runtime: tokio::runtime::Runtime,
+    destination: PathBuf,
+    contents: Vec<u8>,
+    barrier: Arc<Barrier>,
+) -> std::thread::JoinHandle<Result<(), FsError>> {
+    std::thread::spawn(move || {
+        barrier.wait();
+        runtime.block_on(TokioFs.write_new(&destination, &contents))
+    })
+}
+
+#[test]
+fn write_new_has_one_real_filesystem_winner() -> TestResult {
+    let directory = tempfile::tempdir()?;
+    let destination = directory.path().join("winner.bin");
+    let first_bytes = vec![0x31; 16_384];
+    let second_bytes = vec![0xb2; 16_384];
+    // Build before either writer waits: a runtime error must not strand a peer.
+    let first_runtime = tokio::runtime::Builder::new_current_thread().build()?;
+    let second_runtime = tokio::runtime::Builder::new_current_thread().build()?;
+    let barrier = Arc::new(Barrier::new(3));
+    let first = start_writer(
+        first_runtime,
+        destination.clone(),
+        first_bytes.clone(),
+        Arc::clone(&barrier),
+    );
+    let second = start_writer(
+        second_runtime,
+        destination.clone(),
+        second_bytes.clone(),
+        Arc::clone(&barrier),
+    );
+    barrier.wait();
+    let first = first
+        .join()
+        .map_err(|_| std::io::Error::other("first filesystem writer panicked"))?;
+    let second = second
+        .join()
+        .map_err(|_| std::io::Error::other("second filesystem writer panicked"))?;
+
+    assert_eq!(usize::from(first.is_ok()) + usize::from(second.is_ok()), 1);
+    let (winner, loser) = if first.is_ok() {
+        (&first_bytes, &second)
+    } else {
+        (&second_bytes, &first)
+    };
+    assert!(
+        matches!(loser, Err(FsError::AlreadyExists { .. })),
+        "{loser:?}"
+    );
+    assert_eq!(std::fs::read(&destination)?, *winner);
+    assert!(std::fs::symlink_metadata(&destination)?.is_file());
+    assert_names(directory.path(), &["winner.bin"])?;
+    Ok(())
+}
+
+#[test]
+fn staging_keeps_the_destination_absent_until_complete_publication() -> TestResult {
+    let directory = tempfile::tempdir()?;
+    let destination = directory.path().join("published.bin");
+    let contents = [0x00, 0xff, 0x80, b'\n', 0x7f];
+    let staged = StagedFile::create(&destination, &contents).map_err(std::io::Error::other)?;
+
+    assert!(matches!(
+        std::fs::symlink_metadata(&destination),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound
+    ));
+    let entries = std::fs::read_dir(directory.path())?.collect::<std::io::Result<Vec<_>>>()?;
+    let [temporary] = entries.as_slice() else {
+        return Err(std::io::Error::other(
+            "staging must create exactly one private file",
+        ));
+    };
+    assert_eq!(std::fs::read(temporary.path())?, contents);
+
+    staged
+        .publish(&destination)
+        .map_err(std::io::Error::other)?;
+    assert_eq!(std::fs::read(&destination)?, contents);
+    assert_eq!(std::fs::read(temporary.path())?, contents);
+    drop(staged);
+    assert_eq!(std::fs::read(&destination)?, contents);
+    assert_names(directory.path(), &["published.bin"])?;
+    Ok(())
+}
+
+#[test]
+fn a_peer_created_after_staging_survives_refusal_and_stage_cleanup() -> TestResult {
+    let directory = tempfile::tempdir()?;
+    let destination = directory.path().join("peer.bin");
+    let staged = StagedFile::create(&destination, b"our bytes").map_err(std::io::Error::other)?;
+    std::fs::write(&destination, b"peer bytes")?;
+
+    let refused = staged.publish(&destination);
+    assert!(
+        matches!(refused, Err(FsError::AlreadyExists { .. })),
+        "{refused:?}"
+    );
+    assert_eq!(std::fs::read(&destination)?, b"peer bytes");
+    drop(staged);
+    assert_eq!(std::fs::read(&destination)?, b"peer bytes");
+    assert_names(directory.path(), &["peer.bin"])?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn write_new_preserves_binary_content_and_refuses_an_existing_file() -> TestResult {
+    let directory = tempfile::tempdir()?;
+    let destination = directory.path().join("bytes.bin");
+    let bytes = [0x00, 0xff, 0x7f, 0x80, b'\n', 0xfe];
+    TokioFs
+        .write_new(&destination, &bytes)
+        .await
+        .map_err(std::io::Error::other)?;
+    assert_eq!(std::fs::read(&destination)?, bytes);
+
+    let refused = TokioFs.write_new(&destination, b"replacement").await;
+    assert!(
+        matches!(refused, Err(FsError::AlreadyExists { .. })),
+        "{refused:?}"
+    );
+    assert_eq!(std::fs::read(&destination)?, bytes);
+    assert_names(directory.path(), &["bytes.bin"])?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn write_new_refuses_an_existing_empty_file() -> TestResult {
+    let directory = tempfile::tempdir()?;
+    let destination = directory.path().join("empty");
+    std::fs::write(&destination, [])?;
+
+    let refused = TokioFs.write_new(&destination, b"not empty").await;
+    assert!(
+        matches!(refused, Err(FsError::AlreadyExists { .. })),
+        "{refused:?}"
+    );
+    assert!(std::fs::read(&destination)?.is_empty());
+    assert!(std::fs::symlink_metadata(&destination)?.is_file());
+    assert_names(directory.path(), &["empty"])?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn write_new_preserves_an_existing_directory_and_its_child() -> TestResult {
+    let directory = tempfile::tempdir()?;
+    let destination = directory.path().join("occupied");
+    std::fs::create_dir(&destination)?;
+    std::fs::write(destination.join("sentinel"), b"peer bytes")?;
+
+    let refused = TokioFs.write_new(&destination, b"replacement").await;
+    assert!(
+        matches!(refused, Err(FsError::AlreadyExists { .. })),
+        "{refused:?}"
+    );
+    assert!(std::fs::symlink_metadata(&destination)?.is_dir());
+    assert_eq!(std::fs::read(destination.join("sentinel"))?, b"peer bytes");
+    assert_names(directory.path(), &["occupied"])?;
+    assert_names(&destination, &["sentinel"])?;
+    Ok(())
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn write_new_preserves_a_symlink_and_its_existing_target() -> TestResult {
+    let directory = tempfile::tempdir()?;
+    let destination = directory.path().join("link");
+    let target = directory.path().join("target");
+    std::fs::write(&target, b"peer bytes")?;
+    std::os::unix::fs::symlink("target", &destination)?;
+
+    let refused = TokioFs.write_new(&destination, b"replacement").await;
+    assert!(
+        matches!(refused, Err(FsError::AlreadyExists { .. })),
+        "{refused:?}"
+    );
+    assert!(
+        std::fs::symlink_metadata(&destination)?
+            .file_type()
+            .is_symlink()
+    );
+    assert_eq!(std::fs::read_link(&destination)?, Path::new("target"));
+    assert_eq!(std::fs::read(&target)?, b"peer bytes");
+    assert_names(directory.path(), &["link", "target"])?;
+    Ok(())
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn write_new_preserves_a_dangling_symlink_without_creating_its_target() -> TestResult {
+    let directory = tempfile::tempdir()?;
+    let destination = directory.path().join("link");
+    let target = directory.path().join("missing");
+    std::os::unix::fs::symlink("missing", &destination)?;
+
+    let refused = TokioFs.write_new(&destination, b"replacement").await;
+    assert!(
+        matches!(refused, Err(FsError::AlreadyExists { .. })),
+        "{refused:?}"
+    );
+    assert!(
+        std::fs::symlink_metadata(&destination)?
+            .file_type()
+            .is_symlink()
+    );
+    assert_eq!(std::fs::read_link(&destination)?, Path::new("missing"));
+    assert!(matches!(
+        std::fs::symlink_metadata(&target),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound
+    ));
+    assert_names(directory.path(), &["link"])?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn write_still_replaces_a_file_created_exclusively() -> TestResult {
+    let directory = tempfile::tempdir()?;
+    let destination = directory.path().join("replace.bin");
+    TokioFs
+        .write_new(&destination, b"first")
+        .await
+        .map_err(std::io::Error::other)?;
+
+    TokioFs
+        .write(&destination, b"replacement")
+        .await
+        .map_err(std::io::Error::other)?;
+    assert_eq!(std::fs::read(&destination)?, b"replacement");
+    assert!(std::fs::symlink_metadata(&destination)?.is_file());
+    assert_names(directory.path(), &["replace.bin"])?;
+    Ok(())
+}

--- a/crates/nika-kernel-core/public-api.txt
+++ b/crates/nika-kernel-core/public-api.txt
@@ -1124,14 +1124,17 @@ pub trait nika_kernel_core::io::fs::FsWrite: core::marker::Send + core::marker::
 pub async fn nika_kernel_core::io::fs::FsWrite::create_dir_all(&self, path: &std::path::Path) -> core::result::Result<(), nika_kernel_core::io::fs::FsError>
 pub async fn nika_kernel_core::io::fs::FsWrite::remove_file(&self, path: &std::path::Path) -> core::result::Result<(), nika_kernel_core::io::fs::FsError>
 pub async fn nika_kernel_core::io::fs::FsWrite::write(&self, path: &std::path::Path, contents: &[u8]) -> core::result::Result<(), nika_kernel_core::io::fs::FsError>
+pub fn nika_kernel_core::io::fs::FsWrite::write_new(&self, path: &std::path::Path, contents: &[u8]) -> impl core::future::future::Future<Output = core::result::Result<(), nika_kernel_core::io::fs::FsError>> + core::marker::Send
 impl<TraitVariantBlanketType: nika_kernel_core::io::fs::FsWriteDyn> nika_kernel_core::io::fs::FsWrite for TraitVariantBlanketType
 pub async fn TraitVariantBlanketType::create_dir_all(&self, path: &std::path::Path) -> core::result::Result<(), nika_kernel_core::io::fs::FsError>
 pub async fn TraitVariantBlanketType::remove_file(&self, path: &std::path::Path) -> core::result::Result<(), nika_kernel_core::io::fs::FsError>
 pub async fn TraitVariantBlanketType::write(&self, path: &std::path::Path, contents: &[u8]) -> core::result::Result<(), nika_kernel_core::io::fs::FsError>
+pub fn TraitVariantBlanketType::write_new(&self, path: &std::path::Path, contents: &[u8]) -> impl core::future::future::Future<Output = core::result::Result<(), nika_kernel_core::io::fs::FsError>> + core::marker::Send
 pub trait nika_kernel_core::io::fs::FsWriteDyn: core::marker::Send + core::marker::Sync + core::marker::Send
 pub fn nika_kernel_core::io::fs::FsWriteDyn::create_dir_all(&self, path: &std::path::Path) -> impl core::future::future::Future<Output = core::result::Result<(), nika_kernel_core::io::fs::FsError>> + core::marker::Send
 pub fn nika_kernel_core::io::fs::FsWriteDyn::remove_file(&self, path: &std::path::Path) -> impl core::future::future::Future<Output = core::result::Result<(), nika_kernel_core::io::fs::FsError>> + core::marker::Send
 pub fn nika_kernel_core::io::fs::FsWriteDyn::write(&self, path: &std::path::Path, contents: &[u8]) -> impl core::future::future::Future<Output = core::result::Result<(), nika_kernel_core::io::fs::FsError>> + core::marker::Send
+pub fn nika_kernel_core::io::fs::FsWriteDyn::write_new(&self, path: &std::path::Path, contents: &[u8]) -> impl core::future::future::Future<Output = core::result::Result<(), nika_kernel_core::io::fs::FsError>> + core::marker::Send + core::marker::Send
 pub mod nika_kernel_core::io::http
 #[non_exhaustive] pub enum nika_kernel_core::io::http::HttpError
 pub nika_kernel_core::io::http::HttpError::Connection

--- a/crates/nika-kernel-core/src/io/fs.rs
+++ b/crates/nika-kernel-core/src/io/fs.rs
@@ -10,6 +10,9 @@ use std::path::{Path, PathBuf};
 
 use bytes::Bytes;
 
+#[cfg(test)]
+mod legacy_write_tests;
+
 /// Metadata about a filesystem entry.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
@@ -152,6 +155,28 @@ pub trait FsWrite: Send + Sync {
     /// CANCEL SAFETY: NOT cancel-safe unless impl uses atomic
     /// temp-file + rename. Partial writes possible.
     async fn write(&self, path: &Path, contents: &[u8]) -> Result<(), FsError>;
+
+    /// Publish complete contents only if the destination is absent at commit.
+    /// An occupied name, including a symlink, returns `AlreadyExists` without
+    /// replacing it. Durability is not implied. Cancellation can leave a
+    /// temporary file or a completed publication; dropping a future does not
+    /// prove that a detached filesystem operation has stopped.
+    ///
+    /// Existing backends remain source-compatible but must implement this
+    /// operation before serving exclusive writes. The default refuses without
+    /// I/O; it must never approximate exclusivity with `exists` then `write`.
+    fn write_new(
+        &self,
+        path: &Path,
+        contents: &[u8],
+    ) -> impl std::future::Future<Output = Result<(), FsError>> + Send {
+        let _ = (path, contents);
+        async {
+            Err(FsError::Io {
+                reason: "exclusive publication unsupported by this filesystem backend".to_owned(),
+            })
+        }
+    }
 
     /// Create a directory and all parent directories.
     ///

--- a/crates/nika-kernel-core/src/io/fs/legacy_write_tests.rs
+++ b/crates/nika-kernel-core/src/io/fs/legacy_write_tests.rs
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+use std::future::Future;
+use std::path::Path;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::task::{Context, Poll, Waker};
+
+use super::{FsError, FsWrite, FsWriteDyn};
+
+#[derive(Default)]
+struct Calls {
+    write: AtomicUsize,
+    create_dir_all: AtomicUsize,
+    remove_file: AtomicUsize,
+}
+
+impl Calls {
+    fn snapshot(&self) -> [usize; 3] {
+        [
+            self.write.load(Ordering::Relaxed),
+            self.create_dir_all.load(Ordering::Relaxed),
+            self.remove_file.load(Ordering::Relaxed),
+        ]
+    }
+}
+
+#[derive(Default)]
+struct LegacyBaseFs(Calls);
+
+// Deliberately only the three pre-existing members: no write_new override.
+impl FsWrite for LegacyBaseFs {
+    /// CANCEL SAFETY: one synchronous counter increment; no await or I/O.
+    async fn write(&self, _: &Path, _: &[u8]) -> Result<(), FsError> {
+        self.0.write.fetch_add(1, Ordering::Relaxed);
+        Ok(())
+    }
+
+    /// CANCEL SAFETY: one synchronous counter increment; no await or I/O.
+    async fn create_dir_all(&self, _: &Path) -> Result<(), FsError> {
+        self.0.create_dir_all.fetch_add(1, Ordering::Relaxed);
+        Ok(())
+    }
+
+    /// CANCEL SAFETY: one synchronous counter increment; no await or I/O.
+    async fn remove_file(&self, _: &Path) -> Result<(), FsError> {
+        self.0.remove_file.fetch_add(1, Ordering::Relaxed);
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+struct LegacySendFs(Calls);
+
+// This also obtains the base trait through trait_variant's blanket impl.
+impl FsWriteDyn for LegacySendFs {
+    /// CANCEL SAFETY: one synchronous counter increment; no await or I/O.
+    async fn write(&self, _: &Path, _: &[u8]) -> Result<(), FsError> {
+        self.0.write.fetch_add(1, Ordering::Relaxed);
+        Ok(())
+    }
+
+    /// CANCEL SAFETY: one synchronous counter increment; no await or I/O.
+    async fn create_dir_all(&self, _: &Path) -> Result<(), FsError> {
+        self.0.create_dir_all.fetch_add(1, Ordering::Relaxed);
+        Ok(())
+    }
+
+    /// CANCEL SAFETY: one synchronous counter increment; no await or I/O.
+    async fn remove_file(&self, _: &Path) -> Result<(), FsError> {
+        self.0.remove_file.fetch_add(1, Ordering::Relaxed);
+        Ok(())
+    }
+}
+
+fn complete_now<F: Future>(future: F) -> Result<F::Output, &'static str> {
+    let mut future = std::pin::pin!(future);
+    let mut context = Context::from_waker(Waker::noop());
+    match future.as_mut().poll(&mut context) {
+        Poll::Ready(output) => Ok(output),
+        Poll::Pending => Err("the unsupported default must refuse without awaiting IO"),
+    }
+}
+
+fn send_future<F: Future + Send>(future: F) -> F {
+    future
+}
+
+#[test]
+fn legacy_base_backend_refuses_exclusive_publication_without_any_io() -> std::io::Result<()> {
+    let fs = LegacyBaseFs::default();
+    let path = Path::new("not-created/nested/output.bin");
+    let refused = complete_now(FsWrite::write_new(&fs, path, &[0x00, 0xff]))
+        .map_err(std::io::Error::other)?;
+    assert!(matches!(refused, Err(FsError::Io { .. })), "{refused:?}");
+    assert_eq!(fs.0.snapshot(), [0, 0, 0]);
+
+    // The counters are live and the original three operations remain callable.
+    complete_now(FsWrite::write(&fs, path, b"legacy"))
+        .map_err(std::io::Error::other)?
+        .map_err(std::io::Error::other)?;
+    complete_now(FsWrite::create_dir_all(&fs, path))
+        .map_err(std::io::Error::other)?
+        .map_err(std::io::Error::other)?;
+    complete_now(FsWrite::remove_file(&fs, path))
+        .map_err(std::io::Error::other)?
+        .map_err(std::io::Error::other)?;
+    assert_eq!(fs.0.snapshot(), [1, 1, 1]);
+    Ok(())
+}
+
+#[test]
+fn legacy_send_backend_and_its_base_blanket_refuse_without_any_io() -> std::io::Result<()> {
+    let fs = LegacySendFs::default();
+    let path = Path::new("not-created/nested/output.bin");
+    let refused = complete_now(send_future(FsWriteDyn::write_new(&fs, path, b"send")))
+        .map_err(std::io::Error::other)?;
+    assert!(matches!(refused, Err(FsError::Io { .. })), "{refused:?}");
+    assert_eq!(fs.0.snapshot(), [0, 0, 0]);
+
+    let refused =
+        complete_now(FsWrite::write_new(&fs, path, b"base")).map_err(std::io::Error::other)?;
+    assert!(matches!(refused, Err(FsError::Io { .. })), "{refused:?}");
+    assert_eq!(fs.0.snapshot(), [0, 0, 0]);
+
+    complete_now(FsWriteDyn::write(&fs, path, b"legacy"))
+        .map_err(std::io::Error::other)?
+        .map_err(std::io::Error::other)?;
+    complete_now(FsWriteDyn::create_dir_all(&fs, path))
+        .map_err(std::io::Error::other)?
+        .map_err(std::io::Error::other)?;
+    complete_now(FsWriteDyn::remove_file(&fs, path))
+        .map_err(std::io::Error::other)?
+        .map_err(std::io::Error::other)?;
+    assert_eq!(fs.0.snapshot(), [1, 1, 1]);
+    Ok(())
+}

--- a/crates/nika-kernel-mock/public-api.txt
+++ b/crates/nika-kernel-mock/public-api.txt
@@ -302,6 +302,7 @@ impl nika_kernel_core::io::fs::FsWriteDyn for nika_kernel_mock::filesystem::Mock
 pub async fn nika_kernel_mock::filesystem::MockFs::create_dir_all(&self, _path: &std::path::Path) -> core::result::Result<(), nika_kernel_core::io::fs::FsError>
 pub async fn nika_kernel_mock::filesystem::MockFs::remove_file(&self, path: &std::path::Path) -> core::result::Result<(), nika_kernel_core::io::fs::FsError>
 pub async fn nika_kernel_mock::filesystem::MockFs::write(&self, path: &std::path::Path, contents: &[u8]) -> core::result::Result<(), nika_kernel_core::io::fs::FsError>
+pub async fn nika_kernel_mock::filesystem::MockFs::write_new(&self, path: &std::path::Path, contents: &[u8]) -> core::result::Result<(), nika_kernel_core::io::fs::FsError>
 impl<D> owo_colors::OwoColorize for nika_kernel_mock::filesystem::MockFs
 impl<T, U> core::convert::Into<U> for nika_kernel_mock::filesystem::MockFs where U: core::convert::From<T>
 pub fn nika_kernel_mock::filesystem::MockFs::into(self) -> U
@@ -342,6 +343,7 @@ impl<TraitVariantBlanketType> nika_kernel_core::io::fs::FsWrite for nika_kernel_
 pub async fn nika_kernel_mock::filesystem::MockFs::create_dir_all(&self, path: &std::path::Path) -> core::result::Result<(), nika_kernel_core::io::fs::FsError>
 pub async fn nika_kernel_mock::filesystem::MockFs::remove_file(&self, path: &std::path::Path) -> core::result::Result<(), nika_kernel_core::io::fs::FsError>
 pub async fn nika_kernel_mock::filesystem::MockFs::write(&self, path: &std::path::Path, contents: &[u8]) -> core::result::Result<(), nika_kernel_core::io::fs::FsError>
+pub fn nika_kernel_mock::filesystem::MockFs::write_new(&self, path: &std::path::Path, contents: &[u8]) -> impl core::future::future::Future<Output = core::result::Result<(), nika_kernel_core::io::fs::FsError>> + core::marker::Send
 pub mod nika_kernel_mock::http
 #[non_exhaustive] pub struct nika_kernel_mock::http::MockHttp
 impl nika_kernel_mock::http::MockHttp
@@ -1141,6 +1143,7 @@ impl nika_kernel_core::io::fs::FsWriteDyn for nika_kernel_mock::filesystem::Mock
 pub async fn nika_kernel_mock::filesystem::MockFs::create_dir_all(&self, _path: &std::path::Path) -> core::result::Result<(), nika_kernel_core::io::fs::FsError>
 pub async fn nika_kernel_mock::filesystem::MockFs::remove_file(&self, path: &std::path::Path) -> core::result::Result<(), nika_kernel_core::io::fs::FsError>
 pub async fn nika_kernel_mock::filesystem::MockFs::write(&self, path: &std::path::Path, contents: &[u8]) -> core::result::Result<(), nika_kernel_core::io::fs::FsError>
+pub async fn nika_kernel_mock::filesystem::MockFs::write_new(&self, path: &std::path::Path, contents: &[u8]) -> core::result::Result<(), nika_kernel_core::io::fs::FsError>
 impl<D> owo_colors::OwoColorize for nika_kernel_mock::filesystem::MockFs
 impl<T, U> core::convert::Into<U> for nika_kernel_mock::filesystem::MockFs where U: core::convert::From<T>
 pub fn nika_kernel_mock::filesystem::MockFs::into(self) -> U
@@ -1181,6 +1184,7 @@ impl<TraitVariantBlanketType> nika_kernel_core::io::fs::FsWrite for nika_kernel_
 pub async fn nika_kernel_mock::filesystem::MockFs::create_dir_all(&self, path: &std::path::Path) -> core::result::Result<(), nika_kernel_core::io::fs::FsError>
 pub async fn nika_kernel_mock::filesystem::MockFs::remove_file(&self, path: &std::path::Path) -> core::result::Result<(), nika_kernel_core::io::fs::FsError>
 pub async fn nika_kernel_mock::filesystem::MockFs::write(&self, path: &std::path::Path, contents: &[u8]) -> core::result::Result<(), nika_kernel_core::io::fs::FsError>
+pub fn nika_kernel_mock::filesystem::MockFs::write_new(&self, path: &std::path::Path, contents: &[u8]) -> impl core::future::future::Future<Output = core::result::Result<(), nika_kernel_core::io::fs::FsError>> + core::marker::Send
 #[non_exhaustive] pub struct nika_kernel_mock::MockHttp
 impl nika_kernel_mock::http::MockHttp
 pub fn nika_kernel_mock::http::MockHttp::enqueue_err(self, error: nika_kernel_core::io::http::HttpError) -> Self

--- a/crates/nika-kernel-mock/src/filesystem.rs
+++ b/crates/nika-kernel-mock/src/filesystem.rs
@@ -101,6 +101,28 @@ impl FsReadDyn for MockFs {
 }
 
 impl FsWriteDyn for MockFs {
+    async fn write_new(&self, path: &Path, contents: &[u8]) -> Result<(), FsError> {
+        let mut files = self.files.write();
+        let prefix = format!("{}/", path.display());
+        if files
+            .keys()
+            .any(|child| child.to_string_lossy().starts_with(&prefix))
+        {
+            return Err(FsError::AlreadyExists {
+                path: path.display().to_string(),
+            });
+        }
+        match files.entry(path.to_path_buf()) {
+            std::collections::btree_map::Entry::Occupied(_) => Err(FsError::AlreadyExists {
+                path: path.display().to_string(),
+            }),
+            std::collections::btree_map::Entry::Vacant(entry) => {
+                entry.insert(contents.to_vec());
+                Ok(())
+            }
+        }
+    }
+
     async fn write(&self, path: &Path, contents: &[u8]) -> Result<(), FsError> {
         self.files
             .write()

--- a/docs/crate-specs/nika-builtin.md
+++ b/docs/crate-specs/nika-builtin.md
@@ -105,6 +105,16 @@ compact JSON). One rendering, one seam.
 
 ### Honest gaps (delegations, not omissions)
 
+`write overwrite:false` retains the stdlib §write arguments, path result and
+WRITE-002 code, but routes publication through `FsWriteDyn::write_new` so a
+target created after the early absence check remains intact. `JudgedFs`
+delegates this operation after the existing dispatch guard and parent policy.
+Backends without exclusive publication refuse through WRITE-001; implement
+the provided kernel method to migrate them. Replacement writes and edit retain
+their existing seam. Publication is neither fsync durability nor proof that a
+cancelled blocking operation has stopped; inspect the actual file before retry
+after an uncertain result.
+
 - **Path capability gating** (`nika:write` outside-CWD rejection · NIKA-204
   class): NOT here — `nika-policy` (L1.5 · design locked, impl gated on
   kernel-migration) sits between the verbs and this dispatcher. A canary

--- a/docs/crate-specs/nika-fs.md
+++ b/docs/crate-specs/nika-fs.md
@@ -11,7 +11,7 @@
 | License | `AGPL-3.0-or-later` |
 | Edition | 2024 |
 | Publish | `false` — internal L1 effect crate |
-| NIKA codes | none — the kernel fs contract speaks `std::io::Result` (no crate error enum, like nika-clock) |
+| NIKA codes | kernel `FsError` taxonomy — no crate-owned error enum; `OwnedDir` returns `std::io::Result` |
 
 ---
 
@@ -42,7 +42,10 @@ pub struct TokioFs;
 pub struct OwnedDir; // held dirfd · contained components · nofollow children
 
 impl FsReadDyn  for TokioFs { read · read_to_string · exists · canonicalize }
-impl FsWriteDyn for TokioFs { write (ATOMIC temp+rename) · create_dir_all · remove_file }
+impl FsWriteDyn for TokioFs {
+  write (temp+rename, replaces) · write_new (complete temp+exclusive hard link)
+  create_dir_all · remove_file
+}
 impl FsMetaDyn  for TokioFs { metadata }
 impl FsListDyn  for TokioFs { list_dir (sorted) · glob (literal_separator · sorted) }
 
@@ -59,10 +62,45 @@ consumers can `tokio::spawn` filesystem work. (The `*Dyn` forms are
 generic bounds, NOT dyn-dispatch surfaces — RPITIT is not object-safe;
 per the kernel doc, L1 impls fan out via `Arc<T>`, not `Arc<dyn _>`.)
 
+### Exclusive publication and backend migration
+
+`write_new(path, contents)` publishes a complete file only if the destination
+name is unoccupied. TokioFs writes arbitrary bytes to an exclusively created
+temporary sibling, then publishes with `std::fs::hard_link`. An existing file,
+directory, or symlink is preserved and returns `FsError::AlreadyExists`.
+Unsupported filesystem operations fail without falling back to replacement.
+The ordinary `write` operation continues to create or replace by rename;
+other writers using that operation retain their replacement semantics.
+
+The exclusive operation runs in `spawn_blocking`. Dropping its future does
+not stop that worker: publication can complete after the caller stops waiting.
+Complete, exclusive publication is not crash durability; this operation adds
+no `fsync`. Once the link succeeds, the destination is committed. Removing
+the temporary name is best-effort cleanup, and a cleanup failure can leave a
+temporary alias while the operation still reports successful publication.
+An interrupted observer must establish the final state independently rather
+than treating cancellation as proof that no file was written.
+
+The kernel method has a provided default that returns `FsError::Io` without
+calling any filesystem operation. Existing backend implementations still
+compile with their original three methods, but `nika:write` with
+`overwrite:false` refuses until the backend overrides `write_new` with the
+exclusive contract. Wrappers must forward that method explicitly, including
+wrappers whose inner backend already supports it. An `exists` check followed
+by ordinary `write` is not a valid implementation. This migration changes no
+workflow arguments or result shape: the builtin still returns its path.
+
+The lib tests in `src/write_new_tests.rs` use real filesystem readers and
+directory inventories to check one winner, exact bytes, destination absence
+before publication, occupied destinations, normal cleanup, and preservation
+of ordinary replacement. These checks do
+not establish crash durability, worker quiescence, or every filesystem's
+behavior. The earlier admission results below do not cover this new method.
+
 ### Diamond upgrades vs brouillon (CRAFT · ADR-001)
 
 1. **Atomic write** — brouillon used bare `tokio::fs::write` (partial
-   writes observable). Diamond writes to `.nika-tmp.{pid}.{counter}`
+   writes observable). Diamond writes to `.nika-tmp.{pid}.{counter}` (or `..nika-tmp.{pid}.{counter}` for a single-dot-prefixed destination, keeping staging distinct under case folding)
    beside the destination then `rename`s (POSIX atomicity) · parents
    auto-created (parity) · error path cleans the temp best-effort ·
    no `fsync` at this layer (documented · durability is a policy/engine

--- a/docs/crate-specs/nika-kernel-core.md
+++ b/docs/crate-specs/nika-kernel-core.md
@@ -40,3 +40,31 @@ keep importing through the `nika-kernel` facade.
 - NO dependency on any other kernel sibling (the base of the DAG).
 - `#[non_exhaustive]` ratchet + sealed-trait contract unchanged.
 - New io/infra traits land HERE (never in the hub).
+
+## 4. Filesystem backend migration
+
+`FsWrite::write_new(path, contents)` is a provided method, also present on
+the generated `FsWriteDyn` Send companion. It requests publication of complete
+bytes at an unoccupied destination. It is distinct from `write`, which keeps
+its existing create-or-replace contract. No workflow argument or result type
+is introduced by this Rust interface addition.
+
+The default returns `FsError::Io` without invoking `write`, `create_dir_all`,
+or `remove_file`. Backends implementing only those original three methods
+remain source-compatible. They refuse `nika:write` with `overwrite:false`
+until they implement the exclusive operation; they must never simulate it
+with a separate `exists` check and a replacing write. Backend wrappers must
+forward the new method, or they retain the unsupported default even when
+their inner backend implements it.
+
+Implementations report `FsError::AlreadyExists` for an occupied destination
+without changing that entry. A successful exclusive publication does not by
+itself promise `fsync`, cancellation quiescence, or a multi-file transaction.
+A caller abandoning the future cannot infer absence of effects from that
+action alone. Each implementation documents its commit and cleanup behavior.
+
+`io/fs/legacy_write_tests.rs` defines separate base and Send backends with
+only the original three methods. Immediate polling checks that both refuse
+without touching operation counters, including the Send backend's generated
+base implementation. These are interface/default checks, not real IO or
+runtime cancellation tests.

--- a/docs/crate-specs/nika-kernel-mock.md
+++ b/docs/crate-specs/nika-kernel-mock.md
@@ -94,7 +94,9 @@ impl MockClock {
 
 ### 2.2 MockFs — in-memory filesystem
 
-Implements: `nika_kernel::FsRead` + `nika_kernel::FsWrite` (therefore `Filesystem`)
+Implements the `FsReadDyn`, `FsWriteDyn`, `FsMetaDyn` and `FsListDyn`
+companions from `nika_kernel::fs`; their blanket implementations provide the
+base traits and the `Fs` umbrella.
 
 ```rust
 #[derive(Clone, Default)]
@@ -117,11 +119,16 @@ impl MockFs {
 // - glob(root, pattern) → Vec<PathBuf> (suffix matching)
 // - canonicalize(path) → Ok(path) (no-op, in-memory has no symlinks)
 
-// Trait impl: FsWrite
+// Trait impl: FsWriteDyn
+// - write_new(path, contents) → Ok(()) or FsError::AlreadyExists
 // - write(path, contents) → Ok(()) (upsert)
 // - create_dir_all(path) → Ok(()) (no-op, dirs are implicit)
 // - remove_file(path) → Ok(()) or NotFound
 ```
+
+Filesystem write methods return `Result<(), nika_kernel::fs::FsError>`.
+See the [kernel backend migration contract](nika-kernel-core.md#4-filesystem-backend-migration)
+for the provided method and wrapper obligations.
 
 ### 2.3 MockHttp — canned HTTP responses
 

--- a/docs/crate-specs/nika-kernel.md
+++ b/docs/crate-specs/nika-kernel.md
@@ -49,6 +49,11 @@ reserved on kernel traits for the 2.0 Connectome work.
 
 ### 2.1 Effect traits (ISP-layered)
 
+The filesystem signatures below use `nika_kernel::fs::FsError`. The
+provided `write_new` method and backend/wrapper migration are defined in
+[the kernel-core migration contract](nika-kernel-core.md#4-filesystem-backend-migration).
+Its default body is omitted from this API summary.
+
 ```rust
 // ── clock.rs (~40 LOC) ───────────────────────────────────────
 #[trait_variant::make(ClockDyn: Send)]
@@ -61,28 +66,34 @@ pub trait Clock: Send + Sync {
 // ── fs.rs (~120 LOC) ─────────────────────────────────────────
 #[trait_variant::make(FsReadDyn: Send)]
 pub trait FsRead: Send + Sync {
-    async fn read(&self, path: &Path) -> io::Result<Bytes>;
-    async fn read_to_string(&self, path: &Path) -> io::Result<String>;
+    async fn read(&self, path: &Path) -> Result<Bytes, FsError>;
+    async fn read_to_string(&self, path: &Path) -> Result<String, FsError>;
     async fn exists(&self, path: &Path) -> bool;
-    async fn canonicalize(&self, path: &Path) -> io::Result<PathBuf>;
+    async fn canonicalize(&self, path: &Path) -> Result<PathBuf, FsError>;
 }
 
 #[trait_variant::make(FsWriteDyn: Send)]
 pub trait FsWrite: Send + Sync {
-    async fn write(&self, path: &Path, contents: &[u8]) -> io::Result<()>;
-    async fn create_dir_all(&self, path: &Path) -> io::Result<()>;
-    async fn remove_file(&self, path: &Path) -> io::Result<()>;
+    async fn write(&self, path: &Path, contents: &[u8]) -> Result<(), FsError>;
+    // Provided method; default body omitted.
+    fn write_new(
+        &self,
+        path: &Path,
+        contents: &[u8],
+    ) -> impl std::future::Future<Output = Result<(), FsError>> + Send;
+    async fn create_dir_all(&self, path: &Path) -> Result<(), FsError>;
+    async fn remove_file(&self, path: &Path) -> Result<(), FsError>;
 }
 
 #[trait_variant::make(FsMetaDyn: Send)]
 pub trait FsMeta: Send + Sync {
-    async fn metadata(&self, path: &Path) -> io::Result<FileMetadata>;
+    async fn metadata(&self, path: &Path) -> Result<FileMetadata, FsError>;
 }
 
 #[trait_variant::make(FsListDyn: Send)]
 pub trait FsList: Send + Sync {
-    async fn list_dir(&self, path: &Path) -> io::Result<Vec<PathBuf>>;
-    async fn glob(&self, root: &Path, pattern: &str) -> io::Result<Vec<PathBuf>>;
+    async fn list_dir(&self, path: &Path) -> Result<Vec<PathBuf>, FsError>;
+    async fn glob(&self, root: &Path, pattern: &str) -> Result<Vec<PathBuf>, FsError>;
 }
 
 pub trait Fs: FsRead + FsWrite + FsMeta + FsList {}

--- a/estate.yaml
+++ b/estate.yaml
@@ -18,11 +18,11 @@ classes:
   testimonial: "captured evidence — fixtures, corpora, traces, receipts: proves behavior; neither shipped source nor regenerable output"
   foreign: "pointer to a third-party sovereign source"
 summary:
-  classified_files: 4867
+  classified_files: 4872
   file_rows: 11
   pattern_rows: 24
   by_class:
-    authored: 1887
+    authored: 1892
     authored-pin: 2
     generated: 127
     pinned-copy: 146
@@ -151,8 +151,8 @@ patterns:
     - "cargo-public-api 0.51.0"
 - glob: "crates/**/src/**"
   class: authored
-  match_count: 966
-  aggregate_sha256: b3d2cb65b362b767709078d668fa4aea6edc7bb16a0cede721ecb56869e93d83
+  match_count: 970
+  aggregate_sha256: 0a37f8c51732a0e7a898077f34b72784e1134cd197391f3af48dd67738b66256
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored
@@ -162,7 +162,7 @@ patterns:
 - glob: "crates/**"
   class: authored
   match_count: 148
-  aggregate_sha256: 4c4364fb076c7c79d5b85d896385e7d5c275f9daae0913a5078f89316d72f676
+  aggregate_sha256: 890634a72513db06545760d14fe23dca2a4aefd540f125d5b2ebd9ef754a3281
   evidence: "the remaining crate surface — Cargo.toml manifests · build.rs · benches · READMEs · hand-curated data catalogs (llm-providers · mcp-servers · embeddings · model-capabilities, probed daily by catalog-verify.yml); the pricing snapshot is excepted in files:"
   note: "scripts/sync-pack.sh is the ONE vendoring lane; the divergent crate-local duplicate was retired"
 - glob: "fuzz/**"
@@ -183,7 +183,7 @@ patterns:
 - glob: "docs/**"
   class: authored
   match_count: 123
-  aggregate_sha256: 66a06d01c479bb999579b6d86b148c0d553a5960537ac3484be5fb99943fc086
+  aggregate_sha256: a0a1ccd11c5984a1d88de9c28b113acc3cf9b99b28cb803eb99947b739dd9d7e
   evidence: "crate-specs · architecture prose · perf notes — no generation markers at file heads"
 - glob: "scripts/**"
   class: authored
@@ -203,7 +203,7 @@ patterns:
 - glob: ".agents/**"
   class: authored
   match_count: 33
-  aggregate_sha256: 0cb9b4b6bcd6730ee84e3a88ed5cdff581007611d189ac481104f4c8c00c58f4
+  aggregate_sha256: 99ecfac15272afa6b621721b743665d00669115f6a3b54c6303047e06f537b02
   evidence: "the engine-owned portable release kit; wave-sweep advances its manifests with the engine and nika-plugins mirrors these bytes only from immutable engine release tags via resync-mirror.py"
   note: "direction is engine tag → nika-plugins mirror; clients-resync owns only clients.registry.yaml and must never overwrite this tree from a moving downstream main branch"
 - glob: ".claude/**"
@@ -242,8 +242,8 @@ patterns:
   evidence: "examples/README.md — a pointer README (the runnable examples live in the vendored pack + the spec repo)"
 - glob: "changelog.d/**"
   class: authored
-  match_count: 2
-  aggregate_sha256: 8c568ac4a0e925842d19f7199d9bc0c07372d9059ae4992f6e68473543a35f2f
+  match_count: 3
+  aggregate_sha256: 2864d80d1e7c3b32522332a1addf0e62bbb6bbae13ae42b7977ce413ed6e964f
   evidence: "changelog.d/README.md — one hand-written bullet per change, authored by whoever makes the change; scripts/release/changelog-assemble.sh only CONSUMES them (--fold splices and deletes) and never writes one"
   note: "the README is permanent by design: a rule matching nothing is a coverage hole, and every fragment is deleted at fold time"
 - glob: "*"


### PR DESCRIPTION
## What

`nika:write` with `overwrite: false` publishes EXCLUSIVELY: a complete temporary is published by a hard link that fails if the destination now exists, so a file created concurrently between the precheck and the commit is never replaced (`NIKA-BUILTIN-WRITE-002`, as before, but now at the commit point). `overwrite: true` keeps the replacing `rename`. The kernel `FsWrite` trait gains the provided `write_new` method; `TokioFs` implements it, `MockFs` mirrors it, `JudgedFs` delegates; a backend unable to publish exclusively refuses instead of falling back to replacement. No new grant, argument, error code or grammar.

Two commits: the fix (936e56ce · WP06 candidate) and the migration follow-up that reaches the kernel, mock and fs crate specs (b6ef2100).

## Proof

- The race: reproduced on the baseline (one real-filesystem test failed at d9fc7526), green on the candidate; 654 lib tests across five crates; fmt/clippy clean; hygiene 38 GREEN / 9 YELLOW / 0 RED.
- Native cohort (public 0.118.7 vs candidate binary `3fd6a09f…`): 12/12 cells, 32 commands (12 checks · 10 runs · 10 verifies), 0 model USD; C3 = the expected `WRITE-002` refusal on both arms, C5 = the static `NIKA-SEC-004` refusal only.
- Independent capture review (2026-09-06): PASS · 12/12 cells and 32/32 raw captures cross-checked, 10/10 trace journals chain-verified, 112/112 sealed inputs re-hashed, 276 checks, 0 discrepancies.

## Limits stated in the docs and the operating skill

Atomic visibility is not fsync durability; a detached write is not promised to have stopped; cleanup of the temporary is best-effort; no CAS, no multi-file transaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>