### PR TITLE
fix(agent): the done def carries the schema and a missed result is repaired

### DIFF
--- a/changelog.d/agent-schema-rides-the-done-def.fixed.md
+++ b/changelog.d/agent-schema-rides-the-done-def.fixed.md
@@ -1,0 +1,12 @@
+- **An `agent:` task's `schema:` reaches the seat on the first request, and
+  a `nika:done` result that misses it is repaired instead of fatal.** The
+  loop-owned `nika:done` definition now carries the declared schema on its
+  `result` parameter, the one binding every wire sends verbatim (including
+  the seats whose API has no structured-output mode), so the model reads
+  the exact shape instead of guessing it from the prompt. A `result` that
+  fails validation goes back as that call's error observation and the
+  model finishes again, drawing on the same `DEFAULT_SCHEMA_RETRY_BUDGET`
+  the free-text re-ask uses, and the NIKA-464 verdict now says how many
+  repairs were tried. Previously the first request carried no schema, and
+  a non-conforming `nika:done` result died at once while a prose answer
+  got two repairs.

--- a/crates/nika-cli/tests/e2e_pipeline.rs
+++ b/crates/nika-cli/tests/e2e_pipeline.rs
@@ -1268,16 +1268,14 @@ async fn e2e_agent_budget_and_schema_terminals() {
     let ok = agent.run(input).await.expect("conforming result");
     assert!(matches!(ok.output, AgentValue::Structured(v) if v == serde_json::json!({"sum": 5})));
 
+    // A violating done result is fed back and re-asked under the loop's
+    // repair budget (two by default) before the schema gate goes fatal, so
+    // the seat that never conforms answers three times.
     let dispatcher = dispatcher_rig();
-    let provider = MockProvider::new("mock").enqueue_response(InferResponse::new(
-        vec![ContentBlock::ToolUse {
-            id: "s-2".to_owned(),
-            name: "nika:done".to_owned(),
-            input: serde_json::json!({ "result": { "sum": "five" } }),
-        }],
-        TokenUsage::new(10, 5),
-        StopReason::ToolUse,
-    ));
+    let provider = MockProvider::new("mock")
+        .enqueue_response(violating_done("s-2"))
+        .enqueue_response(violating_done("s-3"))
+        .enqueue_response(violating_done("s-4"));
     let agent = AgentVerb::new(
         Arc::new(provider),
         Arc::new(nika_verb_invoke::InvokeVerb::new(Arc::clone(&dispatcher))),
@@ -1292,6 +1290,21 @@ async fn e2e_agent_budget_and_schema_terminals() {
         matches!(bad, VerbAgentError::SchemaValidation { .. }),
         "{bad:?}"
     );
+}
+
+/// A `nika:done` answer whose `result` misses the `sum` schema (a string
+/// where an integer is required) — the shape the schema gate refuses.
+fn violating_done(id: &str) -> nika_kernel::provider::InferResponse {
+    use nika_kernel::provider::{ContentBlock, InferResponse, StopReason, TokenUsage};
+    InferResponse::new(
+        vec![ContentBlock::ToolUse {
+            id: id.to_owned(),
+            name: "nika:done".to_owned(),
+            input: serde_json::json!({ "result": { "sum": "five" } }),
+        }],
+        TokenUsage::new(10, 5),
+        StopReason::ToolUse,
+    )
 }
 
 // ─── test 7 · binary round-trip + tz rendering through the REAL chain ────

--- a/crates/nika-verb-agent/src/intrinsic.rs
+++ b/crates/nika-verb-agent/src/intrinsic.rs
@@ -65,10 +65,16 @@ pub(crate) fn is_loop_owned(name: &str) -> bool {
 /// a poisoned upstream def can never shadow them (the model sees the
 /// loop's own `nika:done` + `nika:compose`, default-deny when absent
 /// from `tools:`).
-pub(crate) fn synthesized_defs(whitelist: &crate::Whitelist) -> Vec<ToolDef> {
+///
+/// `schema` is the task's declared final-output contract, threaded in so
+/// the sentinel def can CARRY it (see [`done_def`]).
+pub(crate) fn synthesized_defs(
+    whitelist: &crate::Whitelist,
+    schema: Option<&serde_json::Value>,
+) -> Vec<ToolDef> {
     let mut defs = Vec::new();
     if whitelist.admits(crate::DONE_TOOL) {
-        defs.push(done_def());
+        defs.push(done_def(schema));
     }
     if whitelist.admits(COMPOSE_TOOL) {
         defs.push(compose_def());
@@ -77,18 +83,47 @@ pub(crate) fn synthesized_defs(whitelist: &crate::Whitelist) -> Vec<ToolDef> {
 }
 
 /// The synthesized `nika:done` sentinel definition (loop-owned).
-fn done_def() -> ToolDef {
+///
+/// Under a TYPED task the `result` parameter carries the declared
+/// `schema:` VERBATIM — the sentinel's own parameter schema IS how the
+/// contract reaches the seat, on the FIRST request and every one after.
+/// The binding is wire-universal by construction: a tool's parameter
+/// schema rides `tools[].function.parameters` (openai-compat),
+/// `functionDeclarations[].parametersJsonSchema` (gemini) and
+/// `input_schema` (anthropic) verbatim, so it needs no capability flag
+/// and it reaches the seats whose API has no structured mode at all
+/// (deepseek). `response_format` deliberately stays OFF the tool-calling
+/// turns — see the loop file's «Structured output» section: a grammar
+/// over the message content fights the `ReAct` turns it would ride on.
+///
+/// Untyped, the parameter stays open (any JSON) and OPTIONAL: a
+/// result-less `done` finishes on the model's last words.
+fn done_def(schema: Option<&serde_json::Value>) -> ToolDef {
+    let Some(schema) = schema else {
+        return ToolDef::new(
+            crate::DONE_TOOL,
+            "Finish the task. Pass `result` when the answer is a value; \
+             omit it to finish with your final message.",
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "result": {
+                        "description": "The final answer value (any JSON)."
+                    }
+                }
+            }),
+        );
+    };
     ToolDef::new(
         crate::DONE_TOOL,
-        "Finish the task. Pass `result` when the answer is a value; \
-         omit it to finish with your final message.",
+        "Finish the task by passing the final answer as `result`. \
+         `result` MUST satisfy the JSON Schema declared for it — the \
+         engine validates it and asks you to call this tool again when \
+         it does not conform.",
         serde_json::json!({
             "type": "object",
-            "properties": {
-                "result": {
-                    "description": "The final answer value (any JSON)."
-                }
-            }
+            "properties": { "result": schema },
+            "required": ["result"]
         }),
     )
 }

--- a/crates/nika-verb-agent/src/lib.rs
+++ b/crates/nika-verb-agent/src/lib.rs
@@ -97,6 +97,7 @@ mod guard;
 pub mod harness_path;
 mod intrinsic;
 mod io;
+mod request;
 mod router;
 mod shape;
 mod spill;
@@ -105,8 +106,8 @@ mod turn;
 use std::sync::Arc;
 
 use nika_kernel::ai::provider::{
-    ContentBlock, InferRequest, InferResponse, Message, ProviderInferDyn, ProviderMeta,
-    ResponseFormat, Role, TokenUsage, ToolDef,
+    ContentBlock, InferRequest, InferResponse, Message, ProviderInferDyn, ProviderMeta, Role,
+    TokenUsage, ToolDef,
 };
 use nika_kernel::ai::tool_defs::ToolDefinitionProviderDyn;
 use nika_kernel::blob::BlobStoreDyn;
@@ -117,6 +118,7 @@ use nika_types::cost::SpendOnFailure;
 use nika_verb_invoke::{InvokeInput, InvokeVerb, VerbInvokeError};
 
 use crate::guard::{Guard, GuardVerdict};
+use crate::request::{build_request, joined_text, opening_messages, routing_query, schema_request};
 use crate::router::ToolRouter;
 
 pub use config::{AgentConfig, GuardConfig, RouterConfig};
@@ -1118,43 +1120,6 @@ struct BatchOutcome {
     all_errors: bool,
 }
 
-/// One turn's request — the live transcript + this turn's routed tools.
-/// `defs` is consumed (the router already handed us an owned `Vec`) so a
-/// large fail-open universe isn't cloned a second time per turn.
-fn build_request(
-    model: &str,
-    messages: Vec<Message>,
-    input: &AgentInput,
-    defs: Vec<ToolDef>,
-) -> InferRequest {
-    let mut request = InferRequest::new(model, messages);
-    request.temperature = input.temperature;
-    request.tools = defs;
-    request
-}
-
-/// The FINAL schema-constrained re-ask request (BUG#11): tools OFF (the
-/// schema constraint and tool-calling do not reliably coexist in one
-/// request across providers — anthropic rejects `response_format`,
-/// openai/gemini are fragile), with the schema wired natively when the
-/// provider supports it (`infer`+schema parity · `build_request` mirror).
-fn schema_request(
-    model: &str,
-    messages: Vec<Message>,
-    input: &AgentInput,
-    schema: &serde_json::Value,
-    native: bool,
-) -> InferRequest {
-    let mut request = InferRequest::new(model, messages);
-    request.temperature = input.temperature;
-    // tools deliberately left empty (default) — see the doc comment.
-    if native {
-        request.response_format = ResponseFormat::JsonSchema(schema.clone());
-    }
-    request
-}
-
-/// Emit the `Finished` event + decorate the output with its spend
 /// identity: tool spend absent (never zero) when nothing reported ·
 /// the absorbed usage split + resolved model ride so the dispatch
 /// layer prices the LLM turns with the same resolver `infer` uses.
@@ -1190,13 +1155,6 @@ fn shaped(
     )
 }
 
-/// Per-component character budgets for the routing query — the live tail
-/// (`last_text` · `last_observations`) must always reach the ranker, so a
-/// long prompt can't evict it via a single tail-truncating cap.
-const QUERY_PROMPT_CHARS: usize = 2048;
-const QUERY_TEXT_CHARS: usize = 1024;
-const QUERY_OBS_CHARS: usize = 1024;
-
 /// One routing decision: select this turn's definitions + report it.
 fn route_turn(
     observer: &dyn AgentObserver,
@@ -1215,20 +1173,6 @@ fn route_turn(
     offered
 }
 
-/// Build the BM25 routing query from the live task context, each piece
-/// bounded independently (a 100 KB prompt can't crowd out the model's
-/// last words or the last observations — the signal routing ranks on).
-fn routing_query(prompt: &str, last_text: &str, last_observations: &str) -> String {
-    let take = |s: &str, n: usize| s.chars().take(n).collect::<String>();
-    format!(
-        "{} {} {}",
-        take(prompt, QUERY_PROMPT_CHARS),
-        take(last_text, QUERY_TEXT_CHARS),
-        take(last_observations, QUERY_OBS_CHARS),
-    )
-}
-
-/// The loop state a single turn's decision reads (keeps `classify_turn`
 /// a small pure function instead of a 7-argument signature).
 struct TurnCtx<'a> {
     input: &'a AgentInput,
@@ -1407,29 +1351,6 @@ fn redact_tool_name(name: &str) -> String {
     name.chars().filter(|c| !c.is_control()).take(64).collect()
 }
 
-/// The opening transcript: optional system, then the user prompt.
-fn opening_messages(input: &AgentInput) -> Vec<Message> {
-    let mut messages = Vec::with_capacity(2);
-    if let Some(system) = &input.system {
-        messages.push(Message::text(Role::System, system.clone()));
-    }
-    messages.push(Message::text(Role::User, input.prompt.clone()));
-    messages
-}
-
-/// Concatenate a response's text blocks (the assistant's words).
-fn joined_text(content: &[ContentBlock]) -> String {
-    content
-        .iter()
-        .filter_map(|block| match block {
-            ContentBlock::Text { text } => Some(text.as_str()),
-            _ => None,
-        })
-        .collect::<Vec<_>>()
-        .join("\n")
-}
-
-/// The typed feedback a failing tool sends the model — the NIKA code
 /// rides along so the model can reason about (and the human can grep)
 /// the failure class. Security-boundary refusals never reach here:
 /// [`security_boundary_code`] reroutes them to the hard stop first.

--- a/crates/nika-verb-agent/src/lib.rs
+++ b/crates/nika-verb-agent/src/lib.rs
@@ -40,24 +40,34 @@
 //!
 //! When the task declares `schema:`, the engine makes the FINAL answer
 //! conform — the same guarantee `infer`+schema gives, with no author
-//! hand-instruction. The loop is two-phase by necessity:
+//! hand-instruction. The contract reaches the seat on the FIRST request:
+//! the loop-owned `nika:done` definition carries the declared schema on
+//! its `result` parameter (`intrinsic::done_def`), so a model choosing
+//! how to finish can read the exact shape it must produce instead of
+//! guessing it from the prompt. That binding is wire-universal — a tool's
+//! parameter schema is sent verbatim by every wire, including the seats
+//! whose API has no structured mode at all.
 //!
-//! - the **tool-calling turns** run UNCONSTRAINED (tools on, no schema);
-//! - the **final answer** is the only thing the schema binds. A
-//!   deliberate `nika:done` `result:` is validated directly (the model
-//!   committed to that shape); a free-text answer (natural completion ·
-//!   result-less `done`) is validated, and if it does not yet conform the
-//!   loop RE-ASKS the provider WITH the schema wired (native
-//!   `response_format` when supported · an instruction otherwise),
-//!   bounded by [`DEFAULT_SCHEMA_RETRY_BUDGET`].
+//! `response_format` is a different mechanism and stays OFF the
+//! tool-calling turns: it constrains the assistant's MESSAGE CONTENT, and
+//! a grammar over the message fights the very turns it would ride on (the
+//! model must stay free to call tools first). It rides ONE request — the
+//! tools-OFF re-ask below — where nothing competes with it.
 //!
-//! The schema NEVER rides a tool-calling turn — tool-calling and
-//! structured-output do not reliably coexist in one request across
-//! providers (the anthropic wire rejects `response_format` outright;
-//! openai/gemini are fragile combining the two), so the re-ask is a
-//! tools-OFF turn and the conflict is sidestepped by construction. The
-//! post-hoc validation remains the safety net (a malformed answer that
-//! exhausts the budget is the NIKA-464 verdict).
+//! Two things can miss the schema, and BOTH repair, drawing on the one
+//! allowance [`DEFAULT_SCHEMA_RETRY_BUDGET`]:
+//!
+//! - a **`nika:done` `result:`** that does not validate — the errors go
+//!   back as that call's tool result (`is_error: true`, the agentic
+//!   convention) and the model finishes again;
+//! - a **free-text answer** (natural completion · result-less `done`) —
+//!   the loop RE-ASKS the provider on a tools-OFF turn WITH the schema
+//!   wired (native `response_format` when supported · an instruction
+//!   otherwise).
+//!
+//! Post-hoc validation remains the safety net: an answer that exhausts
+//! the allowance is the NIKA-464 verdict, and it SAYS how many repairs
+//! were tried.
 //!
 //! ## The intelligence layer (ADR-096 · engine-internal, zero YAML)
 //!
@@ -130,15 +140,17 @@ pub use whitelist::Whitelist;
 /// Default turn budget (spec §1 · `max_turns` default 10).
 pub const DEFAULT_MAX_TURNS: u32 = 10;
 
-/// Default schema-validation retry budget for the FINAL free-text answer
+/// Default schema-repair budget for the FINAL answer of a typed task
 /// (BUG#11 · parity with `nika_verb_infer::DEFAULT_SCHEMA_RETRY_BUDGET`).
 ///
-/// When a `schema:` task's final answer arrives as prose (not yet a
-/// conforming object), the loop re-asks it WITH the schema constrained to
-/// the provider, up to this many extra provider round-trips before the
-/// NIKA-464 verdict. `0` makes the final answer single-shot (validate the
-/// text as-is, no re-ask). Spec-sanctioned: « MAY auto-retry validation
-/// before emitting the schema-validation error ».
+/// ONE allowance covers BOTH ways a final answer can miss the `schema:` —
+/// a `nika:done` `result:` that does not validate (the errors ride back as
+/// that call's tool result and the model finishes again) and a free-text
+/// answer re-asked on a tools-OFF turn with the schema wired. A run that
+/// spends a repair on one path has that much less for the other, so a
+/// wandering model can never buy two budgets. `0` makes the final answer
+/// single-shot (validate as-is, no repair). Spec-sanctioned: « MAY
+/// auto-retry validation before emitting the schema-validation error ».
 pub const DEFAULT_SCHEMA_RETRY_BUDGET: u8 = 2;
 
 /// The sentinel tool the model calls to finish explicitly (spec §2).
@@ -409,91 +421,86 @@ where
     ) -> Result<AgentOutput, VerbAgentError> {
         let (whitelist, defs, model, budget) = armed;
         let (mut router, mut guard) = self.arm_loop(observer, model, defs);
-
-        let mut messages = opening_messages(&input);
-        let mut turns: u32 = 0;
-        let mut total_tokens: u64 = 0;
-        let mut last_text = String::new();
-        let mut last_observations = String::new();
+        let mut st = turn::LoopState::new(opening_messages(&input));
         // `loop`, not `while turns < max_turns`: the Dispatch arm is the
         // SOLE max_turns authority (fires BEFORE spending the final batch)
         // — a trailing `while` exit would be dead code (J2 review fold).
         loop {
-            turns += 1;
-            observer.on_event(&AgentEvent::TurnStarted { turn: turns });
+            st.turns += 1;
+            observer.on_event(&AgentEvent::TurnStarted { turn: st.turns });
 
             // Per-turn routing: rank the universe against the LIVE task
             // context (prompt + last words + last observations · budgeted).
-            let query = routing_query(&input.prompt, &last_text, &last_observations);
-            let offered = route_turn(observer, &router, defs, &query, turns);
+            let query = routing_query(&input.prompt, &st.last_text, &st.last_observations);
+            let offered = route_turn(observer, &router, defs, &query, st.turns);
 
-            let request = build_request(model, messages.clone(), &input, offered);
+            let request = build_request(model, st.messages.clone(), &input, offered);
             let response = self
                 .infer_turn(
                     observer,
-                    turns,
+                    st.turns,
                     request,
-                    &mut total_tokens,
+                    &mut st.total_tokens,
                     usage_total,
                     &input,
                 )
                 .await?;
             let text = joined_text(&response.content);
             if !text.is_empty() {
-                last_text.clone_from(&text);
+                st.last_text.clone_from(&text);
             }
 
             // Decide this turn — the ONE exit-conditions site (spec §2).
             let ctx = TurnCtx {
                 input: &input,
                 whitelist,
-                turns,
-                total_tokens,
-                last_text: &last_text,
+                turns: st.turns,
+                total_tokens: st.total_tokens,
+                last_text: &st.last_text,
+                repairs: st.repair_budget(self.schema_retry_budget),
             };
             // Terminals return one output (FinalText shapes to `schema:` ·
-            // BUG#11); Dispatch feeds back and iterates. One exit point.
+            // BUG#11); Dispatch and RepairDone feed back and iterate. One
+            // exit point.
             let output = match classify_turn(&response, &text, &ctx)? {
                 TurnVerdict::Done(output) => *output,
                 TurnVerdict::FinalText { text, stop_reason } => {
                     self.finalize_schema(
                         observer,
-                        &mut messages,
                         model,
                         text,
                         &response,
                         stop_reason,
                         &input,
-                        &mut total_tokens,
+                        &mut st,
                         usage_total,
-                        turns,
                     )
                     .await?
                 }
+                TurnVerdict::RepairDone(repair) => {
+                    st.repairs = st.repairs.saturating_add(1);
+                    feed_done_repair(&mut st.messages, response, &repair);
+                    continue;
+                }
                 TurnVerdict::Dispatch(tool_uses) => {
-                    let (digest, batch_cost) = self
+                    *tools_cost_usd += self
                         .dispatch_and_feed(
                             observer,
-                            turns,
                             budget,
                             tool_uses,
                             response,
-                            &mut router,
-                            &mut guard,
-                            &mut messages,
-                            &last_text,
+                            (&mut router, &mut guard),
+                            &mut st,
                             run_start,
                         )
                         .await?;
-                    *tools_cost_usd += batch_cost;
-                    last_observations = digest;
                     continue;
                 }
             };
             return Ok(finished(
                 observer,
                 output,
-                (turns, total_tokens),
+                (st.turns, st.total_tokens),
                 (usage_total.clone(), model.to_owned(), *tools_cost_usd),
             ));
         }
@@ -502,41 +509,51 @@ where
     /// One Dispatch turn within the loop: stop at the turn budget (the SOLE
     /// `max_turns` exit · BEFORE spending the batch, mirroring the token
     /// gate's "no wasted side effects"), else append the assistant turn and
-    /// feed the tool batch back. Returns the observations digest for the
-    /// next routing query; the stall and security stops surface as the
-    /// verb's own errors (NIKA-467 · NIKA-468). The budget carries its
-    /// F-P22 blame decided at arm time — the stop names the faulty
-    /// contract when the DEFAULT tripped.
+    /// feed the tool batch back. The observations digest lands in the
+    /// ledger for the next routing query and the batch's tool cost is
+    /// returned; the stall and security stops surface as the verb's own
+    /// errors (NIKA-467 · NIKA-468). The budget carries its F-P22 blame
+    /// decided at arm time — the stop names the faulty contract when the
+    /// DEFAULT tripped.
     #[allow(clippy::too_many_arguments)] // the loop's owned state threaded
     // once into the dispatch step; splitting only relocates the args.
     async fn dispatch_and_feed(
         &self,
         observer: &dyn AgentObserver,
-        turns: u32,
         budget: TurnBudget,
         tool_uses: Vec<ToolUse>,
         response: InferResponse,
-        router: &mut ToolRouter,
-        guard: &mut Guard,
-        messages: &mut Vec<Message>,
-        last_text: &str,
+        intelligence: (&mut ToolRouter, &mut Guard),
+        st: &mut turn::LoopState,
         run_start: Option<ToolRunStart>,
-    ) -> Result<(String, f64), VerbAgentError> {
-        if turns >= budget.max_turns {
+    ) -> Result<f64, VerbAgentError> {
+        let (router, guard) = intelligence;
+        if st.turns >= budget.max_turns {
             return Err(VerbAgentError::MaxTurns {
-                turns,
-                partial_output: last_text.to_owned(),
+                turns: st.turns,
+                partial_output: st.last_text.clone(),
                 blame: budget.blame,
                 blame_source: budget.blame_source,
                 spend: Box::default(), // decorated at the return seam
             });
         }
         // All-whitelisted, non-sentinel tools · feed results back.
-        messages.push(Message::new(Role::Assistant, response.content));
-        self.dispatch_turn(
-            observer, turns, tool_uses, router, guard, messages, last_text, run_start,
-        )
-        .await
+        st.messages
+            .push(Message::new(Role::Assistant, response.content));
+        let (digest, batch_cost) = self
+            .dispatch_turn(
+                observer,
+                st.turns,
+                tool_uses,
+                router,
+                guard,
+                &mut st.messages,
+                &st.last_text,
+                run_start,
+            )
+            .await?;
+        st.last_observations = digest;
+        Ok(batch_cost)
     }
 
     /// Validate + resolve one run's fixed parameters (params · whitelist ·
@@ -556,7 +573,9 @@ where
             let _ = shape::compile(schema)?;
         }
         let whitelist = Whitelist::new(&input.tools);
-        let defs = self.whitelisted_defs(&whitelist).await?;
+        let defs = self
+            .whitelisted_defs(&whitelist, input.schema.as_ref())
+            .await?;
         let model = input
             .model
             .clone()
@@ -654,25 +673,25 @@ where
     ///
     /// Zero re-asks when the answer already conforms (a well-behaved model
     /// · the common path). Otherwise the assistant's prose turn is appended
-    /// and the provider is re-asked WITH the schema constrained, up to the
-    /// retry budget. The tool loop never carries the schema — the re-ask is
-    /// a tools-OFF turn, so the tools-vs-structured-output provider conflict
-    /// (anthropic rejects `response_format` outright · openai/gemini are
-    /// fragile combining the two) is sidestepped by construction.
+    /// and the provider is re-asked WITH the schema constrained, drawing on
+    /// the run's ONE repair allowance (`repairs` — already partly spent if
+    /// a `nika:done` result was repaired earlier this run). The tool loop
+    /// never carries `response_format` — the re-ask is a tools-OFF turn, so
+    /// the tools-vs-structured-output provider conflict (grammar-constrained
+    /// message content fights the tool turns) is sidestepped by construction;
+    /// the sentinel's own parameter schema is what binds during the loop.
     #[allow(clippy::too_many_arguments)] // a terminal-path helper threading
     // the loop's owned state once; splitting it would only relocate the args.
     async fn finalize_schema(
         &self,
         observer: &dyn AgentObserver,
-        messages: &mut Vec<Message>,
         model: &str,
         answer: String,
         final_response: &InferResponse,
         stop_reason: AgentStopReason,
         input: &AgentInput,
-        total_tokens: &mut u64,
+        st: &mut turn::LoopState,
         usage_acc: &mut TokenUsage,
-        turn: u32,
     ) -> Result<AgentOutput, VerbAgentError> {
         // `FinalText` is only produced under a TYPED task (`schema:` or a
         // `returns:` lowered onto the same lane · spec 09); if the schema
@@ -682,8 +701,8 @@ where
             return Ok(AgentOutput::new(
                 AgentValue::Text(answer),
                 stop_reason,
-                turn,
-                *total_tokens,
+                st.turns,
+                st.total_tokens,
             ));
         };
         let validator = shape::compile(schema)?;
@@ -693,7 +712,7 @@ where
         // structured agent tasks single-round-trip when the model complies).
         let mut detail = match shape::validate_text(&answer, &validator) {
             Ok(value) => {
-                return Ok(shaped(value, stop_reason, turn, *total_tokens));
+                return Ok(shaped(value, stop_reason, st.turns, st.total_tokens));
             }
             Err(detail) => detail,
         };
@@ -717,31 +736,42 @@ where
             .cloned()
             .collect();
         if !final_prose.is_empty() {
-            messages.push(Message::new(Role::Assistant, final_prose));
+            st.messages.push(Message::new(Role::Assistant, final_prose));
         }
         let native = self.provider.supports_response_format();
-        for _ in 0..self.schema_retry_budget {
-            messages.push(Message::text(
+        while st.repairs < self.schema_retry_budget {
+            st.repairs = st.repairs.saturating_add(1);
+            st.messages.push(Message::text(
                 Role::User,
                 shape::reask_message(Some(&detail), schema),
             ));
-            let request = schema_request(model, messages.clone(), input, schema, native);
+            let request = schema_request(model, st.messages.clone(), input, schema, native);
             let response = self
-                .infer_turn(observer, turn, request, total_tokens, usage_acc, input)
+                .infer_turn(
+                    observer,
+                    st.turns,
+                    request,
+                    &mut st.total_tokens,
+                    usage_acc,
+                    input,
+                )
                 .await?;
             let text = joined_text(&response.content);
             match shape::validate_text(&text, &validator) {
                 Ok(value) => {
-                    return Ok(shaped(value, stop_reason, turn, *total_tokens));
+                    return Ok(shaped(value, stop_reason, st.turns, st.total_tokens));
                 }
                 Err(d) => {
                     detail = d;
-                    messages.push(Message::new(Role::Assistant, response.content));
+                    st.messages
+                        .push(Message::new(Role::Assistant, response.content));
                 }
             }
         }
         Err(VerbAgentError::SchemaValidation {
-            detail,
+            detail: st
+                .repair_budget(self.schema_retry_budget)
+                .exhausted_detail(&detail),
             spend: Box::default(), // decorated at the return seam
         })
     }
@@ -985,10 +1015,13 @@ where
         }
     }
 
-    /// The whitelisted tool universe + the synthesized sentinel def.
+    /// The whitelisted tool universe + the synthesized sentinel def
+    /// (which CARRIES the task `schema:` on its `result` parameter —
+    /// the contract reaches the seat on the very first request).
     async fn whitelisted_defs(
         &self,
         whitelist: &Whitelist,
+        schema: Option<&serde_json::Value>,
     ) -> Result<Vec<ToolDef>, VerbAgentError> {
         if whitelist.is_empty() {
             return Ok(Vec::new()); // pure conversation · skip the seam
@@ -1011,7 +1044,7 @@ where
                     && is_clean_tool_name(&def.name)
             })
             .collect();
-        defs.extend(intrinsic::synthesized_defs(whitelist));
+        defs.extend(intrinsic::synthesized_defs(whitelist, schema));
         // The AUTHOR's `tools:` order is the request's order (stable sort ·
         // catalog order breaks ties). The order is inert to a real model —
         // a whitelist has no ranking semantics — but the offline rehearsal
@@ -1180,6 +1213,8 @@ struct TurnCtx<'a> {
     turns: u32,
     total_tokens: u64,
     last_text: &'a str,
+    /// The run's one schema-repair allowance, as of this turn.
+    repairs: turn::RepairBudget,
 }
 
 /// One model-emitted tool call, named (two adjacent `String`s in a raw
@@ -1189,6 +1224,16 @@ struct ToolUse {
     id: String,
     name: String,
     args: serde_json::Value,
+}
+
+/// A `nika:done` `result:` that missed the task `schema:` while repair
+/// budget remained — the miss the loop feeds back (named for the same
+/// reason as `ToolUse`: two `String`s in a tuple invite a swap).
+struct DoneRepair {
+    /// The `nika:done` call the feedback answers.
+    tool_use_id: String,
+    /// The validator's failure, verbatim.
+    detail: String,
 }
 
 /// What the loop does after one model response.
@@ -1210,6 +1255,39 @@ enum TurnVerdict {
     },
     /// Continue: dispatch these (validated, non-sentinel) tool calls.
     Dispatch(Vec<ToolUse>),
+    /// Continue: a `nika:done` `result:` missed the task `schema:` and
+    /// the run still has repair budget — the errors go back as THAT
+    /// call's tool result and the model finishes again.
+    RepairDone(DoneRepair),
+}
+
+/// Feed a non-conforming `nika:done` `result:` back as THAT call's tool
+/// result (`is_error: true`) — the same agentic convention every failing
+/// tool already uses (spec §2: models recover from a typed observation).
+///
+/// The assistant turn must ride along or the tool result is an orphan;
+/// its SIBLING tool calls must not, because Terminal 2 already decided
+/// they never run — an unanswered `tool_use` on the transcript is a 400
+/// on a strict wire ("`tool_call_ids` did not have response messages"),
+/// the same trap `finalize_schema` documents.
+fn feed_done_repair(messages: &mut Vec<Message>, response: InferResponse, repair: &DoneRepair) {
+    let turn: Vec<ContentBlock> = response
+        .content
+        .into_iter()
+        .filter(|block| match block {
+            ContentBlock::ToolUse { id, .. } => *id == repair.tool_use_id,
+            _ => true,
+        })
+        .collect();
+    messages.push(Message::new(Role::Assistant, turn));
+    messages.push(Message::new(
+        Role::User,
+        vec![ContentBlock::ToolResult {
+            tool_use_id: repair.tool_use_id.clone(),
+            content: shape::done_repair_message(&repair.detail),
+            is_error: true,
+        }],
+    ));
 }
 
 /// Decide one turn — the ONE place the loop's exit conditions live, in
@@ -1271,13 +1349,17 @@ fn classify_turn(
             done.args.get("result"),
             ctx.last_text,
             ctx.input.schema.as_ref(),
-            ctx.turns,
-            ctx.total_tokens,
+            (ctx.turns, ctx.total_tokens),
+            ctx.repairs,
         )? {
             turn::ExplicitDone::Output(output) => Ok(TurnVerdict::Done(output)),
             turn::ExplicitDone::FinalText { text, stop_reason } => {
                 Ok(final_text_verdict(text, stop_reason, ctx))
             }
+            turn::ExplicitDone::Repair { detail } => Ok(TurnVerdict::RepairDone(DoneRepair {
+                tool_use_id: done.id.clone(),
+                detail,
+            })),
         };
     }
 
@@ -1389,5 +1471,7 @@ fn is_clean_tool_name(name: &str) -> bool {
 
 #[cfg(test)]
 mod tests;
+#[cfg(test)]
+mod tests_schema;
 #[cfg(test)]
 mod tests_spill;

--- a/crates/nika-verb-agent/src/request.rs
+++ b/crates/nika-verb-agent/src/request.rs
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! Request assembly — the transcript the loop opens with, the per-turn
+//! `InferRequest`, the final schema-constrained re-ask, and the BM25
+//! routing query. Moved VERBATIM out of `lib.rs` (the loop file) so the
+//! loop file stays within its 1,500-line budget; behavior is pinned by
+//! the tests that already cover each builder through the loop.
+
+use nika_kernel::ai::provider::{
+    ContentBlock, InferRequest, Message, ResponseFormat, Role, ToolDef,
+};
+
+use crate::AgentInput;
+
+/// One turn's request — the live transcript + this turn's routed tools.
+/// `defs` is consumed (the router already handed us an owned `Vec`) so a
+/// large fail-open universe isn't cloned a second time per turn.
+pub(crate) fn build_request(
+    model: &str,
+    messages: Vec<Message>,
+    input: &AgentInput,
+    defs: Vec<ToolDef>,
+) -> InferRequest {
+    let mut request = InferRequest::new(model, messages);
+    request.temperature = input.temperature;
+    request.tools = defs;
+    request
+}
+
+/// The FINAL schema-constrained re-ask request (BUG#11): tools OFF (the
+/// schema constraint and tool-calling do not reliably coexist in one
+/// request across providers — anthropic rejects `response_format`,
+/// openai/gemini are fragile), with the schema wired natively when the
+/// provider supports it (`infer`+schema parity · `build_request` mirror).
+pub(crate) fn schema_request(
+    model: &str,
+    messages: Vec<Message>,
+    input: &AgentInput,
+    schema: &serde_json::Value,
+    native: bool,
+) -> InferRequest {
+    let mut request = InferRequest::new(model, messages);
+    request.temperature = input.temperature;
+    // tools deliberately left empty (default) — see the doc comment.
+    if native {
+        request.response_format = ResponseFormat::JsonSchema(schema.clone());
+    }
+    request
+}
+
+/// Per-component character budgets for the routing query — the live tail
+/// (`last_text` · `last_observations`) must always reach the ranker, so a
+/// long prompt can't evict it via a single tail-truncating cap.
+const QUERY_PROMPT_CHARS: usize = 2048;
+const QUERY_TEXT_CHARS: usize = 1024;
+const QUERY_OBS_CHARS: usize = 1024;
+
+/// Build the BM25 routing query from the live task context, each piece
+/// bounded independently (a 100 KB prompt can't crowd out the model's
+/// last words or the last observations — the signal routing ranks on).
+pub(crate) fn routing_query(prompt: &str, last_text: &str, last_observations: &str) -> String {
+    let take = |s: &str, n: usize| s.chars().take(n).collect::<String>();
+    format!(
+        "{} {} {}",
+        take(prompt, QUERY_PROMPT_CHARS),
+        take(last_text, QUERY_TEXT_CHARS),
+        take(last_observations, QUERY_OBS_CHARS),
+    )
+}
+
+/// The opening transcript: optional system, then the user prompt.
+pub(crate) fn opening_messages(input: &AgentInput) -> Vec<Message> {
+    let mut messages = Vec::with_capacity(2);
+    if let Some(system) = &input.system {
+        messages.push(Message::text(Role::System, system.clone()));
+    }
+    messages.push(Message::text(Role::User, input.prompt.clone()));
+    messages
+}
+
+/// Concatenate a response's text blocks (the assistant's words).
+pub(crate) fn joined_text(content: &[ContentBlock]) -> String {
+    content
+        .iter()
+        .filter_map(|block| match block {
+            ContentBlock::Text { text } => Some(text.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}

--- a/crates/nika-verb-agent/src/shape.rs
+++ b/crates/nika-verb-agent/src/shape.rs
@@ -152,6 +152,23 @@ pub(crate) fn reask_message(detail: Option<&str>, schema: &serde_json::Value) ->
     }
 }
 
+/// The feedback a NON-CONFORMING `nika:done` `result:` sends back — as
+/// that call's tool result, `is_error: true` (the agentic convention the
+/// loop already uses for every failing tool: models repair from a typed
+/// observation). No schema is re-rendered here: under a typed task the
+/// sentinel's own definition CARRIES the schema on every request, so
+/// repeating it would be pure token cost. That is the difference from
+/// [`reask_message`], which rides a tools-OFF turn where no definition
+/// carries anything.
+pub(crate) fn done_repair_message(detail: &str) -> String {
+    format!(
+        "The `result` did not satisfy the required output schema. \
+         Validation failed with: {detail}. Call this tool again with a \
+         `result` that conforms to the schema declared for it — do not \
+         answer in prose."
+    )
+}
+
 /// Pull the first JSON value out of model text: a bare parse, else the
 /// first balanced `{…}`/`[…]` span (tolerates code fences + prose).
 /// String-aware so a brace inside a string literal never miscounts depth.

--- a/crates/nika-verb-agent/src/tests.rs
+++ b/crates/nika-verb-agent/src/tests.rs
@@ -11,14 +11,14 @@ use nika_kernel::ai::provider::{InferResponse, ResponseFormat, StopReason, Token
 use nika_kernel::runtime::tool_executor::ToolResult;
 use nika_kernel_mock::{MockProvider, MockToolDefinitionProvider, MockToolExecutor};
 
-fn usage(input: u64, output: u64) -> TokenUsage {
+pub(super) fn usage(input: u64, output: u64) -> TokenUsage {
     let mut usage = TokenUsage::default();
     usage.input_tokens = input;
     usage.output_tokens = output;
     usage
 }
 
-fn text_response(text: &str) -> InferResponse {
+pub(super) fn text_response(text: &str) -> InferResponse {
     InferResponse::new(
         vec![ContentBlock::Text {
             text: text.to_owned(),
@@ -28,7 +28,7 @@ fn text_response(text: &str) -> InferResponse {
     )
 }
 
-fn tool_use_response(id: &str, name: &str, args: serde_json::Value) -> InferResponse {
+pub(super) fn tool_use_response(id: &str, name: &str, args: serde_json::Value) -> InferResponse {
     InferResponse::new(
         vec![
             ContentBlock::Text {
@@ -45,17 +45,17 @@ fn tool_use_response(id: &str, name: &str, args: serde_json::Value) -> InferResp
     )
 }
 
-fn def(name: &str) -> ToolDef {
+pub(super) fn def(name: &str) -> ToolDef {
     ToolDef::new(name, format!("{name} description"), serde_json::json!({}))
 }
 
-struct Rig {
-    provider: Arc<MockProvider>,
-    tools: Arc<MockToolExecutor>,
-    verb: AgentVerb<MockProvider, MockToolExecutor, MockToolDefinitionProvider>,
+pub(super) struct Rig {
+    pub(super) provider: Arc<MockProvider>,
+    pub(super) tools: Arc<MockToolExecutor>,
+    pub(super) verb: AgentVerb<MockProvider, MockToolExecutor, MockToolDefinitionProvider>,
 }
 
-fn rig(provider: MockProvider, tools: MockToolExecutor, universe: Vec<ToolDef>) -> Rig {
+pub(super) fn rig(provider: MockProvider, tools: MockToolExecutor, universe: Vec<ToolDef>) -> Rig {
     let provider = Arc::new(provider);
     let tools = Arc::new(tools);
     let invoke = Arc::new(InvokeVerb::new(Arc::clone(&tools)));
@@ -1228,32 +1228,6 @@ async fn uncompilable_schema_fails_before_any_infer() {
         0,
         "C07: fail before paid infer"
     );
-}
-
-#[tokio::test]
-async fn schema_validates_the_done_result_value() {
-    let r = rig(
-        MockProvider::new("mock").enqueue_response(tool_use_response(
-            "c",
-            DONE_TOOL,
-            serde_json::json!({"result": {"score": "nine"}}),
-        )),
-        MockToolExecutor::new(),
-        Vec::new(),
-    );
-    let mut input = AgentInput::new("rate it");
-    input.tools = vec![DONE_TOOL.to_owned()];
-    input.schema = Some(serde_json::json!({
-        "type": "object",
-        "properties": {"score": {"type": "integer"}},
-        "required": ["score"]
-    }));
-    let err = r
-        .verb
-        .run(input)
-        .await
-        .expect_err("done result misses schema");
-    assert!(matches!(err, VerbAgentError::SchemaValidation { .. }));
 }
 
 // ── §6 · seam failures + parameter validation ───────────────────────

--- a/crates/nika-verb-agent/src/tests.rs
+++ b/crates/nika-verb-agent/src/tests.rs
@@ -7,7 +7,7 @@
 
 use super::*;
 use nika_error::traits::NikaErrorCode;
-use nika_kernel::ai::provider::{InferResponse, StopReason, TokenUsage};
+use nika_kernel::ai::provider::{InferResponse, ResponseFormat, StopReason, TokenUsage};
 use nika_kernel::runtime::tool_executor::ToolResult;
 use nika_kernel_mock::{MockProvider, MockToolDefinitionProvider, MockToolExecutor};
 

--- a/crates/nika-verb-agent/src/tests_schema.rs
+++ b/crates/nika-verb-agent/src/tests_schema.rs
@@ -1,0 +1,425 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The typed-task contract: how a declared `schema:` reaches the seat,
+//! and what happens when the value it sends back misses.
+//!
+//! Measured on three real seats before this suite existed: the schema
+//! never rode the FIRST request (the sentinel's `result` parameter had a
+//! description and nothing else, so the seat could only guess the keys
+//! from the prompt), and a `nika:done` result that missed was fatal on
+//! attempt 1 while a prose answer got two repairs. Both are pinned here.
+//!
+//! Split from `tests.rs` under the 1500-LOC file cap; the rig helpers
+//! are shared (`crate::tests`), so a change to the loop's test double
+//! still moves both suites at once.
+
+use super::*;
+use nika_kernel::ai::provider::{ResponseFormat, ToolDef};
+use nika_kernel::runtime::tool_executor::ToolResult;
+use nika_kernel_mock::{MockProvider, MockToolExecutor};
+
+use crate::tests::{def, rig, text_response, tool_use_response};
+
+/// The task contract used across this suite: an object with one
+/// required integer. A string `score` misses it in a way no extraction
+/// trick can rescue — the model has to send a different value.
+fn score_schema() -> serde_json::Value {
+    serde_json::json!({
+        "type": "object",
+        "properties": {"score": {"type": "integer"}},
+        "required": ["score"],
+        "additionalProperties": false
+    })
+}
+
+/// The `nika:done` definition as it left for the provider on a request.
+fn done_def_on(request: &InferRequest) -> &ToolDef {
+    request
+        .tools
+        .iter()
+        .find(|t| t.name == DONE_TOOL)
+        .expect("the sentinel def rides every request that admits it")
+}
+
+// ── (a) the schema binds on the FIRST request ───────────────────────
+
+#[tokio::test]
+async fn the_first_request_carries_the_schema_on_the_done_def() {
+    // The whole of F1: request #1 must already tell the seat the shape.
+    let r = rig(
+        MockProvider::new("mock").enqueue_response(tool_use_response(
+            "c",
+            DONE_TOOL,
+            serde_json::json!({"result": {"score": 9}}),
+        )),
+        MockToolExecutor::new(),
+        vec![def("nika:read")],
+    );
+    let mut input = AgentInput::new("rate it");
+    input.tools = vec![DONE_TOOL.to_owned(), "nika:read".to_owned()];
+    input.schema = Some(score_schema());
+    r.verb.run(input).await.expect("conforming result");
+
+    let reqs = r.provider.captured_requests();
+    let first = &reqs[0];
+    let done = done_def_on(first);
+    assert_eq!(
+        done.parameters["properties"]["result"],
+        score_schema(),
+        "the declared schema IS the `result` parameter's schema, verbatim"
+    );
+    assert_eq!(
+        done.parameters["required"],
+        serde_json::json!(["result"]),
+        "a typed task finishes by PASSING the value, not by prose"
+    );
+    // The other half of the decision: the grammar mechanism stays off the
+    // tool-calling turn — the def is what binds during the loop.
+    assert!(
+        matches!(first.response_format, ResponseFormat::Text),
+        "response_format never rides a tool-calling turn"
+    );
+}
+
+#[tokio::test]
+async fn a_native_provider_still_keeps_response_format_off_the_loop() {
+    // Even where `supports_response_format()` is true, the loop turns
+    // stay unconstrained: a grammar over the message content would fight
+    // the tool calls the loop exists to make. The binding is the def.
+    let r = rig(
+        MockProvider::new("mock")
+            .with_response_format_support(true)
+            .enqueue_response(tool_use_response("c1", "nika:read", serde_json::json!({})))
+            .enqueue_response(tool_use_response(
+                "c2",
+                DONE_TOOL,
+                serde_json::json!({"result": {"score": 3}}),
+            )),
+        MockToolExecutor::new().enqueue_ok(ToolResult::success("c1", "ok")),
+        vec![def("nika:read")],
+    );
+    let mut input = AgentInput::new("read then rate");
+    input.tools = vec![DONE_TOOL.to_owned(), "nika:read".to_owned()];
+    input.schema = Some(score_schema());
+    r.verb.run(input).await.expect("conforming result");
+
+    for (i, request) in r.provider.captured_requests().iter().enumerate() {
+        assert!(
+            matches!(request.response_format, ResponseFormat::Text),
+            "turn {} carried a grammar it should not have",
+            i + 1
+        );
+        assert_eq!(
+            done_def_on(request).parameters["properties"]["result"],
+            score_schema(),
+            "every loop turn re-states the contract on the def"
+        );
+    }
+}
+
+#[tokio::test]
+async fn an_untyped_task_leaves_the_result_open_and_optional() {
+    // No `schema:` ⇒ the sentinel keeps its permissive shape: `result` is
+    // any JSON and omitting it (finish on the last words) stays legal.
+    let r = rig(
+        MockProvider::new("mock").enqueue_response(tool_use_response(
+            "c",
+            DONE_TOOL,
+            serde_json::json!({}),
+        )),
+        MockToolExecutor::new(),
+        Vec::new(),
+    );
+    let mut input = AgentInput::new("just talk");
+    input.tools = vec![DONE_TOOL.to_owned()];
+    r.verb.run(input).await.expect("result-less done finishes");
+
+    let reqs = r.provider.captured_requests();
+    let done = done_def_on(&reqs[0]);
+    assert!(
+        done.parameters.get("required").is_none(),
+        "untyped, `result` must stay optional"
+    );
+    assert!(
+        done.parameters["properties"]["result"]
+            .get("type")
+            .is_none(),
+        "untyped, `result` accepts any JSON"
+    );
+}
+
+// ── (c) a conforming result is accepted first try ───────────────────
+
+#[tokio::test]
+async fn a_conforming_done_result_costs_exactly_one_request() {
+    let r = rig(
+        MockProvider::new("mock").enqueue_response(tool_use_response(
+            "c",
+            DONE_TOOL,
+            serde_json::json!({"result": {"score": 7}}),
+        )),
+        MockToolExecutor::new(),
+        Vec::new(),
+    );
+    let mut input = AgentInput::new("rate it");
+    input.tools = vec![DONE_TOOL.to_owned()];
+    input.schema = Some(score_schema());
+    let out = r.verb.run(input).await.expect("conforming result");
+    assert_eq!(
+        out.output,
+        AgentValue::Structured(serde_json::json!({"score": 7}))
+    );
+    assert_eq!(out.stop_reason, AgentStopReason::ExplicitCompletion);
+    assert_eq!(
+        r.provider.captured_requests().len(),
+        1,
+        "a conforming result is never re-asked"
+    );
+}
+
+// ── (b) a non-conforming result REPAIRS, then is fatal WITH the count ─
+
+#[tokio::test]
+async fn a_non_conforming_done_result_is_repaired_not_fatal() {
+    // The heart of F2: the miss goes back as THAT call's tool result and
+    // the model finishes again. One repair, then a clean value.
+    let r = rig(
+        MockProvider::new("mock")
+            .enqueue_response(tool_use_response(
+                "c1",
+                DONE_TOOL,
+                serde_json::json!({"result": {"score": "nine"}}),
+            ))
+            .enqueue_response(tool_use_response(
+                "c2",
+                DONE_TOOL,
+                serde_json::json!({"result": {"score": 9}}),
+            )),
+        MockToolExecutor::new(),
+        Vec::new(),
+    );
+    let mut input = AgentInput::new("rate it");
+    input.tools = vec![DONE_TOOL.to_owned()];
+    input.schema = Some(score_schema());
+    let out = r.verb.run(input).await.expect("the repair conforms");
+    assert_eq!(
+        out.output,
+        AgentValue::Structured(serde_json::json!({"score": 9}))
+    );
+
+    // The feedback rode the wire as a TOOL RESULT answering that call —
+    // the agentic convention, not a bare user message.
+    let reqs = r.provider.captured_requests();
+    assert_eq!(reqs.len(), 2, "one repair round-trip, no more");
+    let repair_turn = &reqs[1];
+    let fed_back = repair_turn
+        .messages
+        .iter()
+        .flat_map(|m| m.content.iter())
+        .find_map(|b| match b {
+            ContentBlock::ToolResult {
+                tool_use_id,
+                content,
+                is_error,
+            } if tool_use_id == "c1" => Some((content.clone(), *is_error)),
+            _ => None,
+        })
+        .expect("the miss answers the `nika:done` call it came from");
+    assert!(fed_back.1, "a miss is an error observation");
+    assert!(
+        fed_back
+            .0
+            .contains("did not satisfy the required output schema"),
+        "the feedback names the contract: {}",
+        fed_back.0
+    );
+    assert!(
+        fed_back.0.contains("integer"),
+        "the feedback carries the validator's own words: {}",
+        fed_back.0
+    );
+    // And the def still carries the schema on the repair turn.
+    assert_eq!(
+        done_def_on(repair_turn).parameters["properties"]["result"],
+        score_schema()
+    );
+}
+
+#[tokio::test]
+async fn done_repairs_exhaust_the_budget_then_the_verdict_names_the_count() {
+    // Three misses under the default budget of 2: repair, repair, verdict.
+    let bad = || {
+        tool_use_response(
+            "c",
+            DONE_TOOL,
+            serde_json::json!({"result": {"score": "nine"}}),
+        )
+    };
+    let r = rig(
+        MockProvider::new("mock")
+            .enqueue_response(bad())
+            .enqueue_response(bad())
+            .enqueue_response(bad()),
+        MockToolExecutor::new(),
+        Vec::new(),
+    );
+    let mut input = AgentInput::new("rate it");
+    input.tools = vec![DONE_TOOL.to_owned()];
+    input.schema = Some(score_schema());
+    let err = r.verb.run(input).await.expect_err("budget exhausted");
+    let VerbAgentError::SchemaValidation { detail, .. } = &err else {
+        panic!("expected the schema verdict, got {err:?}");
+    };
+    assert!(
+        detail.contains("after 2 repair attempts"),
+        "the verdict must say how many repairs were tried: {detail}"
+    );
+    assert_eq!(
+        nika_error::traits::NikaErrorCode::nika_code(&err).num,
+        464,
+        "still NIKA-464 · wire NIKA-INFER-002"
+    );
+    assert_eq!(
+        r.provider.captured_requests().len(),
+        3,
+        "the first call + exactly DEFAULT_SCHEMA_RETRY_BUDGET repairs"
+    );
+}
+
+#[tokio::test]
+async fn a_zero_budget_run_keeps_the_done_miss_single_shot() {
+    // `with_schema_retry_budget(0)` is the documented single-shot knob —
+    // it must still bind (no repair) and must NOT invent an attempt count.
+    let provider = Arc::new(
+        MockProvider::new("mock").enqueue_response(tool_use_response(
+            "c",
+            DONE_TOOL,
+            serde_json::json!({"result": {"score": "nine"}}),
+        )),
+    );
+    let tools = Arc::new(MockToolExecutor::new());
+    let verb = AgentVerb::new(
+        Arc::clone(&provider),
+        Arc::new(InvokeVerb::new(Arc::clone(&tools))),
+        Arc::new(nika_kernel_mock::MockToolDefinitionProvider::with_defs(
+            Vec::new(),
+        )),
+        "mock/agent",
+    )
+    .with_schema_retry_budget(0);
+    let mut input = AgentInput::new("rate it");
+    input.tools = vec![DONE_TOOL.to_owned()];
+    input.schema = Some(score_schema());
+    let err = verb.run(input).await.expect_err("no repair budget");
+    let VerbAgentError::SchemaValidation { detail, .. } = &err else {
+        panic!("expected the schema verdict, got {err:?}");
+    };
+    assert!(
+        !detail.contains("repair attempt"),
+        "zero spent ⇒ no attempt phrase: {detail}"
+    );
+    assert_eq!(provider.captured_requests().len(), 1, "single-shot");
+}
+
+#[tokio::test]
+async fn the_repair_feedback_drops_the_siblings_that_never_ran() {
+    // Terminal 2: `nika:done` wins over its batch-mates and they are NOT
+    // dispatched. Re-sending them would leave an unanswered tool call on
+    // the transcript — a 400 on a strict wire. Only the sentinel's own
+    // call may ride back into the repair turn.
+    let turn = InferResponse::new(
+        vec![
+            ContentBlock::ToolUse {
+                id: "sibling".to_owned(),
+                name: "nika:read".to_owned(),
+                input: serde_json::json!({}),
+            },
+            ContentBlock::ToolUse {
+                id: "done-1".to_owned(),
+                name: DONE_TOOL.to_owned(),
+                input: serde_json::json!({"result": {"score": "nine"}}),
+            },
+        ],
+        crate::tests::usage(10, 5),
+        nika_kernel::ai::provider::StopReason::ToolUse,
+    );
+    let r = rig(
+        MockProvider::new("mock")
+            .enqueue_response(turn)
+            .enqueue_response(tool_use_response(
+                "done-2",
+                DONE_TOOL,
+                serde_json::json!({"result": {"score": 1}}),
+            )),
+        MockToolExecutor::new(),
+        vec![def("nika:read")],
+    );
+    let mut input = AgentInput::new("rate it");
+    input.tools = vec![DONE_TOOL.to_owned(), "nika:read".to_owned()];
+    input.schema = Some(score_schema());
+    r.verb.run(input).await.expect("the repair conforms");
+
+    let reqs = r.provider.captured_requests();
+    let ids: Vec<&str> = reqs[1]
+        .messages
+        .iter()
+        .flat_map(|m| m.content.iter())
+        .filter_map(|b| match b {
+            ContentBlock::ToolUse { id, .. } => Some(id.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        ids,
+        vec!["done-1"],
+        "only the sentinel's own call survives into the repair turn"
+    );
+    assert_eq!(
+        r.tools.captured_calls().len(),
+        0,
+        "a batch-mate of a winning `done` never runs"
+    );
+}
+
+// ── the ONE budget · both repair paths draw on it ───────────────────
+
+#[tokio::test]
+async fn the_done_repair_and_the_text_reask_share_one_budget() {
+    // A run that spends one repair on a `nika:done` miss has ONE left for
+    // the free-text re-ask — never a second full allowance.
+    let r = rig(
+        MockProvider::new("mock")
+            // 1 · a done result that misses → repair #1
+            .enqueue_response(tool_use_response(
+                "c1",
+                DONE_TOOL,
+                serde_json::json!({"result": {"score": "nine"}}),
+            ))
+            // 2 · the model gives up on the tool and answers in prose →
+            //     the free-text path, which now has 1 repair left
+            .enqueue_response(text_response("the score is nine"))
+            // 3 · the one remaining re-ask · still prose → verdict
+            .enqueue_response(text_response("still nine, sorry"))
+            // 4 · would be a SECOND allowance · must never be requested
+            .enqueue_response(text_response(r#"{"score": 9}"#)),
+        MockToolExecutor::new(),
+        Vec::new(),
+    );
+    let mut input = AgentInput::new("rate it");
+    input.tools = vec![DONE_TOOL.to_owned()];
+    input.schema = Some(score_schema());
+    let err = r.verb.run(input).await.expect_err("one budget, not two");
+    let VerbAgentError::SchemaValidation { detail, .. } = &err else {
+        panic!("expected the schema verdict, got {err:?}");
+    };
+    assert!(
+        detail.contains("after 2 repair attempts"),
+        "one done repair + one text re-ask = 2: {detail}"
+    );
+    assert_eq!(
+        r.provider.captured_requests().len(),
+        3,
+        "the 4th canned response must stay unconsumed"
+    );
+}

--- a/crates/nika-verb-agent/src/turn.rs
+++ b/crates/nika-verb-agent/src/turn.rs
@@ -1,17 +1,98 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
 
-//! Terminal-2 (`nika:done`) classification — split from `lib.rs` so
-//! `classify_turn` stays under the 100-line fn-length ratchet without
-//! growing the loop file past 1,500.
+//! Terminal-2 (`nika:done`) classification and the loop's per-run
+//! ledger — split from `lib.rs` so `classify_turn` and `run_loop` stay
+//! under the 100-line fn-length ratchet without growing the loop file
+//! past 1,500.
 
+use nika_kernel::ai::provider::Message;
 use nika_kernel::runtime::agent::AgentStopReason;
 
 use crate::shape;
 use crate::{AgentOutput, AgentValue, VerbAgentError};
 
-/// A `nika:done` turn: either a finalized output, or free text the
-/// loop must schema-finalize (the C07 re-ask).
+/// The ONE schema-repair allowance of a run, shared by BOTH repair
+/// paths: a non-conforming `nika:done` `result:` (fed back as a tool
+/// result so the model calls the sentinel again) and a free-text final
+/// answer (`finalize_schema`'s tools-OFF re-ask). One budget, so a
+/// mixed run can never spend two.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct RepairBudget {
+    /// Repairs already spent this run, across both paths.
+    pub(crate) spent: u8,
+    /// The run's allowance (`AgentVerb::schema_retry_budget`).
+    pub(crate) total: u8,
+}
+
+impl RepairBudget {
+    /// Repairs still available.
+    pub(crate) fn left(self) -> u8 {
+        self.total.saturating_sub(self.spent)
+    }
+
+    /// Decorate the NIKA-464 detail with what the loop actually tried —
+    /// a verdict that spent repairs must SAY so (a bare validation
+    /// message reads as « never attempted »). Zero spent ⇒ unchanged:
+    /// a single-shot run has no attempt count to report.
+    pub(crate) fn exhausted_detail(self, detail: &str) -> String {
+        match self.spent {
+            0 => detail.to_owned(),
+            1 => format!("{detail} (after 1 repair attempt)"),
+            n => format!("{detail} (after {n} repair attempts)"),
+        }
+    }
+}
+
+/// The loop's own per-run ledger — what every turn reads and the
+/// feed-back arms write: the live transcript, the turn and token
+/// counters, the model's last words, the last observations digest and
+/// the ONE schema-repair counter. One value threaded through the loop's
+/// helpers, so `run_loop` stays the exit-conditions site rather than a
+/// variable ledger, and so the two repair paths cannot each keep a
+/// counter of their own.
+pub(crate) struct LoopState {
+    /// The transcript the next request is built from.
+    pub(crate) messages: Vec<Message>,
+    /// Turns spent so far.
+    pub(crate) turns: u32,
+    /// Tokens spent so far, across every provider call of the run.
+    pub(crate) total_tokens: u64,
+    /// The model's most recent non-empty words.
+    pub(crate) last_text: String,
+    /// The last dispatched batch's observations digest (a routing signal).
+    pub(crate) last_observations: String,
+    /// Schema repairs spent this run: `nika:done` result repairs AND
+    /// free-text re-asks draw on this one counter, so a mixed run can
+    /// never spend two budgets.
+    pub(crate) repairs: u8,
+}
+
+impl LoopState {
+    /// A fresh ledger over the opening transcript.
+    pub(crate) fn new(messages: Vec<Message>) -> Self {
+        Self {
+            messages,
+            turns: 0,
+            total_tokens: 0,
+            last_text: String::new(),
+            last_observations: String::new(),
+            repairs: 0,
+        }
+    }
+
+    /// The repair allowance as of now, against the run's `total`.
+    pub(crate) fn repair_budget(&self, total: u8) -> RepairBudget {
+        RepairBudget {
+            spent: self.repairs,
+            total,
+        }
+    }
+}
+
+/// A `nika:done` turn: a finalized output, free text the loop must
+/// schema-finalize (the C07 re-ask), or a non-conforming `result:` the
+/// loop repairs in-place.
 pub(crate) enum ExplicitDone {
     /// Validated `result:` — return as-is.
     Output(Box<AgentOutput>),
@@ -22,41 +103,57 @@ pub(crate) enum ExplicitDone {
         /// Always `ExplicitCompletion` — the sentinel fired.
         stop_reason: AgentStopReason,
     },
+    /// A `result:` that missed the schema while repair budget remains:
+    /// the validation errors go BACK as this call's tool result and the
+    /// model calls the sentinel again (the agentic convention).
+    Repair {
+        /// The validator's human-readable failure, verbatim.
+        detail: String,
+    },
 }
 
 /// Classify a `nika:done` call: a `result:` is a DELIBERATE structured
-/// value (validate directly · a miss is a verdict, never a re-ask ·
-/// BUG#11) except the C07 string/null-vs-object case, which re-asks.
-/// A result-LESS done finishes on the last free text.
+/// value, so it is validated directly — but a miss is REPAIRABLE, not
+/// instantly fatal: the errors ride back as the call's tool result and
+/// the model gets another go, bounded by the run's one [`RepairBudget`]
+/// (the C07 string/null-vs-object case still routes to the free-text
+/// re-ask, which is the shape that path already fixes). A result-LESS
+/// done finishes on the last free text.
 pub(crate) fn classify_explicit_done(
     result: Option<&serde_json::Value>,
     last_text: &str,
     schema: Option<&serde_json::Value>,
-    turns: u32,
-    total_tokens: u64,
+    turns: (u32, u64),
+    repairs: RepairBudget,
 ) -> Result<ExplicitDone, VerbAgentError> {
-    match result {
-        Some(result) => {
-            let coerced = shape::coerce_done_result(result);
-            match shape::shape_output(AgentValue::Structured(coerced), schema) {
-                Ok(value) => Ok(ExplicitDone::Output(Box::new(AgentOutput::new(
-                    value,
-                    AgentStopReason::ExplicitCompletion,
-                    turns,
-                    total_tokens,
-                )))),
-                Err(_) if shape::string_or_null_may_reask(result, schema) => {
-                    Ok(ExplicitDone::FinalText {
-                        text: result.as_str().unwrap_or("").to_owned(),
-                        stop_reason: AgentStopReason::ExplicitCompletion,
-                    })
-                }
-                Err(err) => Err(err),
-            }
-        }
-        None => Ok(ExplicitDone::FinalText {
+    let (turns, total_tokens) = turns;
+    let Some(result) = result else {
+        return Ok(ExplicitDone::FinalText {
             text: last_text.to_owned(),
             stop_reason: AgentStopReason::ExplicitCompletion,
+        });
+    };
+    let coerced = shape::coerce_done_result(result);
+    match shape::shape_output(AgentValue::Structured(coerced), schema) {
+        Ok(value) => Ok(ExplicitDone::Output(Box::new(AgentOutput::new(
+            value,
+            AgentStopReason::ExplicitCompletion,
+            turns,
+            total_tokens,
+        )))),
+        Err(_) if shape::string_or_null_may_reask(result, schema) => Ok(ExplicitDone::FinalText {
+            text: result.as_str().unwrap_or("").to_owned(),
+            stop_reason: AgentStopReason::ExplicitCompletion,
         }),
+        Err(VerbAgentError::SchemaValidation { detail, .. }) if repairs.left() > 0 => {
+            Ok(ExplicitDone::Repair { detail })
+        }
+        Err(VerbAgentError::SchemaValidation { detail, spend }) => {
+            Err(VerbAgentError::SchemaValidation {
+                detail: repairs.exhausted_detail(&detail),
+                spend,
+            })
+        }
+        Err(err) => Err(err),
     }
 }


### PR DESCRIPTION
## What

Measured on the public 0.118.7 binary across three real seats (48 paid runs): the `agent:` verb's declared `schema:` never reached the seat on the first request (the synthesized `nika_done` tool carried an untyped `result` and no `response_format`), and a `nika_done(result)` that failed validation was fatal `NIKA-INFER-002` at attempt 1 with no repair — while a failing TEXT final answer was re-asked twice. Half the schema runs on deepseek-chat and gpt-4o-mini died on that path, on a shape the engine had never told the seat.

- The `nika_done` def carries the declared schema on `result` (with `required`), so the contract reaches the seat on request #1 on every wire.
- A non-conforming `nika_done` result is fed back as an error tool result and re-asked under the SAME repair budget the text path uses; the fatal message counts the repairs tried.
- `response_format` stays confined to the tools-off re-ask (the wire decision is documented in the code).
- The request builders and a `LoopState` ledger are carved out of the loop file (pure moves; `run_loop` back under the fn cap).

## Proof

110 lib tests green; clippy `-D warnings`; fn/file/crate caps; public API unchanged. Mutation: gutting the done-path repair kills 4 tests, removing the schema binding kills 3. Zero-cost capture against a loopback server: request #1 carries the full schema on `nika_done.parameters.properties.result`; a flat object that misses a property is repaired on the next request; a conforming one is accepted first try. Real seats on the repro: deepseek-chat and gpt-4o-mini both green in three turns where both died before. Independently reviewed before merge.

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>
