### PR TITLE
docs(plugins): the skills stop teaching an empty write as mkdir

### DIFF
--- a/.agents/plugins/nika/skills/nika-authoring/SKILL.md
+++ b/.agents/plugins/nika/skills/nika-authoring/SKILL.md
@@ -567,7 +567,7 @@ The order is `invoke: nika:*` → `invoke: mcp:<server>/<tool>` →
 
    The reflexes worth memorising: HTTP (curl/wget/helper fetch) →
    `nika:fetch` · file plumbing (cat/tee/cp/mkdir) →
-   `nika:read`/`nika:write` (`create_dirs: true`) · JSON shaping
+   `nika:read`/`nika:write` (`create_dirs: true` creates the missing parents of a FILE — no empty write stands in for `mkdir`) · JSON shaping
    (jq/sed) → `nika:jq` or an `extract:` binding · in-place edits →
    `nika:edit` · finding files (`find`/`ls`) → `nika:glob` · searching
    them (`grep`/`rg`) → `nika:grep` · `date`/`uuidgen`/`shasum` →

--- a/.agents/plugins/nika/skills/nika-migration/SKILL.md
+++ b/.agents/plugins/nika/skills/nika-migration/SKILL.md
@@ -28,7 +28,7 @@ sub-second pure-shell pipelines with zero AI and zero HTTP (a
 | `curl` / `wget` / `fetch()` helper | `invoke:` `tool: "nika:fetch"` — **for an API, set `mode: raw` or `mode: jq`** (the default `markdown` mode is for pages and escapes JSON bodies) |
 | `curl … \| jq` in one breath | ONE fetch task: `mode: jq` + `jq: '<expression>'` — the shape rides the fetch |
 | `jq` / `sed` on JSON | `nika:jq` (arg name is `expression`), or an `extract:` binding |
-| `cat` / `cp` / `mkdir` / `tee` | `nika:read` / `nika:write` (`create_dirs: true`) |
+| `cat` / `cp` / `mkdir` / `tee` | `nika:read` / `nika:write` — a directory is made by writing its FIRST file inside it with `create_dirs: true`, never by an empty write at the directory's path (that creates a FILE there, and nothing deletes it) |
 | in-place file edits | `nika:edit` |
 | the LLM call (SDK, `curl` to an API) | `infer:` with `prompt`, `schema?`, `max_tokens` |
 | an agent loop (retry-until-good) | `agent:` with `tools` allowlist + `max_turns` |


### PR DESCRIPTION
## What

Two skill cells mapped `mkdir` to `nika:write (create_dirs: true)` — the exact reading that, measured on an agent benchmark, made a model write an empty file at the directory's path and then lose every write beneath it for the rest of the run.

## How

The cells now say what the tool does: a directory is made by writing its first file inside it with `create_dirs: true`; an empty write at the directory's path creates a FILE there, and nothing deletes it. The same sentences already landed in the spec's vendored pack and travel separately.

## Proof

Docs only (two `SKILL.md` cells under `plugins/`); no code path changes.

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>
