### PR TITLE
fix(agent): the done def hoists $defs, repairs respect the token budget, turns carry the task timeout

### DIFF
--- a/changelog.d/agent-done-def-hoists-defs.fixed.md
+++ b/changelog.d/agent-done-def-hoists-defs.fixed.md
@@ -1,0 +1,9 @@
+- **A typed `agent:` task's `nika:done` definition keeps an internal `$ref`
+  resolvable on the wire.** The declared `schema:` rides nested under the
+  sentinel's `result` parameter, and a JSON pointer such as
+  `"$ref": "#/$defs/row"` resolves against the document root, which on the
+  wire is that wrapper: the definition now hoists the schema's
+  `$defs`/`definitions` to the wrapper's root and drops a `$schema` keyword,
+  so a seat that validates its tool input follows the pointer to the
+  definition instead of to nothing. A schema without definitions renders
+  exactly as before, and local validation is unchanged.

--- a/changelog.d/agent-repair-turns-respect-the-token-budget.fixed.md
+++ b/changelog.d/agent-repair-turns-respect-the-token-budget.fixed.md
@@ -1,0 +1,7 @@
+- **An `agent:` loop no longer spends past `max_tokens_total` on `nika:done`
+  repairs.** A `result` that misses the declared `schema:` is fed back for a
+  repair, and that repair is one more provider request: when the tokens
+  already spent meet the budget, the request is not made and the run ends on
+  the budget verdict (`NIKA-AGENT-002`), the same gate a tool dispatch
+  passes. Previously the repair turns bypassed that gate, so a run could
+  exceed the author's budget by up to `DEFAULT_SCHEMA_RETRY_BUDGET` requests.

--- a/changelog.d/agent-turns-follow-the-task-timeout.fixed.md
+++ b/changelog.d/agent-turns-follow-the-task-timeout.fixed.md
@@ -1,0 +1,8 @@
+- **An `agent:` task's `timeout:` now governs every provider call of its
+  loop (#1516).** Each turn's request, the `nika:done` repair turns and the
+  final tools-off re-ask carry the task budget to the transport deadline,
+  the way an `infer:` task already did, so a slow seat is no longer cut at
+  the transport's 30 s cloud default on its first turn (measured on 0.118.7:
+  agent tasks declaring `timeout: "840s"` failed with `NIKA-INFER-001` at
+  30 002 ms while the same seat under `infer:` completed). Without a
+  `timeout:` the transport's per-provider default still applies.

--- a/changelog.d/agent-turns-follow-the-task-timeout.fixed.md
+++ b/changelog.d/agent-turns-follow-the-task-timeout.fixed.md
@@ -1,8 +1,9 @@
 - **An `agent:` task's `timeout:` now governs every provider call of its
-  loop (#1516).** Each turn's request, the `nika:done` repair turns and the
+  native loop (#1516).** Each turn's request, the `nika:done` repair turns and the
   final tools-off re-ask carry the task budget to the transport deadline,
   the way an `infer:` task already did, so a slow seat is no longer cut at
   the transport's 30 s cloud default on its first turn (measured on 0.118.7:
   agent tasks declaring `timeout: "840s"` failed with `NIKA-INFER-001` at
   30 002 ms while the same seat under `infer:` completed). Without a
-  `timeout:` the transport's per-provider default still applies.
+  `timeout:` the transport's per-provider default still applies; a seat-routed
+  (harness) agent is bounded by the task's own deadline, not per call.

--- a/crates/nika-runtime/src/dispatch.rs
+++ b/crates/nika-runtime/src/dispatch.rs
@@ -882,6 +882,11 @@ where
         Self::bridge_inputs(&mut input, scope, ctx);
         input.max_turns = action.max_turns.as_ref().map(|t| t.value);
         input.max_tokens_total = action.max_tokens_total.as_ref().map(|t| t.value);
+        // The task `timeout:` flows to the provider transport deadline of
+        // every loop turn — the infer branch's law (issue 1516: the loop
+        // took the transport's 30 s cloud default while `infer:` on the
+        // same seat honored the same `timeout:`).
+        input.timeout = ctx.deadline;
         input.temperature = temp_f32(action.temperature.as_ref());
         input.schema = task_schema(action.schema.as_ref(), contract);
         // The buffer is the CALLER's (per task-attempt-loop · still
@@ -1220,6 +1225,8 @@ mod infer_deadline_tests {
 // convention — `run_and_capture` is `pub(super)` for that sibling).
 #[cfg(test)]
 mod tests;
+#[cfg(test)]
+mod tests_agent_deadline;
 /// #651 (OBS-E promoted) — an `infer` whose visible answer is BLANK while
 /// the provider billed real tokens settles the task FAILED with the typed
 /// `NIKA-INFER-004`, and the run verdict follows (no more « 7/7 done ·

--- a/crates/nika-runtime/src/dispatch/tests_agent_deadline.rs
+++ b/crates/nika-runtime/src/dispatch/tests_agent_deadline.rs
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The agent twin of the infer deadline proof: a task `timeout:` reaches
+//! the provider request of every loop turn. Measured on 0.118.7 (#1516):
+//! four agent tasks declaring `timeout: "840s"` died on their FIRST turn
+//! at 30 002 ms — the transport's cloud default — while the same seat
+//! under `infer:` with the same `timeout:` completed.
+
+#![allow(clippy::expect_used, clippy::panic)]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use nika_kernel::ai::provider::InferRequest;
+use nika_kernel_mock::{
+    MockClock, MockProvider, MockShell, MockToolDefinitionProvider, MockToolExecutor,
+};
+use nika_verb_agent::AgentVerb;
+use nika_verb_exec::ExecVerb;
+use nika_verb_invoke::InvokeVerb;
+
+use crate::{DeterministicStamper, Runtime, RuntimeConfig, VecSink};
+
+/// Settle one agent workflow on a capturing mock seat (a text answer on
+/// turn 1 · no tools) and hand back every provider request the loop built.
+async fn agent_requests(yaml: &str) -> Vec<InferRequest> {
+    let wf = nika_schema::parse(
+        yaml,
+        nika_schema::FileId::new(0),
+        nika_schema::ParseMode::Strict,
+    )
+    .expect("fixture parses");
+    let report = nika_check::check(&wf);
+    assert!(report.is_clean(), "fixture passes the ladder: {report:?}");
+    let provider = Arc::new(MockProvider::new("mock").enqueue_text("ok"));
+    let invoke = Arc::new(InvokeVerb::new(Arc::new(MockToolExecutor::new())));
+    let registry = Arc::new(nika_providers::ProviderRegistry::without_http(
+        nika_providers::ProvidersConfig::default(),
+    ));
+    let runtime = Runtime::new(
+        ExecVerb::new(Arc::new(MockShell::new())),
+        Arc::clone(&invoke),
+        nika_verb_infer::InferVerb::new(registry, "mock/echo"),
+        AgentVerb::new(
+            Arc::clone(&provider),
+            invoke,
+            Arc::new(MockToolDefinitionProvider::new()),
+            "mock/echo",
+        ),
+        MockClock::new(),
+        RuntimeConfig::default(),
+    );
+    let mut stamper = DeterministicStamper::new();
+    let mut sink = VecSink::new();
+    let outcome = runtime
+        .run(&wf, &report, &mut stamper, &mut sink)
+        .await
+        .expect("the run completes");
+    assert!(outcome.ok, "the canned answer settles green");
+    provider.captured_requests()
+}
+
+#[tokio::test]
+async fn task_timeout_governs_the_agent_turns_provider_deadline() {
+    // The infer proof's exact field, on an agent task: `timeout: "7m"`.
+    let captured = agent_requests(
+        "nika: w\nmodel: mock/echo\ntasks:\n  ask:\n    timeout: \"7m\"\n    agent: { prompt: \"hello\" }\n",
+    )
+    .await;
+    assert_eq!(captured.len(), 1, "one provider round-trip");
+    assert_eq!(
+        captured[0].timeout,
+        Some(Duration::from_secs(420)),
+        "the task budget rides the agent's provider request"
+    );
+}
+
+#[tokio::test]
+async fn an_agent_task_without_timeout_leaves_the_transport_default() {
+    let captured = agent_requests(
+        "nika: w\nmodel: mock/echo\ntasks:\n  ask:\n    agent: { prompt: \"hello\" }\n",
+    )
+    .await;
+    assert_eq!(captured.len(), 1, "one provider round-trip");
+    assert_eq!(
+        captured[0].timeout, None,
+        "no task budget ⇒ the transport applies its own per-provider default"
+    );
+}

--- a/crates/nika-verb-agent/public-api.txt
+++ b/crates/nika-verb-agent/public-api.txt
@@ -831,6 +831,7 @@ pub nika_verb_agent::AgentInput::prompt: alloc::string::String
 pub nika_verb_agent::AgentInput::schema: core::option::Option<serde_json::value::Value>
 pub nika_verb_agent::AgentInput::system: core::option::Option<alloc::string::String>
 pub nika_verb_agent::AgentInput::temperature: core::option::Option<f32>
+pub nika_verb_agent::AgentInput::timeout: core::option::Option<core::time::Duration>
 pub nika_verb_agent::AgentInput::tools: alloc::vec::Vec<alloc::string::String>
 impl nika_verb_agent::AgentInput
 pub fn nika_verb_agent::AgentInput::new(prompt: impl core::convert::Into<alloc::string::String>) -> Self

--- a/crates/nika-verb-agent/src/intrinsic.rs
+++ b/crates/nika-verb-agent/src/intrinsic.rs
@@ -85,8 +85,10 @@ pub(crate) fn synthesized_defs(
 /// The synthesized `nika:done` sentinel definition (loop-owned).
 ///
 /// Under a TYPED task the `result` parameter carries the declared
-/// `schema:` VERBATIM — the sentinel's own parameter schema IS how the
-/// contract reaches the seat, on the FIRST request and every one after.
+/// `schema:` (its `$defs` hoisted to the wrapper root — see
+/// [`typed_done_parameters`]) — the sentinel's own parameter schema IS
+/// how the contract reaches the seat, on the FIRST request and every one
+/// after.
 /// The binding is wire-universal by construction: a tool's parameter
 /// schema rides `tools[].function.parameters` (openai-compat),
 /// `functionDeclarations[].parametersJsonSchema` (gemini) and
@@ -120,12 +122,40 @@ fn done_def(schema: Option<&serde_json::Value>) -> ToolDef {
          `result` MUST satisfy the JSON Schema declared for it — the \
          engine validates it and asks you to call this tool again when \
          it does not conform.",
-        serde_json::json!({
-            "type": "object",
-            "properties": { "result": schema },
-            "required": ["result"]
-        }),
+        typed_done_parameters(schema),
     )
+}
+
+/// The typed sentinel's parameter schema: the declared `schema:` nested
+/// under `result`, with its `$defs`/`definitions` HOISTED to the wrapper's
+/// root. An internal JSON pointer (`"$ref": "#/$defs/row"`) resolves
+/// against the DOCUMENT root, and on the wire that root is this wrapper —
+/// nested verbatim, the pointer lands on nothing and a seat that validates
+/// its tool input reads a dangling ref. A `$schema` keyword is dropped (it
+/// has no place inside a tool input); everything else stays where the
+/// author wrote it, and local validation is untouched (it runs against the
+/// declared schema at its own root). A schema with nothing to hoist
+/// renders exactly as before.
+fn typed_done_parameters(schema: &serde_json::Value) -> serde_json::Value {
+    let mut nested = schema.clone();
+    let mut hoisted = serde_json::Map::new();
+    if let Some(declared) = nested.as_object_mut() {
+        declared.remove("$schema");
+        for key in ["$defs", "definitions"] {
+            if let Some(defs) = declared.remove(key) {
+                hoisted.insert(key.to_owned(), defs);
+            }
+        }
+    }
+    let mut parameters = serde_json::json!({
+        "type": "object",
+        "properties": { "result": nested },
+        "required": ["result"]
+    });
+    if let Some(root) = parameters.as_object_mut() {
+        root.extend(hoisted);
+    }
+    parameters
 }
 
 /// The synthesized `nika:compose` definition (loop-owned, like the

--- a/crates/nika-verb-agent/src/intrinsic.rs
+++ b/crates/nika-verb-agent/src/intrinsic.rs
@@ -135,7 +135,9 @@ fn done_def(schema: Option<&serde_json::Value>) -> ToolDef {
 /// has no place inside a tool input); everything else stays where the
 /// author wrote it, and local validation is untouched (it runs against the
 /// declared schema at its own root). A schema with nothing to hoist
-/// renders exactly as before.
+/// renders exactly as before. Only `$defs`/`definitions` pointers are
+/// rescued: a `"$ref": "#"` or a `#/properties/…` pointer still names
+/// the wrapper on the wire (the author's root is `properties.result`).
 fn typed_done_parameters(schema: &serde_json::Value) -> serde_json::Value {
     let mut nested = schema.clone();
     let mut hoisted = serde_json::Map::new();

--- a/crates/nika-verb-agent/src/io.rs
+++ b/crates/nika-verb-agent/src/io.rs
@@ -27,6 +27,12 @@ pub struct AgentInput {
     pub max_turns: Option<u32>,
     /// Cumulative token budget across all turns.
     pub max_tokens_total: Option<u64>,
+    /// The task-level `timeout:` budget (spec 03) — plumbed to the
+    /// provider transport deadline so the HTTP effect's fixed default
+    /// cannot undercut a longer task budget (F1 · a local model
+    /// routinely needs minutes). `None` → the adapter's per-provider
+    /// default governs. Rides EVERY turn of the loop (issue 1516).
+    pub timeout: Option<std::time::Duration>,
     /// Sampling temperature (0-2 · validated here).
     pub temperature: Option<f32>,
     /// JSON Schema validating the FINAL output (spec `schema:`).
@@ -57,6 +63,7 @@ impl AgentInput {
             tools: Vec::new(),
             max_turns: None,
             max_tokens_total: None,
+            timeout: None,
             temperature: None,
             schema: None,
             permits: None,

--- a/crates/nika-verb-agent/src/lib.rs
+++ b/crates/nika-verb-agent/src/lib.rs
@@ -59,7 +59,8 @@
 //!
 //! - a **`nika:done` `result:`** that does not validate — the errors go
 //!   back as that call's tool result (`is_error: true`, the agentic
-//!   convention) and the model finishes again;
+//!   convention) and the model finishes again (one more request, so the
+//!   `max_tokens_total` gate applies to it as to any dispatch);
 //! - a **free-text answer** (natural completion · result-less `done`) —
 //!   the loop RE-ASKS the provider on a tools-OFF turn WITH the schema
 //!   wired (native `response_format` when supported · an instruction
@@ -1356,15 +1357,31 @@ fn classify_turn(
             turn::ExplicitDone::FinalText { text, stop_reason } => {
                 Ok(final_text_verdict(text, stop_reason, ctx))
             }
-            turn::ExplicitDone::Repair { detail } => Ok(TurnVerdict::RepairDone(DoneRepair {
-                tool_use_id: done.id.clone(),
-                detail,
-            })),
+            turn::ExplicitDone::Repair { detail } => {
+                // A repair is one more provider request: the token budget
+                // gates it exactly like a dispatch (a met budget ends the
+                // run on the budget verdict, never a silent overrun).
+                token_budget_gate(ctx)?;
+                Ok(TurnVerdict::RepairDone(DoneRepair {
+                    tool_use_id: done.id.clone(),
+                    detail,
+                }))
+            }
         };
     }
 
     // The loop WILL iterate to feed tool results back · enforce the token
     // budget NOW (spec §2 case 3 · `>=` exhausted · before spending more).
+    token_budget_gate(ctx)?;
+
+    Ok(TurnVerdict::Dispatch(tool_uses))
+}
+
+/// The token gate (spec §2 case 3 · `>=` exhausted): the loop is about
+/// to ask the provider again — to feed a tool batch back or to repair a
+/// `nika:done` result — and a budget already met stops it BEFORE that
+/// request. Both iterating verdicts pass here, so neither can overrun.
+fn token_budget_gate(ctx: &TurnCtx<'_>) -> Result<(), VerbAgentError> {
     if let Some(budget) = ctx.input.max_tokens_total
         && ctx.total_tokens >= budget
     {
@@ -1374,8 +1391,7 @@ fn classify_turn(
             spend: Box::default(), // decorated at the return seam
         });
     }
-
-    Ok(TurnVerdict::Dispatch(tool_uses))
+    Ok(())
 }
 
 /// Route a free-text final answer: a no-schema task closes immediately

--- a/crates/nika-verb-agent/src/request.rs
+++ b/crates/nika-verb-agent/src/request.rs
@@ -25,6 +25,11 @@ pub(crate) fn build_request(
     let mut request = InferRequest::new(model, messages);
     request.temperature = input.temperature;
     request.tools = defs;
+    // The task `timeout:` rides EVERY turn of the loop — the transport's
+    // per-provider default must not undercut the author's budget on the
+    // turns a slow seat needs it (issue 1516: the loop died at the 30 s
+    // cloud default while `infer:` on the same seat honored `timeout:`).
+    request.timeout = input.timeout;
     request
 }
 
@@ -45,6 +50,9 @@ pub(crate) fn schema_request(
     let mut request = InferRequest::new(model, messages);
     request.temperature = input.temperature;
     // tools deliberately left empty (default) — see the doc comment.
+    // The re-ask is one more provider call of the same task: it carries
+    // the task `timeout:` like every loop turn (`build_request` mirror).
+    request.timeout = input.timeout;
     if native {
         request.response_format = ResponseFormat::JsonSchema(schema.clone());
     }

--- a/crates/nika-verb-agent/src/request.rs
+++ b/crates/nika-verb-agent/src/request.rs
@@ -28,11 +28,13 @@ pub(crate) fn build_request(
     request
 }
 
-/// The FINAL schema-constrained re-ask request (BUG#11): tools OFF (the
-/// schema constraint and tool-calling do not reliably coexist in one
-/// request across providers — anthropic rejects `response_format`,
-/// openai/gemini are fragile), with the schema wired natively when the
-/// provider supports it (`infer`+schema parity · `build_request` mirror).
+/// The FINAL schema-constrained re-ask request (BUG#11): tools OFF (a
+/// grammar over the message content fights the tool-calling turns it
+/// would ride on — see the loop file's «Structured output» section), and
+/// `response_format` wired only when `native` says the seat carries a
+/// structured mode (the provider profile's `supports_response_format()`);
+/// otherwise the re-ask message already in the transcript carries the
+/// schema as an instruction (`infer`+schema parity · `build_request` mirror).
 pub(crate) fn schema_request(
     model: &str,
     messages: Vec<Message>,

--- a/crates/nika-verb-agent/src/tests_schema.rs
+++ b/crates/nika-verb-agent/src/tests_schema.rs
@@ -548,10 +548,11 @@ fn a_schema_without_defs_renders_the_pinned_wrapper_byte_for_byte() {
 #[tokio::test]
 async fn a_repair_turn_is_gated_by_the_token_budget() {
     // Two violating dones queued; the first answer already spends the
-    // whole budget (15 tokens · `>=` exhausted). Measured before the gate:
-    // the loop asked for the repair anyway and the run ended on NIKA-464
-    // after TWO requests, one past the author's budget. A repair is a
-    // request like any other: not asked, the budget verdict instead.
+    // whole budget (15 tokens · `>=` exhausted). Without the gate the loop
+    // asks for the repair anyway: a second request past the author's
+    // budget (and, the allowance being two, a third one the mock queue
+    // cannot answer). A repair is a request like any other: not asked,
+    // the budget verdict instead — one request, NIKA-461.
     let bad = || {
         tool_use_response(
             "c",

--- a/crates/nika-verb-agent/src/tests_schema.rs
+++ b/crates/nika-verb-agent/src/tests_schema.rs
@@ -14,6 +14,8 @@
 //! are shared (`crate::tests`), so a change to the loop's test double
 //! still moves both suites at once.
 
+use std::time::Duration;
+
 use super::*;
 use nika_kernel::ai::provider::{ResponseFormat, ToolDef};
 use nika_kernel::runtime::tool_executor::ToolResult;
@@ -588,5 +590,73 @@ async fn a_repair_turn_is_gated_by_the_token_budget() {
         r.provider.captured_requests().len(),
         1,
         "the repair was never requested"
+    );
+}
+
+// ── (f) the task `timeout:` rides every request the loop builds ─────
+
+#[tokio::test]
+async fn every_loop_turn_carries_the_task_timeout_including_a_repair() {
+    // The loop builds a request per turn; the task `timeout:` must ride
+    // each one — the repair turn included — or the transport's own default
+    // governs exactly the turns a slow seat needs the budget on (measured
+    // on 0.118.7: the loop died at the 30 s cloud default while `infer:`
+    // on the same seat honored the same `timeout:`).
+    let r = rig(
+        MockProvider::new("mock")
+            .enqueue_response(tool_use_response(
+                "c1",
+                DONE_TOOL,
+                serde_json::json!({"result": {"score": "nine"}}),
+            ))
+            .enqueue_response(tool_use_response(
+                "c2",
+                DONE_TOOL,
+                serde_json::json!({"result": {"score": 9}}),
+            )),
+        MockToolExecutor::new(),
+        Vec::new(),
+    );
+    let mut input = AgentInput::new("rate it");
+    input.tools = vec![DONE_TOOL.to_owned()];
+    input.schema = Some(score_schema());
+    input.timeout = Some(Duration::from_secs(420));
+    r.verb.run(input).await.expect("the repair conforms");
+    let reqs = r.provider.captured_requests();
+    assert_eq!(reqs.len(), 2, "the first turn and its repair");
+    for (i, request) in reqs.iter().enumerate() {
+        assert_eq!(
+            request.timeout,
+            Some(Duration::from_secs(420)),
+            "turn {} lost the task budget",
+            i + 1
+        );
+    }
+}
+
+#[tokio::test]
+async fn the_tools_off_reask_carries_the_task_timeout_too() {
+    // The free-text re-ask has its own builder; same law, same field.
+    let r = rig(
+        MockProvider::new("mock")
+            .enqueue_response(text_response("nine out of ten"))
+            .enqueue_response(text_response(r#"{"score": 9}"#)),
+        MockToolExecutor::new(),
+        Vec::new(),
+    );
+    let mut input = AgentInput::new("rate it");
+    input.schema = Some(score_schema());
+    input.timeout = Some(Duration::from_secs(420));
+    let out = r.verb.run(input).await.expect("the re-ask conforms");
+    assert_eq!(
+        out.output,
+        AgentValue::Structured(serde_json::json!({"score": 9}))
+    );
+    let reqs = r.provider.captured_requests();
+    assert_eq!(reqs.len(), 2, "the prose answer and the schema re-ask");
+    assert_eq!(
+        reqs[1].timeout,
+        Some(Duration::from_secs(420)),
+        "the re-ask lost the task budget"
     );
 }

--- a/crates/nika-verb-agent/src/tests_schema.rs
+++ b/crates/nika-verb-agent/src/tests_schema.rs
@@ -423,3 +423,170 @@ async fn the_done_repair_and_the_text_reask_share_one_budget() {
         "the 4th canned response must stay unconsumed"
     );
 }
+
+// ── (d) the def's `$defs` ride at the wrapper root, where a `$ref` lands ─
+
+/// A contract whose `result` reaches into its own `$defs` — the shape a
+/// schema-authoring tool emits by default.
+fn rows_schema() -> serde_json::Value {
+    serde_json::json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+            "rows": {"type": "array", "items": {"$ref": "#/$defs/row"}}
+        },
+        "required": ["rows"],
+        "$defs": {
+            "row": {
+                "type": "object",
+                "properties": {"id": {"type": "integer"}},
+                "required": ["id"]
+            }
+        }
+    })
+}
+
+#[tokio::test]
+async fn the_done_def_hoists_defs_to_the_wrapper_root() {
+    // On the wire the document root is the SENTINEL'S parameter schema,
+    // not the declared schema: `#/$defs/row` resolves against the wrapper,
+    // so the definitions must ride at its root and NOT under
+    // `properties.result` (nested verbatim, a seat that validates its tool
+    // input followed the pointer to nothing).
+    let r = rig(
+        MockProvider::new("mock").enqueue_response(tool_use_response(
+            "c",
+            DONE_TOOL,
+            serde_json::json!({"result": {"rows": [{"id": 1}]}}),
+        )),
+        MockToolExecutor::new(),
+        Vec::new(),
+    );
+    let mut input = AgentInput::new("list the rows");
+    input.tools = vec![DONE_TOOL.to_owned()];
+    input.schema = Some(rows_schema());
+    let out = r
+        .verb
+        .run(input)
+        .await
+        .expect("local validation resolves the ref at the declared root");
+    assert_eq!(
+        out.output,
+        AgentValue::Structured(serde_json::json!({"rows": [{"id": 1}]}))
+    );
+
+    let reqs = r.provider.captured_requests();
+    let parameters = &done_def_on(&reqs[0]).parameters;
+    assert_eq!(
+        parameters["$defs"]["row"]["required"],
+        serde_json::json!(["id"]),
+        "the definitions ride at the wrapper root, where the pointer lands"
+    );
+    let result = &parameters["properties"]["result"];
+    assert!(
+        result.get("$defs").is_none(),
+        "no second copy under `result`"
+    );
+    assert!(
+        result.get("$schema").is_none(),
+        "`$schema` has no place inside a tool input"
+    );
+    assert_eq!(
+        result["properties"]["rows"]["items"]["$ref"],
+        serde_json::json!("#/$defs/row"),
+        "the pointer itself is left as the author wrote it"
+    );
+    assert_eq!(result["required"], serde_json::json!(["rows"]));
+}
+
+#[test]
+fn the_done_def_hoists_definitions_too_and_drops_the_schema_keyword() {
+    // The draft-7 spelling hoists the same way; `$schema` is DROPPED from
+    // the nested schema, not moved — a tool input declares no dialect.
+    let declared = serde_json::json!({
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {"row": {"$ref": "#/definitions/row"}},
+        "definitions": {"row": {"type": "object"}}
+    });
+    let whitelist = Whitelist::new(&[DONE_TOOL.to_owned()]);
+    let defs = crate::intrinsic::synthesized_defs(&whitelist, Some(&declared));
+    let parameters = &defs[0].parameters;
+    assert_eq!(
+        parameters["definitions"]["row"],
+        serde_json::json!({"type": "object"})
+    );
+    let result = &parameters["properties"]["result"];
+    assert!(result.get("definitions").is_none());
+    assert!(result.get("$schema").is_none());
+    assert!(parameters.get("$schema").is_none(), "dropped, not hoisted");
+    assert_eq!(
+        result["properties"]["row"]["$ref"],
+        serde_json::json!("#/definitions/row")
+    );
+}
+
+#[test]
+fn a_schema_without_defs_renders_the_pinned_wrapper_byte_for_byte() {
+    // No regression on the pinned shape: nothing to hoist ⇒ the wrapper is
+    // exactly the one every seat has read since the schema first rode
+    // the def.
+    let whitelist = Whitelist::new(&[DONE_TOOL.to_owned()]);
+    let defs = crate::intrinsic::synthesized_defs(&whitelist, Some(&score_schema()));
+    let pinned = serde_json::json!({
+        "type": "object",
+        "properties": {"result": score_schema()},
+        "required": ["result"]
+    });
+    assert_eq!(defs[0].parameters.to_string(), pinned.to_string());
+}
+
+// ── (e) a repair is a request: the token budget gates it ────────────
+
+#[tokio::test]
+async fn a_repair_turn_is_gated_by_the_token_budget() {
+    // Two violating dones queued; the first answer already spends the
+    // whole budget (15 tokens · `>=` exhausted). Measured before the gate:
+    // the loop asked for the repair anyway and the run ended on NIKA-464
+    // after TWO requests, one past the author's budget. A repair is a
+    // request like any other: not asked, the budget verdict instead.
+    let bad = || {
+        tool_use_response(
+            "c",
+            DONE_TOOL,
+            serde_json::json!({"result": {"score": "nine"}}),
+        )
+    };
+    let r = rig(
+        MockProvider::new("mock")
+            .enqueue_response(bad())
+            .enqueue_response(bad()),
+        MockToolExecutor::new(),
+        Vec::new(),
+    );
+    let mut input = AgentInput::new("rate it");
+    input.tools = vec![DONE_TOOL.to_owned()];
+    input.schema = Some(score_schema());
+    input.max_tokens_total = Some(15); // the first answer spends exactly 15
+    let err = r.verb.run(input).await.expect_err("the budget terminal");
+    assert!(
+        matches!(
+            &err,
+            VerbAgentError::MaxTokens {
+                total_tokens: 15,
+                ..
+            }
+        ),
+        "a met budget ends the run on the budget verdict, not on a repair: {err:?}"
+    );
+    assert_eq!(
+        nika_error::traits::NikaErrorCode::nika_code(&err).num,
+        461,
+        "NIKA-461 · wire NIKA-AGENT-002"
+    );
+    assert_eq!(
+        r.provider.captured_requests().len(),
+        1,
+        "the repair was never requested"
+    );
+}


### PR DESCRIPTION
## What

Closes #1516. Three follow-ups from the independent review of #1507 (the schema-on-the-first-request change) plus the agent loop's ignored task `timeout:`:

1. **`$defs`/`$ref` in a declared `agent.schema`** — the typed `nika:done` definition nested the schema verbatim under `properties.result`, so an internal pointer (`"$ref": "#/$defs/row"`) resolved against the wrapper on the wire and a seat validating its tool input followed it to nothing. `$defs`/`definitions` are now hoisted to the wrapper root and a `$schema` keyword is dropped; nothing else moves, and local validation is untouched.
2. **Repair turns vs `max_tokens_total`** — a `nika:done` repair turn continued past the token gate, so a run could exceed the author's budget by up to `DEFAULT_SCHEMA_RETRY_BUDGET` requests. The gate is one function now, passed by the dispatch verdict and the repair verdict alike: a met budget ends the run on `NIKA-AGENT-002` before the repair is requested, never a silent overrun.
3. **Stale wire comment** on `schema_request` (« anthropic rejects `response_format` ») replaced by what the code does: `response_format` rides only when the provider profile's `supports_response_format()` says so; otherwise the re-ask message carries the schema as an instruction.
4. **Task `timeout:` on the agent loop** (#1516) — measured on 0.118.7, agent tasks declaring `timeout: "840s"` died on their first turn at 30 002 ms (the transport's cloud default) while the same seat under `infer:` with the same `timeout:` completed. `AgentInput` gains `timeout`, the agent branch of dispatch sets it from the same deadline the infer branch uses, and every request the loop builds carries it: each turn, the repair turns, the tools-off re-ask.

## How

- `crates/nika-verb-agent/src/intrinsic.rs` — the typed `done_def` branch calls `typed_done_parameters(schema)`: clone, remove `$schema`, move `$defs`/`definitions` to the wrapper root, keep everything else where the author wrote it. A schema with nothing to hoist renders byte-for-byte as before (`serde_json` without `preserve_order`).
- `crates/nika-verb-agent/src/lib.rs` — `token_budget_gate(ctx)` (the inline `>=` gate moved out of `classify_turn`), called from the Dispatch site and the `ExplicitDone::Repair` arm; the module doc bullet names it. `lib.rs` sits at 1493 raw lines.
- `crates/nika-verb-agent/src/request.rs` — the comment fix; both builders set `request.timeout = input.timeout`.
- `crates/nika-verb-agent/src/io.rs` — `AgentInput.timeout: Option<Duration>` (the `InferInput.timeout` doc sentence); `public-api.txt` gains the field line at its sorted position, rendered locally with the CI's exact `cargo +nightly-2026-08-24 public-api --omit auto-trait-impls` and byte-identical to the baseline.
- `crates/nika-runtime/src/dispatch.rs` — `dispatch_agent` sets `input.timeout = ctx.deadline` (the infer branch's law) and declares a carved `#[cfg(test)] mod tests_agent_deadline;`.
- Fragments: `agent-done-def-hoists-defs.fixed.md` · `agent-repair-turns-respect-the-token-budget.fixed.md` · `agent-turns-follow-the-task-timeout.fixed.md`.

## Proof

- `cargo test -p nika-verb-agent --lib`: 116 passed (6 new). `cargo test -p nika-runtime --lib`: 291 passed (2 new).
- `cargo clippy -p nika-verb-agent -p nika-runtime --all-targets -- -D warnings`: clean. Caps: fn ≤ 100 OK · files ≤ 1500 OK · zero `unwrap`/`expect` in `src/` OK · crates ≤ 15 000 LOC OK · 38 fragments OK. Pre-push gate green (453 s), cargo-deny and cargo-machete green.
- Mutation proofs (each a one-line revert, run then restored):
  - `the_done_def_hoists_defs_to_the_wrapper_root` fails when `"$defs"` is dropped from the hoist list;
  - `the_done_def_hoists_definitions_too_and_drops_the_schema_keyword` fails when `declared.remove("$schema")` is removed;
  - `a_schema_without_defs_renders_the_pinned_wrapper_byte_for_byte` fails when a `$defs` entry is inserted unconditionally;
  - `a_repair_turn_is_gated_by_the_token_budget` fails when `token_budget_gate(ctx)?` leaves the Repair arm (two requests, NIKA-464 instead of the budget verdict);
  - `every_loop_turn_carries_the_task_timeout_including_a_repair` and `the_tools_off_reask_carries_the_task_timeout_too` fail when `request.timeout = input.timeout` is removed from `build_request` and `schema_request` respectively;
  - `task_timeout_governs_the_agent_turns_provider_deadline` fails when `input.timeout = ctx.deadline` is removed from `dispatch_agent`.

## Follow-ups

- Spec, upstream repo (`02-verbs.md`, the `nika:done` `result:` sentence): « Under a task that declares `schema:`, `result:` is required and must satisfy that schema — a miss is fed back as the call's error observation and the model finishes again, within the run's one repair allowance; without `schema:`, `result:` stays optional (any JSON value), and an absent `result:` finishes on the final assistant message (string). »
- A repair turn still bypasses the `max_turns` gate (bounded by the u8 repair allowance); only the token budget is gated here, as the review asked.
- A `$ref` to anything other than `$defs`/`definitions` (the root `#`, a `properties` path) still resolves against the wrapper on the wire.

## Review follow-up (independent review, folded)

- the repair-gate test's comment narrates the mutant it kills faithfully; the hoist's doc comment names the pointer shapes it does not rescue (a root or a properties pointer still names the wrapper on the wire); the timeout fragment says the native loop is what follows the task deadline per call.
- Not in this PR: the seat-routed (harness) path drops the task timeout per call — it is bounded by the task's own deadline; a follow-up plumbs it per call.
