### PR TITLE
fix(nika-cli): preserve underscore codes in run json

### DIFF
--- a/changelog.d/run-json-underscore-error-code.fixed.md
+++ b/changelog.d/run-json-underscore-error-code.fixed.md
@@ -1,0 +1,3 @@
+- **Run JSON preserves error codes containing underscores.** Failed runs
+  retain codes such as `NIKA-BUILTIN-JSON_MERGE_PATCH-001` in `error.code`
+  when they appear in the diagnostic, so consumers can classify the refusal.

--- a/crates/nika-cli/src/verbs/run/epilogue.rs
+++ b/crates/nika-cli/src/verbs/run/epilogue.rs
@@ -383,12 +383,13 @@ pub(super) fn failure_witnesses(view: &crate::RunView) -> Vec<&str> {
 
 /// Best-effort wire-code extraction: the first `NIKA-…` token in a
 /// diagnostic (findings render `[NIKA-PARSE-009]` · run details lead with
-/// `NIKA-431 · …`). Never invents — no token, no code.
+/// `NIKA-431 · …`). Builtin sub-namespaces can contain underscores
+/// (`NIKA-BUILTIN-JSON_MERGE_PATCH-001`). No token, no code.
 pub(super) fn first_nika_code(text: &str) -> Option<&str> {
     let start = text.find("NIKA-")?;
     let rest = &text[start..];
     let end = rest
-        .find(|c: char| !(c.is_ascii_uppercase() || c.is_ascii_digit() || c == '-'))
+        .find(|c: char| !(c.is_ascii_uppercase() || c.is_ascii_digit() || matches!(c, '-' | '_')))
         .unwrap_or(rest.len());
     let code = rest[..end].trim_end_matches('-');
     // A bare `NIKA-` prefix with no digits is prose, not a code.
@@ -618,6 +619,76 @@ mod tests {
         );
         assert_eq!(super::first_nika_code("the NIKA- prefix alone"), None);
         assert_eq!(super::first_nika_code("no code here"), None);
+    }
+
+    /// Exercise the emitted constants, including every underscore-named
+    /// builtin family, without claiming to execute media/provider calls.
+    #[test]
+    fn error_envelope_preserves_canonical_builtin_codes() -> Result<(), serde_json::Error> {
+        let sources = [
+            include_str!("../../../../nika-builtin/src/data.rs"),
+            include_str!("../../../../nika-builtin/src/image_fx.rs"),
+            include_str!("../../../../nika-builtin/src/image/types.rs"),
+            include_str!("../../../../nika-builtin/src/tts/types.rs"),
+        ];
+        let codes: std::collections::BTreeSet<_> = sources
+            .iter()
+            .flat_map(|source| source.lines())
+            .filter(|line| line.contains("const ") && line.contains(": &str = "))
+            .filter_map(|line| line.split('"').nth(1))
+            .filter(|code| code.starts_with("NIKA-BUILTIN-") && code.contains('_'))
+            .collect();
+        assert!(
+            codes.len() >= 22,
+            "the emitted-code inventory must not be empty or truncated"
+        );
+        for code in codes {
+            for message in [
+                format!("{code} · invalid arguments"),
+                format!("task `patch` failed — [{code}]: invalid arguments"),
+                format!("diagnostic:\n\"{code}\"\nnext line"),
+            ] {
+                assert_eq!(super::first_nika_code(&message), Some(code), "{message}");
+                let envelope: Value = serde_json::from_str(&super::error_envelope_line(&message))?;
+                assert_eq!(
+                    envelope,
+                    json!({"error": {"code": code, "message": message}})
+                );
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn first_nika_code_keeps_lexical_boundaries() {
+        for text in [
+            "NIKA-",
+            "NIKA-BUILTIN-JSON_MERGE_PATCH-",
+            "NIKA-BUILTIN-JSON_MERGE_PATCH-no-number",
+            "NIKA-BUILTIN-JSON/MERGE_PATCH-001",
+            "nika-BUILTIN-JSON_MERGE_PATCH-001",
+        ] {
+            assert_eq!(super::first_nika_code(text), None, "{text}");
+        }
+        for text in [
+            "échec 🦋 [NIKA-BUILTIN-JSON_MERGE_PATCH-001] détail",
+            "\u{1b}[31mNIKA-BUILTIN-JSON_MERGE_PATCH-001\u{1b}[0m",
+            "NIKA-BUILTIN-JSON_MERGE_PATCH-001 · then NIKA-431",
+        ] {
+            assert_eq!(
+                super::first_nika_code(text),
+                Some("NIKA-BUILTIN-JSON_MERGE_PATCH-001"),
+                "{text}"
+            );
+        }
+        assert_eq!(
+            super::first_nika_code("[NIKA-431] NIKA-VAR-001"),
+            Some("NIKA-431")
+        );
+        assert_eq!(
+            super::first_nika_code("NIKA-PARSE-009--- · detail"),
+            Some("NIKA-PARSE-009")
+        );
     }
 
     /// A findings render condenses to the line that carries the code.


### PR DESCRIPTION
Run JSON omitted `error.code` for builtin error codes containing underscores because its best-effort lexer stopped before their numeric suffix. Accept underscores in the existing token scan while preserving the error message and JSON envelope.

Regression cases derive valid codes from the emitted builtin constants and cover surrounding text, malformed prefixes and codes without underscores. The changelog fragment records the observable behavior.

Validation: the two new tests fail before the fix; all 16 epilogue tests pass after it. Independent review exercised 37 lexical controls and 10 native workflows. The publication run passes 7,440 workspace library tests with 3 skipped and workspace/all-targets Clippy. Its final pass classified one unchanged ARM test as `LEAK` despite passing assertions; the two earlier full H-only passes did not. The ARM source blob and its direct dependencies are unchanged from the base; the lifecycle signal remains a follow-up, not a resolved claim. Linux integration coverage remains owned by CI; an earlier in-process parallel CLI test run exposed an existing current-directory isolation issue, which this change does not resolve.

This is a bounded CLI error-reporting fix. It does not claim complete tool qualification or a benchmark ranking.
