### PR TITLE
fix(runtime): preserve agent results and stop explicit refusals

### DIFF
--- a/changelog.d/agent-done-schema-resource-id.fixed.md
+++ b/changelog.d/agent-done-schema-resource-id.fixed.md
@@ -1,0 +1,5 @@
+- **Typed agent completion keeps definitions inside their schema resource.**
+  When the output schema has a resource `$id`, `nika:done` keeps its `$defs`
+  and `definitions` with that resource so local references resolve in the
+  exposed tool definition. Schemas without a resource ID retain the existing
+  wrapper projection; final-output validation is unchanged.

--- a/changelog.d/agent-final-text-repairs-respect-token-budget.fixed.md
+++ b/changelog.d/agent-final-text-repairs-respect-token-budget.fixed.md
@@ -4,7 +4,8 @@
   `nika:done` repairs. An exhausted budget returns `NIKA-AGENT-002` with
   the last assistant text and observed usage instead of requesting another
   answer. This partial output stays separate from the `nika:done` result
-  being validated and updates with each text repair.
+  being validated and updates with each text repair. An empty current message
+  is preserved even when an earlier tool-loop reply contained text.
   A conforming answer still succeeds at or above the budget. This also
   covers result-less, string and null `nika:done` answers that need the
   final-text repair path.

--- a/changelog.d/agent-final-text-repairs-respect-token-budget.fixed.md
+++ b/changelog.d/agent-final-text-repairs-respect-token-budget.fixed.md
@@ -1,0 +1,10 @@
+- **Typed `agent:` final-text repairs respect `max_tokens_total`.** When
+  the final text does not match the task schema, each additional repair
+  checks the cumulative token budget, including usage from earlier
+  `nika:done` repairs. An exhausted budget returns `NIKA-AGENT-002` with
+  the last assistant text and observed usage instead of requesting another
+  answer. This partial output stays separate from the `nika:done` result
+  being validated and updates with each text repair.
+  A conforming answer still succeeds at or above the budget. This also
+  covers result-less, string and null `nika:done` answers that need the
+  final-text repair path.

--- a/changelog.d/explicit-provider-refusal.fixed.md
+++ b/changelog.d/explicit-provider-refusal.fixed.md
@@ -1,0 +1,4 @@
+- **Explicit provider refusals stop before repair or tool dispatch.**
+  Buffered OpenAI and Anthropic refusals stop `agent:` and `infer:` after
+  recording incurred usage, even alongside valid structured content.
+  Ordinary text without a refusal signal keeps its existing behavior.

--- a/changelog.d/read-argument-contract.fixed.md
+++ b/changelog.d/read-argument-contract.fixed.md
@@ -1,0 +1,5 @@
+- **Read argument errors no longer recover as missing files.** Check rejects
+  literal nonstring `path` and nonboolean `binary` values, while whole-value
+  bindings remain checked at runtime. Invalid arguments report
+  `NIKA-INVOKE-002`; `NIKA-BUILTIN-READ-001` remains exclusive to missing
+  files, preserving first-run recovery and the existing read permissions.

--- a/crates/nika-builtin/src/file.rs
+++ b/crates/nika-builtin/src/file.rs
@@ -17,14 +17,17 @@ use crate::{Args, BuiltinFailure, BuiltinOutcome, req_str, strict_bool, strict_u
 #[cfg(test)]
 mod glob_grep_tests;
 #[cfg(test)]
+mod read_tests;
+#[cfg(test)]
 mod write_tests;
 
 /// `nika:read` — text (default) or binary. Returns the file content.
 pub(crate) async fn read<F: FsReadDyn>(fs: &F, args: &Args) -> BuiltinOutcome {
-    const C1: &str = "NIKA-BUILTIN-READ-001";
+    // READ-001 is exclusively NotFound: first-run recovery filters on it.
+    const ARG: &str = "NIKA-INVOKE-002";
     const C3: &str = "NIKA-BUILTIN-READ-003";
-    let path = req_str(args, "path", C1)?;
-    if strict_bool(args, "binary", false, C1)? {
+    let path = req_str(args, "path", ARG)?;
+    if strict_bool(args, "binary", false, ARG)? {
         // Opaque bytes flow tool→tool — we surface them base64-tagged so
         // they round-trip through the string `content` channel without
         // pretending to be text (spec 04 value-rendering).

--- a/crates/nika-builtin/src/file/read_tests.rs
+++ b/crates/nika-builtin/src/file/read_tests.rs
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! Read argument failures must never select a missing-file recovery.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use bytes::Bytes;
+use nika_kernel_mock::MockFs;
+use serde_json::json;
+
+use super::*;
+
+fn args(value: serde_json::Value) -> Args {
+    match value {
+        serde_json::Value::Object(map) => map,
+        other => panic!("test object required, got {other}"),
+    }
+}
+
+#[tokio::test]
+async fn read_invalid_arguments_are_not_missing_files() {
+    let fs = MockFs::new().with_file("present.txt", "existing bytes");
+    for value in [
+        json!("true"),
+        json!("false"),
+        json!(1),
+        json!(null),
+        json!([]),
+        json!({}),
+    ] {
+        let error = read(&fs, &args(json!({"path": "present.txt", "binary": value})))
+            .await
+            .expect_err("nonboolean binary must fail");
+        assert_eq!(error.code, "NIKA-INVOKE-002", "{value}: {error:?}");
+        assert!(!error.transient);
+        assert!(error.message.contains("binary"));
+    }
+    for value in [json!(true), json!(12), json!(null), json!([]), json!({})] {
+        let error = read(&fs, &args(json!({"path": value})))
+            .await
+            .expect_err("nonstring path must fail");
+        assert_eq!(error.code, "NIKA-INVOKE-002", "{value}: {error:?}");
+        assert!(error.message.contains("path"));
+    }
+    assert_eq!(
+        read(&fs, &Args::new())
+            .await
+            .expect_err("missing path")
+            .code,
+        "NIKA-INVOKE-002"
+    );
+}
+
+struct UnreadableFs(AtomicUsize);
+
+impl FsReadDyn for UnreadableFs {
+    async fn read(&self, path: &Path) -> Result<Bytes, FsError> {
+        self.0.fetch_add(1, Ordering::Relaxed);
+        Err(FsError::PermissionDenied {
+            path: path.display().to_string(),
+        })
+    }
+
+    async fn read_to_string(&self, path: &Path) -> Result<String, FsError> {
+        self.read(path).await.map(|_| String::new())
+    }
+
+    async fn exists(&self, _: &Path) -> bool {
+        false
+    }
+
+    async fn canonicalize(&self, path: &Path) -> Result<PathBuf, FsError> {
+        Ok(path.to_owned())
+    }
+}
+
+#[tokio::test]
+async fn read_invalid_arguments_do_not_call_the_read_seam() {
+    let fs = UnreadableFs(AtomicUsize::new(0));
+    for value in [
+        json!({}),
+        json!({"path": false}),
+        json!({"path": "present.txt", "binary": "true"}),
+    ] {
+        let error = read(&fs, &args(value)).await.expect_err("invalid args");
+        assert_eq!(error.code, "NIKA-INVOKE-002");
+    }
+    assert_eq!(fs.0.load(Ordering::Relaxed), 0);
+    for binary in [false, true] {
+        let error = read(&fs, &args(json!({"path": "unreadable", "binary": binary})))
+            .await
+            .expect_err("permission failure");
+        assert_eq!(error.code, "NIKA-BUILTIN-READ-002");
+    }
+    assert_eq!(fs.0.load(Ordering::Relaxed), 2);
+}
+
+#[tokio::test]
+async fn read_valid_modes_and_file_failures_keep_their_contract() {
+    let text = "\u{feff}hello\r\n\0no final newline";
+    let fs = MockFs::new()
+        .with_file("text", text)
+        .with_file("bytes", vec![0, 255, 128, 10]);
+    for value in [
+        json!({"path": "text"}),
+        json!({"path": "text", "binary": false}),
+    ] {
+        assert_eq!(
+            read(&fs, &args(value)).await.expect("text read"),
+            json!(text)
+        );
+    }
+    assert_eq!(
+        read(&fs, &args(json!({"path": "bytes", "binary": true})))
+            .await
+            .expect("binary read"),
+        json!({"bytes_base64": "AP+ACg==", "len": 4})
+    );
+    assert_eq!(
+        read(&fs, &args(json!({"path": "bytes"})))
+            .await
+            .expect_err("invalid UTF-8")
+            .code,
+        "NIKA-BUILTIN-READ-003"
+    );
+    for binary in [false, true] {
+        assert_eq!(
+            read(&fs, &args(json!({"path": "missing", "binary": binary})))
+                .await
+                .expect_err("missing file")
+                .code,
+            "NIKA-BUILTIN-READ-001"
+        );
+    }
+}

--- a/crates/nika-check/src/conformance_codes.rs
+++ b/crates/nika-check/src/conformance_codes.rs
@@ -60,7 +60,13 @@ pub(crate) fn of(report: &CheckReport) -> Vec<SpecCode> {
             builtin
         }
     }));
-    codes.extend(report.unknown_args.iter().map(|_| builtin));
+    codes.extend(report.unknown_args.iter().map(|a| {
+        if a.tool == "nika:read" && a.invalid_value.is_some() {
+            SpecCode::new("INVOKE", 2, SpecCategory::ValidationError)
+        } else {
+            builtin
+        }
+    }));
     codes.extend(report.missing_args.iter().map(|_| builtin));
     // Gate liveness (03 §static liveness · check-only, reach.rs):
     // DAG-006 statically dead task · DAG-007 out-of-vocabulary literal.

--- a/crates/nika-check/src/findings.rs
+++ b/crates/nika-check/src/findings.rs
@@ -509,6 +509,27 @@ fn fold_unknown_tool(t: &crate::UnknownTool) -> UnifiedFinding {
 }
 
 fn fold_unknown_arg(a: &crate::UnknownArg) -> UnifiedFinding {
+    if a.tool == "nika:read"
+        && let Some(value) = &a.invalid_value
+    {
+        let expected = if a.arg == "path" {
+            "a string"
+        } else {
+            "a boolean (true/false)"
+        };
+        let mut f = UnifiedFinding::new(
+            "unknown_arg",
+            "ARGS",
+            format!(
+                "`{}` `{}:` must be {expected}, not {value} (task `{}`)",
+                a.tool, a.arg, a.task
+            ),
+        );
+        f.code = Some("NIKA-INVOKE-002".to_owned());
+        f.docs_url = Some(format!("{}/NIKA-INVOKE-002", super::ERROR_DOCS_BASE));
+        f.task = Some(a.task.clone());
+        return f;
+    }
     if a.tool == "nika:notify"
         && a.arg == "channel"
         && let Some(value) = &a.invalid_value

--- a/crates/nika-check/src/requirements.rs
+++ b/crates/nika-check/src/requirements.rs
@@ -9,7 +9,7 @@ use serde::Serialize;
 use nika_schema::expression::NamespaceRef;
 use nika_schema::raw::{RawAction, RawWorkflow};
 
-use super::flow::{action_effect_fields, collect_json_strings, prompt_system_fields, refs_in_str};
+use super::flow::{action_effect_fields, collect_json_strings, refs_in_str};
 use nika_schema::types::{SecretSource, VarDecl, WhenGate};
 
 /// One model the run will call, with the tasks that call it.
@@ -126,7 +126,7 @@ fn inputs_reads_of_task(
 ) {
     // Env reads: every template-bearing string of the task surface,
     // through the REAL extractor (the same path the analyzer uses).
-    for text in task_template_fields(&task.value.action) {
+    for text in action_effect_fields(&task.value.action) {
         collect_inputs_reads(text, inputs_read);
     }
     for (_, v) in &task.value.with {
@@ -171,28 +171,6 @@ fn inputs_reads_of_task(
     // `on_finally:` cleanups carry full actions (and gates) of their own.
 }
 
-/// Every template-bearing string of one action — flow's effect fields
-/// (command · stdin · exec env · invoke args) PLUS the prompts (a config
-/// read in a prompt is as much a requirement as one in a command).
-fn task_template_fields(action: &RawAction) -> Vec<&str> {
-    let mut fields = action_effect_fields(action);
-    match action {
-        RawAction::Infer(a) => {
-            fields.extend(prompt_system_fields(&a.prompt.value, a.system.as_ref()));
-        }
-        RawAction::Agent(a) => {
-            fields.extend(prompt_system_fields(&a.prompt.value, a.system.as_ref()));
-        }
-        RawAction::Exec(_) | RawAction::Invoke(_) => {}
-        #[allow(
-            clippy::unreachable,
-            reason = "non_exhaustive future variant — enum and checker ship together; fail loud beats silently-wrong output"
-        )]
-        other => unreachable!("unknown action: {other:?}"),
-    }
-    fields
-}
-
 fn collect_inputs_reads(text: &str, out: &mut BTreeSet<String>) {
     for r in refs_in_str(text) {
         if let NamespaceRef::Inputs(name) = r
@@ -211,6 +189,18 @@ mod tests {
 
     fn wf_of(yaml: &str) -> RawWorkflow {
         parse(yaml, FileId::new(0), ParseMode::Strict).expect("fixture parses")
+    }
+
+    #[test]
+    fn prompt_and_system_inputs_are_collected_once_for_both_model_verbs() {
+        for verb in ["infer", "agent"] {
+            let wf = wf_of(&format!(
+                "nika: requirements\ntasks:\n  model:\n    {verb}:\n      \
+                 prompt: '${{{{ inputs.prompt }}}} ${{{{ inputs.shared }}}}'\n      \
+                 system: '${{{{ inputs.system }}}} ${{{{ inputs.shared }}}}'\n"
+            ));
+            assert_eq!(collect(&wf).inputs_read, ["prompt", "shared", "system"]);
+        }
     }
 
     #[test]

--- a/crates/nika-check/src/tools.rs
+++ b/crates/nika-check/src/tools.rs
@@ -27,6 +27,9 @@ use nika_schema::raw::{RawAction, RawWorkflow};
 
 use nika_types::suggest::did_you_mean;
 
+#[cfg(test)]
+mod read_tests;
+
 /// An invoke/agent tool naming a `nika:` builtin that does not exist.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 #[non_exhaustive]
@@ -121,7 +124,8 @@ pub struct UnknownArg {
     /// (`#[non_exhaustive]`).
     pub declared: Vec<String>,
     /// When the defect is a VALUE (not an unknown key) — `channel: slack`
-    /// on `nika:notify`. `None` for the undeclared-key class. Additive.
+    /// on `nika:notify`, or a wrong literal type on `nika:read`.
+    /// `None` for the undeclared-key class. Additive.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub invalid_value: Option<String>,
 }
@@ -139,6 +143,7 @@ pub(super) fn scan_unknown_args(wf: &RawWorkflow) -> Vec<UnknownArg> {
     for task in &wf.tasks {
         let id = &task.value.id.value;
         collect_args(id, &task.value.action, &mut findings);
+        collect_read_types(id, &task.value.action, &mut findings);
         collect_notify_channel(id, &task.value.action, &mut findings);
     }
     findings
@@ -177,6 +182,51 @@ fn collect_args(site: &str, action: &RawAction, out: &mut Vec<UnknownArg>) {
             invalid_value: None,
         });
     }
+}
+
+/// Read's literal argument types are decidable before any filesystem access.
+/// A whole-value binding can return a boolean; interpolation with surrounding
+/// text and containers cannot. Only the whole binding's result defers to the
+/// runtime's strict argument readers, not every value containing a template.
+fn collect_read_types(site: &str, action: &RawAction, out: &mut Vec<UnknownArg>) {
+    let RawAction::Invoke(a) = action else {
+        return;
+    };
+    if a.tool().is_none_or(|t| t.value != "nika:read") {
+        return;
+    }
+    let Some(args) = a.args.as_ref().and_then(|a| a.value.as_object()) else {
+        return;
+    };
+    for key in ["path", "binary"] {
+        let Some(value) = args.get(key) else {
+            continue; // missing path has its own finding; absent binary defaults false
+        };
+        let valid = match key {
+            "path" => value.is_string(),
+            _ => value.is_boolean() || deferred_read_boolean(value),
+        };
+        if !valid {
+            out.push(UnknownArg {
+                task: site.to_owned(),
+                tool: "nika:read".to_owned(),
+                arg: key.to_owned(),
+                suggestion: None,
+                declared: vec!["path".to_owned(), "binary".to_owned()],
+                invalid_value: Some(value.to_string()),
+            });
+        }
+    }
+}
+
+fn deferred_read_boolean(value: &serde_json::Value) -> bool {
+    let Some(text) = value.as_str().map(str::trim) else {
+        return false;
+    };
+    let Ok(islands) = nika_schema::expression::scan_templates(text) else {
+        return true; // the expression analyzer reports malformed templates
+    };
+    matches!(islands.as_slice(), [island] if island.start == 0 && island.end == text.len())
 }
 
 /// The one declared key the unknown key unambiguously abbreviates —

--- a/crates/nika-check/src/tools/read_tests.rs
+++ b/crates/nika-check/src/tools/read_tests.rs
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! Literal read types are decidable without evaluating dynamic bindings.
+
+use nika_schema::parser::{ParseMode, parse};
+use nika_schema::source::FileId;
+use serde_json::json;
+
+use super::*;
+
+fn read_findings(args: &serde_json::Value) -> Vec<UnknownArg> {
+    let yaml = format!(
+        "nika: read-contract\ntasks:\n  read:\n    invoke: {{tool: 'nika:read', args: {args}}}\n"
+    );
+    let wf = parse(&yaml, FileId::new(0), ParseMode::Strict).expect("fixture parses");
+    scan_unknown_args(&wf)
+}
+
+#[test]
+fn read_type_findings_keep_their_code_and_teaching() {
+    let yaml = "nika: read-contract\npermits: {tools: [nika:read], fs: {read: ['./data/**']}}\ntasks:\n  read:\n    invoke: {tool: 'nika:read', args: {path: 42, binary: 'true'}}\n";
+    let wf = parse(yaml, FileId::new(0), ParseMode::Strict).expect("fixture parses");
+    let report = crate::check(&wf);
+    assert!(!report.is_clean());
+    let findings: Vec<_> = report
+        .findings
+        .iter()
+        .filter(|f| f.gate == "ARGS")
+        .collect();
+    assert_eq!(findings.len(), 2);
+    assert!(
+        findings
+            .iter()
+            .all(|f| f.code.as_deref() == Some("NIKA-INVOKE-002"))
+    );
+    assert!(
+        findings
+            .iter()
+            .any(|f| f.message.contains("`path:` must be a string"))
+    );
+    assert!(
+        findings
+            .iter()
+            .any(|f| f.message.contains("`binary:` must be a boolean"))
+    );
+    assert_eq!(
+        report
+            .extra_conformance_codes()
+            .iter()
+            .filter(|c| c.to_string() == "NIKA-INVOKE-002")
+            .count(),
+        2
+    );
+    assert!(
+        crate::typed_renames(&report).is_empty(),
+        "type errors never become key renames"
+    );
+}
+
+#[test]
+fn read_rejects_nonboolean_binary_literals() {
+    for value in [
+        json!("true"),
+        json!("false"),
+        json!(1),
+        json!(null),
+        json!([]),
+        json!({}),
+    ] {
+        let findings = read_findings(&json!({"path": "file.txt", "binary": value}));
+        assert_eq!(findings.len(), 1, "{value}: {findings:?}");
+        assert_eq!(findings[0].arg, "binary");
+        assert!(findings[0].invalid_value.is_some());
+        assert!(
+            findings[0].suggestion.is_none(),
+            "a type error has no key rename"
+        );
+    }
+}
+
+#[test]
+fn read_rejects_nonstring_path_literals() {
+    for value in [json!(true), json!(12), json!(null), json!([]), json!({})] {
+        let findings = read_findings(&json!({"path": value}));
+        assert_eq!(findings.len(), 1, "{value}: {findings:?}");
+        assert_eq!(findings[0].arg, "path");
+    }
+}
+
+#[test]
+fn read_accepts_default_boolean_and_whole_value_bindings() {
+    for value in [
+        json!({"path": "file.txt"}),
+        json!({"path": "file.txt", "binary": false}),
+        json!({"path": "file.txt", "binary": true}),
+        json!({"path": "${{ with.path }}", "binary": "${{ with.binary }}"}),
+        json!({"path": "dir/${{ with.name }}", "binary": "  ${{ with.binary }}  "}),
+    ] {
+        assert!(read_findings(&value).is_empty(), "{value}");
+    }
+}
+
+#[test]
+fn read_rejects_interpolation_that_cannot_produce_a_boolean() {
+    for value in [
+        json!("prefix ${{ with.binary }}"),
+        json!("${{ with.binary }}suffix"),
+        json!("${{ with.a }}${{ with.b }}"),
+        json!(["${{ with.binary }}"]),
+        json!({"value": "${{ with.binary }}"}),
+    ] {
+        let findings = read_findings(&json!({"path": "file.txt", "binary": value}));
+        assert_eq!(findings.len(), 1, "{value}: {findings:?}");
+        assert_eq!(findings[0].arg, "binary");
+    }
+}
+
+#[test]
+fn read_unknown_keys_remain_key_errors() {
+    let findings = read_findings(&json!({"path": "file.txt", "encoding": "utf-8"}));
+    assert_eq!(findings.len(), 1);
+    assert_eq!(findings[0].arg, "encoding");
+    assert!(findings[0].invalid_value.is_none());
+}

--- a/crates/nika-check/src/walk.rs
+++ b/crates/nika-check/src/walk.rs
@@ -80,7 +80,9 @@ pub(crate) fn deeply_referenced(wf: &RawWorkflow) -> BTreeSet<String> {
 fn for_each_island_text(wf: &RawWorkflow, visit: &mut dyn FnMut(&str)) {
     for task in &wf.tasks {
         let t = &task.value;
-        visit_action(&t.action, visit);
+        for text in crate::flow::action_effect_fields(&t.action) {
+            visit(text);
+        }
         if let Some(when) = &t.when
             && let Some(expr) = when.value.as_expr()
         {
@@ -92,66 +94,13 @@ fn for_each_island_text(wf: &RawWorkflow, visit: &mut dyn FnMut(&str)) {
             visit(src);
         }
         for (_, v) in &t.with {
-            visit_json(&v.value, visit);
+            for text in crate::flow::collect_json_strings(&v.value) {
+                visit(text);
+            }
         }
     }
     for (_, decl) in &wf.outputs {
         visit(&decl.value().value);
-    }
-}
-
-fn visit_action(action: &RawAction, visit: &mut dyn FnMut(&str)) {
-    match action {
-        RawAction::Exec(a) => {
-            for fragment in a.command.text_fragments() {
-                visit(fragment);
-            }
-            if let Some(stdin) = &a.stdin {
-                visit(&stdin.value);
-            }
-            for (_, v) in &a.env {
-                visit(&v.value);
-            }
-        }
-        RawAction::Invoke(a) => {
-            if let Some(args) = &a.args {
-                visit_json(&args.value, visit);
-            }
-        }
-        RawAction::Infer(a) => {
-            visit(&a.prompt.value);
-            if let Some(system) = &a.system {
-                visit(&system.value);
-            }
-        }
-        RawAction::Agent(a) => {
-            visit(&a.prompt.value);
-            if let Some(system) = &a.system {
-                visit(&system.value);
-            }
-        }
-        #[allow(
-            clippy::unreachable,
-            reason = "non_exhaustive future variant — enum and checker ship together; fail loud beats silently-wrong output"
-        )]
-        other => unreachable!("unknown action: {other:?}"),
-    }
-}
-
-pub(crate) fn visit_json(value: &serde_json::Value, visit: &mut dyn FnMut(&str)) {
-    match value {
-        serde_json::Value::String(s) => visit(s),
-        serde_json::Value::Array(items) => {
-            for item in items {
-                visit_json(item, visit);
-            }
-        }
-        serde_json::Value::Object(map) => {
-            for item in map.values() {
-                visit_json(item, visit);
-            }
-        }
-        serde_json::Value::Null | serde_json::Value::Bool(_) | serde_json::Value::Number(_) => {}
     }
 }
 
@@ -192,4 +141,85 @@ pub fn static_read_paths(wf: &RawWorkflow) -> Vec<(String, String)> {
         }
     }
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nika_schema::parser::{ParseMode, parse};
+    use nika_schema::source::FileId;
+
+    fn workflow(task: &str) -> Result<RawWorkflow, String> {
+        parse(
+            &format!("nika: references\ntasks:\n  consumer:\n{task}\n"),
+            FileId::new(0),
+            ParseMode::Strict,
+        )
+        .map_err(|errors| format!("{errors:?}"))
+    }
+
+    #[test]
+    fn output_references_cover_every_action_text_surface() -> Result<(), String> {
+        for task in [
+            "    exec: { shell: 'echo ${{ tasks.shallow.output }} ${{ tasks.deep.output.x }}' }",
+            "    exec: { command: ['echo', '${{ tasks.shallow.output }}', '${{ tasks.deep.output.x }}'] }",
+            "    exec: { command: ['cat'], stdin: '${{ tasks.shallow.output }} ${{ tasks.deep.output.x }}' }",
+            "    exec: { command: ['echo'], env: { X: '${{ tasks.shallow.output }} ${{ tasks.deep.output.x }}' } }",
+            "    infer: { prompt: '${{ tasks.shallow.output }} ${{ tasks.deep.output.x }}' }",
+            "    infer: { prompt: 'plain', system: '${{ tasks.shallow.output }} ${{ tasks.deep.output.x }}' }",
+            "    agent: { prompt: '${{ tasks.shallow.output }} ${{ tasks.deep.output.x }}', tools: [] }",
+            "    agent: { prompt: 'plain', system: '${{ tasks.shallow.output }} ${{ tasks.deep.output.x }}', tools: [] }",
+            "    invoke: { tool: 'nika:read', args: { path: '${{ tasks.shallow.output }}', binary: '${{ tasks.deep.output.x }}' } }",
+            "    invoke: { tool: 'mcp:local/tool', args: { nested: [null, 1, true, { text: '${{ tasks.shallow.output }} ${{ tasks.deep.output.x }}' }] } }",
+            "    invoke: { workflow: './child.nika.yaml', args: { text: '${{ tasks.shallow.output }} ${{ tasks.deep.output.x }}' } }",
+        ] {
+            let wf = workflow(task)?;
+            assert_eq!(
+                consumed_outputs(&wf),
+                BTreeSet::from(["shallow".to_owned(), "deep".to_owned()]),
+                "{task}"
+            );
+            assert_eq!(
+                deeply_referenced(&wf),
+                BTreeSet::from(["deep".to_owned()]),
+                "{task}"
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn output_references_keep_workflow_surfaces_and_ignore_nonvalues() -> Result<(), String> {
+        let wf = workflow(
+            "    invoke: { tool: 'nika:log' }\n\
+             \x20   with:\n\
+             \x20     nested: [null, false, 42, { text: '${{ tasks.nested.output.value }}' }]\n\
+             \x20     '${{ tasks.key.output }}': '${{ tasks.envelope }}'\n\
+             \x20   when: '${{ tasks.gate.output.ok }}'\n\
+             \x20   for_each: { items: '${{ tasks.items.output }}' }\n\
+             outputs:\n  public: '${{ tasks.public.output }}'\n  again: '${{ tasks.nested.output.value }}'",
+        )?;
+        assert_eq!(
+            consumed_outputs(&wf),
+            ["nested", "gate", "items", "public"]
+                .map(str::to_owned)
+                .into_iter()
+                .collect()
+        );
+        assert_eq!(
+            deeply_referenced(&wf),
+            BTreeSet::from(["nested".to_owned(), "gate".to_owned()])
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn output_references_ignore_literals_and_bare_envelopes() -> Result<(), String> {
+        let wf = workflow(
+            "    invoke: { tool: 'mcp:local/tool', args: { text: 'tasks.literal.output', bare: '${{ tasks.envelope }}', empty: [], scalar: null } }",
+        )?;
+        assert!(consumed_outputs(&wf).is_empty());
+        assert!(deeply_referenced(&wf).is_empty());
+        Ok(())
+    }
 }

--- a/crates/nika-display/src/check_render.rs
+++ b/crates/nika-display/src/check_render.rs
@@ -460,6 +460,7 @@ fn arg_rows(report: &CheckReport) -> Vec<String> {
     let mut rows: Vec<String> = report
         .unknown_args
         .iter()
+        .filter(|u| !(u.tool == "nika:read" && u.invalid_value.is_some()))
         .map(|u| {
             // With a suggestion the fix is the rename; without one (a
             // wrong-name-entirely miss — `extract` for fetch's `mode`),
@@ -475,6 +476,14 @@ fn arg_rows(report: &CheckReport) -> Vec<String> {
             )
         })
         .collect();
+    // Value errors use the checker's teaching, never the unknown-key wording.
+    rows.extend(
+        report
+            .findings
+            .iter()
+            .filter(|f| f.kind == "unknown_arg" && f.code.as_deref() == Some("NIKA-INVOKE-002"))
+            .map(|f| format!("[NIKA-INVOKE-002] {}", f.message)),
+    );
     rows.extend(report.missing_args.iter().map(|m| {
         format!(
             "[{BUILTIN_CONTRACT}] `{}` (task `{}`) is missing required `{}`",

--- a/crates/nika-display/src/check_render/tests.rs
+++ b/crates/nika-display/src/check_render/tests.rs
@@ -1,3 +1,30 @@
+#[test]
+fn read_argument_types_are_not_rendered_as_unknown_keys() {
+    use nika_schema::{FileId, ParseMode, parse};
+    let yaml = "nika: read-contract\ntasks:\n  read:\n    invoke: {tool: 'nika:read', args: {path: 42, binary: 'true', encoding: 'utf-8'}}\n";
+    let wf = parse(yaml, FileId::new(0), ParseMode::Strict).expect("fixture parses");
+    let report = nika_check::check(&wf);
+    let rows = super::arg_rows(&report);
+    assert_eq!(rows.len(), 3);
+    assert!(
+        rows.iter()
+            .any(|r| r.contains("`path:` must be a string") && r.contains("NIKA-INVOKE-002"))
+    );
+    assert!(
+        rows.iter()
+            .any(|r| r.contains("`binary:` must be a boolean") && r.contains("NIKA-INVOKE-002"))
+    );
+    assert!(
+        rows.iter()
+            .any(|r| r.contains("has no `encoding` arg") && r.contains("NIKA-BUILTIN-001"))
+    );
+    assert!(
+        !rows
+            .iter()
+            .any(|r| r.contains("has no `path`") || r.contains("has no `binary`"))
+    );
+}
+
 mod trifecta_rung_tests {
     use nika_schema::parser::{ParseMode, parse};
     use nika_schema::source::FileId;

--- a/crates/nika-lsp/src/analysis/diagnostics.rs
+++ b/crates/nika-lsp/src/analysis/diagnostics.rs
@@ -116,6 +116,9 @@ fn push_tool_findings(
         ));
     }
     for a in &report.unknown_args {
+        if a.tool == "nika:read" && a.invalid_value.is_some() {
+            continue; // the unified value diagnostic below owns this finding
+        }
         let mut msg = format!(
             "tool `{}` (task `{}`) has no arg `{}`",
             a.tool, a.task, a.arg
@@ -132,6 +135,15 @@ fn push_tool_findings(
             None,
             msg,
         ));
+    }
+    for f in &report.findings {
+        if f.kind == "unknown_arg" && f.code.as_deref() == Some("NIKA-INVOKE-002") {
+            diags.push(error_diag(
+                task_range(index, task_spans, f.task.as_deref().unwrap_or_default()),
+                f.code.clone(),
+                f.message.clone(),
+            ));
+        }
     }
     for m in &report.missing_args {
         let msg = format!(
@@ -318,6 +330,38 @@ mod tests {
             Ok(wf) => from_report(&index, &check(&wf), &wf),
             Err(err) => vec![from_parse_error(&index, &err)],
         }
+    }
+
+    #[test]
+    fn read_type_errors_keep_the_checker_message_code_and_task_span() {
+        let yaml = "nika: read-contract\npermits: {tools: [nika:read], fs: {read: ['./data/**']}}\ntasks:\n  read:\n    invoke: {tool: 'nika:read', args: {path: 42, binary: 'true', encoding: 'utf-8'}}\n";
+        let wf = parse(yaml, FileId::new(0), ParseMode::Strict).expect("fixture parses");
+        let report = check(&wf);
+        let diags = diags_of(yaml);
+        let typed: Vec<_> = diags
+            .iter()
+            .filter(|d| {
+                matches!(&d.code,
+            Some(NumberOrString::String(c)) if c == "NIKA-INVOKE-002")
+            })
+            .collect();
+        assert_eq!(typed.len(), 2);
+        for diag in typed {
+            assert_eq!(diag.range.start.line, 3);
+            assert!(report.findings.iter().any(|f| f.message == diag.message));
+        }
+        assert_eq!(
+            diags
+                .iter()
+                .filter(|d| d.message.contains("has no arg"))
+                .count(),
+            1
+        );
+        assert!(
+            diags
+                .iter()
+                .any(|d| d.message.contains("has no arg `encoding`"))
+        );
     }
 
     #[test]

--- a/crates/nika-providers/src/wire/anthropic.rs
+++ b/crates/nika-providers/src/wire/anthropic.rs
@@ -495,6 +495,7 @@ fn map_stop(raw: Option<&str>) -> StopReason {
         Some("max_tokens") => StopReason::MaxTokens,
         Some("stop_sequence") => StopReason::StopSequence,
         Some("tool_use") => StopReason::ToolUse,
+        Some("refusal") => StopReason::ContentFilter,
         Some(other) => StopReason::Unknown(other.to_owned()),
         None => StopReason::Unknown("missing-stop-reason".to_owned()),
     }

--- a/crates/nika-providers/src/wire/mod.rs
+++ b/crates/nika-providers/src/wire/mod.rs
@@ -15,6 +15,8 @@ pub(crate) mod openai_compat;
 #[cfg(test)]
 mod openai_compat_usage_tests;
 mod openai_schema;
+#[cfg(test)]
+mod refusal_tests;
 
 use std::collections::VecDeque;
 use std::pin::Pin;

--- a/crates/nika-providers/src/wire/openai_compat.rs
+++ b/crates/nika-providers/src/wire/openai_compat.rs
@@ -384,6 +384,14 @@ fn parse_response(
         .pointer("/choices/0/finish_reason")
         .and_then(Value::as_str);
     let mut resp = InferResponse::new(content, usage, map_finish(raw_finish));
+    // Keep the billed response intact; verbs stop before consuming its output.
+    if msg
+        .and_then(|m| m.get("refusal"))
+        .and_then(Value::as_str)
+        .is_some_and(|refusal| !refusal.is_empty())
+    {
+        resp.stop_reason = StopReason::ContentFilter;
+    }
     // The budget law (R3-F1): an omitting backend gets an UNREPORTED
     // mark, not a fabricated zero the budgets would trust — and an EMPTY
     // usage object carries no signal, same class as the omission.

--- a/crates/nika-providers/src/wire/refusal_tests.rs
+++ b/crates/nika-providers/src/wire/refusal_tests.rs
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+use crate::test_support::{FakeHttp, resolved_with};
+use nika_kernel::ai::provider::{ContentBlock, InferRequest, ProviderInferDyn, StopReason};
+use serde_json::{Value, json};
+
+#[tokio::test]
+async fn openai_refusal_overrides_finish_but_preserves_content_usage_and_raw() {
+    for finish in ["stop", "length", "tool_calls"] {
+        for refusal in [
+            None,
+            Some(Value::Null),
+            Some(json!("")),
+            Some(json!("refused")),
+        ] {
+            let explicit = refusal.as_ref().and_then(Value::as_str) == Some("refused");
+            let mut body = json!({
+                "id":"req-refusal", "model":"gpt-4o-mini",
+                "choices":[{"message":{"content":"{\"value\":7}","tool_calls":[{
+                    "id":"c", "function":{"name":"read","arguments":"{}"}
+                }]},"finish_reason":finish}],
+                "usage":{"prompt_tokens":81,"completion_tokens":11,
+                    "prompt_tokens_details":{"cached_tokens":9},
+                    "completion_tokens_details":{"reasoning_tokens":4}}
+            });
+            if let Some(refusal) = refusal {
+                body["choices"][0]["message"]["refusal"] = refusal;
+            }
+            let http = FakeHttp::with_json(200, &body.to_string());
+            let response = resolved_with(&http, "openai", "test-key")
+                .infer(InferRequest::new("gpt-4o-mini", vec![]))
+                .await
+                .expect("successful HTTP response retains billing metadata");
+            let expected = if explicit {
+                StopReason::ContentFilter
+            } else {
+                match finish {
+                    "length" => StopReason::MaxTokens,
+                    "tool_calls" => StopReason::ToolUse,
+                    _ => StopReason::EndTurn,
+                }
+            };
+            assert_eq!(response.stop_reason, expected);
+            assert_eq!(response.finish_reason_raw.as_deref(), Some(finish));
+            assert!(matches!(response.content[0], ContentBlock::Text { .. }));
+            assert!(matches!(response.content[1], ContentBlock::ToolUse { .. }));
+            assert_eq!(response.usage.input_tokens, 81);
+            assert_eq!(response.usage.output_tokens, 11);
+            assert_eq!(response.usage.cache_read_tokens, Some(9));
+            assert_eq!(response.usage.reasoning_tokens, Some(4));
+            assert!(response.usage_reported);
+            assert_eq!(response.request_id.as_deref(), Some("req-refusal"));
+            assert_eq!(http.captured().len(), 1);
+        }
+    }
+}
+
+#[tokio::test]
+async fn anthropic_refusal_preserves_cache_usage_and_raw() {
+    for stop in ["refusal", "end_turn", "future_stop"] {
+        let body = json!({
+            "id":"req-refusal", "model":"claude-haiku-4-5",
+            "content":[{"type":"text","text":"refusal-like text"}],
+            "stop_reason":stop,
+            "usage":{"input_tokens":69,"output_tokens":11,
+                "cache_read_input_tokens":9,"cache_creation_input_tokens":3}
+        });
+        let http = FakeHttp::with_json(200, &body.to_string());
+        let response = resolved_with(&http, "anthropic", "test-key")
+            .infer(InferRequest::new("claude-haiku-4-5", vec![]))
+            .await
+            .expect("successful HTTP response retains billing metadata");
+        assert_eq!(
+            response.stop_reason,
+            match stop {
+                "refusal" => StopReason::ContentFilter,
+                "end_turn" => StopReason::EndTurn,
+                _ => StopReason::Unknown(stop.into()),
+            }
+        );
+        assert_eq!(response.finish_reason_raw.as_deref(), Some(stop));
+        assert_eq!(response.usage.input_tokens, 81);
+        assert_eq!(response.usage.output_tokens, 11);
+        assert_eq!(response.usage.cache_read_tokens, Some(9));
+        assert_eq!(response.usage.cache_creation_tokens, Some(3));
+        assert_eq!(http.captured().len(), 1);
+    }
+}

--- a/crates/nika-verb-agent/src/harness_path.rs
+++ b/crates/nika-verb-agent/src/harness_path.rs
@@ -416,6 +416,49 @@ mod tests {
         }
     }
 
+    #[tokio::test]
+    async fn the_one_door_native_choice_keeps_typed_repairs_on_the_provider() {
+        use crate::tests::{rig, text_response};
+        use nika_kernel_mock::{MockProvider, MockToolExecutor};
+
+        let r = rig(
+            MockProvider::new("mock")
+                .enqueue_response(text_response("unfinished"))
+                .enqueue_response(text_response(r#"{"score":7}"#)),
+            MockToolExecutor::new(),
+            Vec::new(),
+        );
+        let backend = Arc::new(TapeBackend {
+            tape: Mutex::new(vec![completed("harness answer")]),
+        });
+        let verb = r
+            .verb
+            .with_harness_seat(HarnessSeat::new(backend.clone(), "/tmp"));
+        let mut input = AgentInput::new("return a score");
+        input.native_only = true;
+        input.max_tokens_total = Some(15);
+        input.schema = Some(serde_json::json!({"type":"object"}));
+        let err = verb.run(input).await.expect_err("native token budget");
+        assert!(matches!(
+            err,
+            VerbAgentError::MaxTokens {
+                total_tokens: 15,
+                ..
+            }
+        ));
+        assert_eq!(r.provider.captured_requests().len(), 1);
+        assert_eq!(backend.tape.lock().unwrap().len(), 1, "seat unused");
+
+        // Negative control: an unpinned untyped task uses that same seat.
+        let out = verb
+            .run(AgentInput::new("finish"))
+            .await
+            .expect("seat runs");
+        assert_eq!(out.output, AgentValue::Text("harness answer".to_owned()));
+        assert!(backend.tape.lock().unwrap().is_empty());
+        assert_eq!(r.provider.captured_requests().len(), 1);
+    }
+
     /// A permission ask event whose reply closure records the verdict.
     fn ask(
         question: &str,

--- a/crates/nika-verb-agent/src/intrinsic.rs
+++ b/crates/nika-verb-agent/src/intrinsic.rs
@@ -85,7 +85,7 @@ pub(crate) fn synthesized_defs(
 /// The synthesized `nika:done` sentinel definition (loop-owned).
 ///
 /// Under a TYPED task the `result` parameter carries the declared
-/// `schema:` (its `$defs` hoisted to the wrapper root — see
+/// `schema:` (its `$defs` kept at the resource root — see
 /// [`typed_done_parameters`]) — the sentinel's own parameter schema IS
 /// how the contract reaches the seat, on the FIRST request and every one
 /// after.
@@ -127,25 +127,32 @@ fn done_def(schema: Option<&serde_json::Value>) -> ToolDef {
 }
 
 /// The typed sentinel's parameter schema: the declared `schema:` nested
-/// under `result`, with its `$defs`/`definitions` HOISTED to the wrapper's
-/// root. An internal JSON pointer (`"$ref": "#/$defs/row"`) resolves
-/// against the DOCUMENT root, and on the wire that root is this wrapper —
-/// nested verbatim, the pointer lands on nothing and a seat that validates
-/// its tool input reads a dangling ref. A `$schema` keyword is dropped (it
-/// has no place inside a tool input); everything else stays where the
-/// author wrote it, and local validation is untouched (it runs against the
-/// declared schema at its own root). A schema with nothing to hoist
-/// renders exactly as before. Only `$defs`/`definitions` pointers are
-/// rescued: a `"$ref": "#"` or a `#/properties/…` pointer still names
-/// the wrapper on the wire (the author's root is `properties.result`).
+/// under `result`. A non-fragment `$id` identifies a resource rooted at
+/// `result`: keep its `$defs`/`definitions` there so local pointers and
+/// relative resource IDs retain their base. Hoisting those definitions
+/// would leave `"$ref": "#/$defs/row"` dangling inside that resource.
+///
+/// Without such an ID (including empty or fragment-only IDs), retain the
+/// existing hoist to the wrapper root, where local definition pointers
+/// resolve. On that path only `$defs`/`definitions` pointers are rescued:
+/// `"$ref": "#"` and `#/properties/…` still name the wrapper on the wire.
+/// The existing `$schema` removal is unchanged; this is not a dialect
+/// translation. References are never rewritten, and local final-output
+/// validation still runs against the original declared schema.
 fn typed_done_parameters(schema: &serde_json::Value) -> serde_json::Value {
     let mut nested = schema.clone();
     let mut hoisted = serde_json::Map::new();
     if let Some(declared) = nested.as_object_mut() {
         declared.remove("$schema");
-        for key in ["$defs", "definitions"] {
-            if let Some(defs) = declared.remove(key) {
-                hoisted.insert(key.to_owned(), defs);
+        let has_resource_id = declared
+            .get("$id")
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|id| !id.is_empty() && !id.starts_with('#'));
+        if !has_resource_id {
+            for key in ["$defs", "definitions"] {
+                if let Some(defs) = declared.remove(key) {
+                    hoisted.insert(key.to_owned(), defs);
+                }
             }
         }
     }

--- a/crates/nika-verb-agent/src/lib.rs
+++ b/crates/nika-verb-agent/src/lib.rs
@@ -718,10 +718,9 @@ where
             Err(detail) => detail,
         };
 
-        // The answer is prose · append it and re-ask WITH the schema wired.
-        // The cumulative token budget gates the TOOL loop (classify_turn);
-        // the final shaping is bounded by schema_retry_budget instead — a
-        // concluded answer is a success even over budget (spec §2 terminal).
+        // The answer does not conform yet. Each repair spends a provider
+        // request, so BOTH the repair allowance and token budget govern it.
+        // An already valid answer returned above keeps terminal precedence.
         //
         // STRIP any tool-call blocks from the final turn first: a result-less
         // `nika:done` (or any terminal tool call) rides `final_response.content`
@@ -740,7 +739,11 @@ where
             st.messages.push(Message::new(Role::Assistant, final_prose));
         }
         let native = self.provider.supports_response_format();
+        // The done-result candidate can differ from the assistant's words.
+        // Budget errors preserve those words, then each re-ask's latest text.
+        let mut partial_output = st.last_text.clone();
         while st.repairs < self.schema_retry_budget {
+            turn::token_budget_gate(input.max_tokens_total, st.total_tokens, &partial_output)?;
             st.repairs = st.repairs.saturating_add(1);
             st.messages.push(Message::text(
                 Role::User,
@@ -764,6 +767,7 @@ where
                 }
                 Err(d) => {
                     detail = d;
+                    partial_output = text;
                     st.messages
                         .push(Message::new(Role::Assistant, response.content));
                 }
@@ -1361,7 +1365,11 @@ fn classify_turn(
                 // A repair is one more provider request: the token budget
                 // gates it exactly like a dispatch (a met budget ends the
                 // run on the budget verdict, never a silent overrun).
-                token_budget_gate(ctx)?;
+                turn::token_budget_gate(
+                    ctx.input.max_tokens_total,
+                    ctx.total_tokens,
+                    ctx.last_text,
+                )?;
                 Ok(TurnVerdict::RepairDone(DoneRepair {
                     tool_use_id: done.id.clone(),
                     detail,
@@ -1372,26 +1380,9 @@ fn classify_turn(
 
     // The loop WILL iterate to feed tool results back · enforce the token
     // budget NOW (spec §2 case 3 · `>=` exhausted · before spending more).
-    token_budget_gate(ctx)?;
+    turn::token_budget_gate(ctx.input.max_tokens_total, ctx.total_tokens, ctx.last_text)?;
 
     Ok(TurnVerdict::Dispatch(tool_uses))
-}
-
-/// The token gate (spec §2 case 3 · `>=` exhausted): the loop is about
-/// to ask the provider again — to feed a tool batch back or to repair a
-/// `nika:done` result — and a budget already met stops it BEFORE that
-/// request. Both iterating verdicts pass here, so neither can overrun.
-fn token_budget_gate(ctx: &TurnCtx<'_>) -> Result<(), VerbAgentError> {
-    if let Some(budget) = ctx.input.max_tokens_total
-        && ctx.total_tokens >= budget
-    {
-        return Err(VerbAgentError::MaxTokens {
-            total_tokens: ctx.total_tokens,
-            partial_output: ctx.last_text.to_owned(),
-            spend: Box::default(), // decorated at the return seam
-        });
-    }
-    Ok(())
 }
 
 /// Route a free-text final answer: a no-schema task closes immediately
@@ -1487,6 +1478,8 @@ fn is_clean_tool_name(name: &str) -> bool {
 
 #[cfg(test)]
 mod tests;
+#[cfg(test)]
+mod tests_budgets;
 #[cfg(test)]
 mod tests_schema;
 #[cfg(test)]

--- a/crates/nika-verb-agent/src/lib.rs
+++ b/crates/nika-verb-agent/src/lib.rs
@@ -739,9 +739,9 @@ where
             st.messages.push(Message::new(Role::Assistant, final_prose));
         }
         let native = self.provider.supports_response_format();
-        // The done-result candidate can differ from the assistant's words.
-        // Budget errors preserve those words, then each re-ask's latest text.
-        let mut partial_output = st.last_text.clone();
+        // The done-result candidate and routing fallback can differ from this
+        // terminal message. Preserve its text, including an empty message.
+        let mut partial_output = joined_text(&final_response.content);
         while st.repairs < self.schema_retry_budget {
             turn::token_budget_gate(input.max_tokens_total, st.total_tokens, &partial_output)?;
             st.repairs = st.repairs.saturating_add(1);

--- a/crates/nika-verb-agent/src/lib.rs
+++ b/crates/nika-verb-agent/src/lib.rs
@@ -117,8 +117,8 @@ mod turn;
 use std::sync::Arc;
 
 use nika_kernel::ai::provider::{
-    ContentBlock, InferRequest, InferResponse, Message, ProviderInferDyn, ProviderMeta, Role,
-    TokenUsage, ToolDef,
+    ContentBlock, InferRequest, InferResponse, Message, ProviderError, ProviderInferDyn,
+    ProviderMeta, Role, StopReason, TokenUsage, ToolDef,
 };
 use nika_kernel::ai::tool_defs::ToolDefinitionProviderDyn;
 use nika_kernel::blob::BlobStoreDyn;
@@ -616,7 +616,7 @@ where
     }
 
     /// One provider call: infer, fold its usage into the running total,
-    /// and report the budget checkpoint. Maps a provider failure to 463.
+    /// report its budget checkpoint, then stop on refusal (NIKA-463).
     async fn infer_turn(
         &self,
         observer: &dyn AgentObserver,
@@ -662,6 +662,16 @@ where
             total_tokens: *total_tokens,
             budget: input.max_tokens_total,
         });
+        if matches!(response.stop_reason, StopReason::ContentFilter)
+            || response.finish_reason_raw.as_deref() == Some("refusal")
+        {
+            return Err(VerbAgentError::Inference {
+                source: ProviderError::Other {
+                    reason: "provider explicitly refused the response".to_owned(),
+                },
+                spend: Box::default(),
+            });
+        }
         Ok(response)
     }
 
@@ -1480,6 +1490,8 @@ fn is_clean_tool_name(name: &str) -> bool {
 mod tests;
 #[cfg(test)]
 mod tests_budgets;
+#[cfg(test)]
+mod tests_refusal;
 #[cfg(test)]
 mod tests_schema;
 #[cfg(test)]

--- a/crates/nika-verb-agent/src/tests_budgets.rs
+++ b/crates/nika-verb-agent/src/tests_budgets.rs
@@ -227,6 +227,55 @@ async fn mixed_done_budget_error_preserves_latest_assistant_text() {
 }
 
 #[tokio::test]
+async fn empty_natural_final_after_done_repair_does_not_revive_old_text() {
+    for budget in [26, 25] {
+        let mut first = tool_use_response(
+            "bad",
+            DONE_TOOL,
+            serde_json::json!({"result":{"score":false}}),
+        );
+        first.content[0] = ContentBlock::Text {
+            text: "obsolete first attempt".to_owned(),
+        };
+        let r = rig(
+            MockProvider::new("mock")
+                .enqueue_response(metered(first, 9, 4))
+                .enqueue_response(metered(text_response(""), 9, 4))
+                .enqueue_response(text_response(r#"{"score":9}"#)),
+            MockToolExecutor::new(),
+            Vec::new(),
+        );
+        let mut input = typed_input(budget);
+        input.timeout = Some(Duration::from_secs(317));
+        let events = Recording::default();
+        let err = r
+            .verb
+            .run_observed(input, &events)
+            .await
+            .expect_err("the empty final answer still needs a repair");
+        let reqs = r.provider.captured_requests();
+        assert_eq!(reqs.len(), 2, "no third request after spending 26 tokens");
+        assert!(
+            reqs.iter()
+                .all(|q| q.timeout == Some(Duration::from_secs(317)))
+        );
+        assert_token_stop(&err, 26, 18, 8);
+        assert_eq!(events.checkpoints(), [(1, 13), (2, 26)]);
+        assert!(events.finished().is_empty());
+        assert!(r.tools.captured_calls().is_empty());
+        let partial_output = match err {
+            VerbAgentError::MaxTokens { partial_output, .. } => Some(partial_output),
+            _ => None,
+        };
+        assert_eq!(
+            partial_output.as_deref(),
+            Some(""),
+            "preserve the current empty message, not the older routing text"
+        );
+    }
+}
+
+#[tokio::test]
 async fn successive_reasks_replace_the_budget_error_text() {
     for latest in ["the newest partial answer", ""] {
         let r = rig(

--- a/crates/nika-verb-agent/src/tests_budgets.rs
+++ b/crates/nika-verb-agent/src/tests_budgets.rs
@@ -1,0 +1,487 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! Cumulative budgets on typed final answers. Scripts fix the spend and
+//! capture the requests independently of the loop's counters: an invalid
+//! answer still needs work, while an already valid conclusion must win.
+
+use std::sync::Mutex;
+use std::time::Duration;
+
+use super::*;
+use crate::tests::{def, rig, text_response, tool_use_response, usage};
+use nika_error::traits::NikaErrorCode;
+use nika_kernel::ai::provider::ProviderError;
+use nika_kernel::runtime::tool_executor::ToolResult;
+use nika_kernel_mock::{MockProvider, MockToolExecutor};
+
+#[derive(Default)]
+struct Recording(Mutex<Vec<AgentEvent>>);
+
+impl AgentObserver for Recording {
+    fn on_event(&self, event: &AgentEvent) {
+        self.0.lock().unwrap().push(event.clone());
+    }
+}
+
+impl Recording {
+    fn checkpoints(&self) -> Vec<(u32, u64)> {
+        self.0
+            .lock()
+            .unwrap()
+            .iter()
+            .filter_map(|event| match event {
+                AgentEvent::BudgetCheckpoint {
+                    turn, total_tokens, ..
+                } => Some((*turn, *total_tokens)),
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn finished(&self) -> Vec<(u32, u64)> {
+        self.0
+            .lock()
+            .unwrap()
+            .iter()
+            .filter_map(|event| match event {
+                AgentEvent::Finished {
+                    turns,
+                    total_tokens,
+                } => Some((*turns, *total_tokens)),
+                _ => None,
+            })
+            .collect()
+    }
+}
+
+fn typed_input(budget: u64) -> AgentInput {
+    let mut input = AgentInput::new("return the integer score");
+    input.schema = Some(serde_json::json!({
+        "type": "object",
+        "properties": {"score": {"type": "integer"}},
+        "required": ["score"],
+        "additionalProperties": false
+    }));
+    input.max_tokens_total = Some(budget);
+    input.tools = vec![DONE_TOOL.to_owned()];
+    input.timeout = Some(Duration::from_secs(43));
+    input
+}
+
+fn metered(mut response: InferResponse, input: u64, output: u64) -> InferResponse {
+    response.usage = usage(input, output);
+    response
+}
+
+fn assert_token_stop(err: &VerbAgentError, tokens: u64, input: u64, output: u64) {
+    assert!(
+        matches!(err, VerbAgentError::MaxTokens { total_tokens, .. } if *total_tokens == tokens),
+        "expected token stop at {tokens}, got {err:?}"
+    );
+    assert_eq!(err.nika_code().num, 461);
+    assert_eq!(err.spec_code(), "NIKA-AGENT-002");
+    let spend = err.spend().expect("all observed response usage survives");
+    assert_eq!(spend.usage.input_tokens, input);
+    assert_eq!(spend.usage.output_tokens, output);
+    assert_eq!(spend.model_resolved.as_deref(), Some("mock/agent"));
+}
+
+async fn exhausted_final_text_never_reasks(first: InferResponse) {
+    // The first answer spends 11+6=17. Exact, exceeded and zero
+    // ceilings all forbid an additional request for an invalid answer.
+    for budget in [17, 16, 0] {
+        let r = rig(
+            MockProvider::new("mock")
+                .enqueue_response(metered(first.clone(), 11, 6))
+                .enqueue_response(text_response(r#"{"score":7}"#)),
+            MockToolExecutor::new(),
+            Vec::new(),
+        );
+        let events = Recording::default();
+        let result = r.verb.run_observed(typed_input(budget), &events).await;
+        assert_eq!(
+            r.provider.captured_requests().len(),
+            1,
+            "budget {budget}: an invalid typed answer cannot buy a repair"
+        );
+        assert_token_stop(&result.expect_err("no typed conclusion"), 17, 11, 6);
+        assert!(r.tools.captured_calls().is_empty());
+        assert_eq!(events.checkpoints(), [(1, 17)]);
+        assert!(events.finished().is_empty());
+    }
+}
+
+#[tokio::test]
+async fn exhausted_natural_text_never_reasks() {
+    exhausted_final_text_never_reasks(text_response("score is seven")).await;
+}
+
+#[tokio::test]
+async fn exhausted_resultless_done_never_reasks() {
+    exhausted_final_text_never_reasks(tool_use_response("done", DONE_TOOL, serde_json::json!({})))
+        .await;
+}
+
+#[tokio::test]
+async fn exhausted_string_done_never_reasks() {
+    exhausted_final_text_never_reasks(tool_use_response(
+        "done",
+        DONE_TOOL,
+        serde_json::json!({"result": "score is seven"}),
+    ))
+    .await;
+}
+
+#[tokio::test]
+async fn exhausted_null_done_never_reasks() {
+    exhausted_final_text_never_reasks(tool_use_response(
+        "done",
+        DONE_TOOL,
+        serde_json::json!({"result": null}),
+    ))
+    .await;
+}
+
+async fn assert_done_partial_text(result: serde_json::Value, mixed: bool) {
+    let expected = "collected eight rows; the ninth needs validation";
+    let mut done = tool_use_response("done", DONE_TOOL, serde_json::json!({"result": result}));
+    done.content[0] = ContentBlock::Text {
+        text: expected.to_owned(),
+    };
+    let mut provider = MockProvider::new("mock");
+    if mixed {
+        provider = provider.enqueue_response(metered(
+            tool_use_response(
+                "bad",
+                DONE_TOOL,
+                serde_json::json!({"result":{"score":false}}),
+            ),
+            11,
+            6,
+        ));
+    }
+    let (input_tokens, output_tokens, total, calls) = if mixed {
+        (13, 10, 40, 2)
+    } else {
+        (11, 6, 17, 1)
+    };
+    let r = rig(
+        provider
+            .enqueue_response(metered(done, input_tokens, output_tokens))
+            .enqueue_response(text_response(r#"{"score":7}"#)),
+        MockToolExecutor::new(),
+        Vec::new(),
+    );
+    let events = Recording::default();
+    let err = r
+        .verb
+        .run_observed(typed_input(total), &events)
+        .await
+        .expect_err("the budget forbids another request");
+    let reqs = r.provider.captured_requests();
+    assert_eq!(reqs.len(), calls);
+    assert!(
+        reqs.iter()
+            .all(|q| q.timeout == Some(Duration::from_secs(43)))
+    );
+    let (spent_input, spent_output) = if mixed { (24, 16) } else { (11, 6) };
+    assert_token_stop(&err, total, spent_input, spent_output);
+    let checkpoints = if mixed {
+        vec![(1, 17), (2, 40)]
+    } else {
+        vec![(1, 17)]
+    };
+    assert_eq!(events.checkpoints(), checkpoints);
+    assert!(events.finished().is_empty());
+    assert!(r.tools.captured_calls().is_empty());
+    let partial_output = match err {
+        VerbAgentError::MaxTokens { partial_output, .. } => Some(partial_output),
+        _ => None,
+    };
+    assert_eq!(
+        partial_output.as_deref(),
+        Some(expected),
+        "preserve prose, not the done candidate"
+    );
+}
+
+#[tokio::test]
+async fn null_done_budget_error_preserves_assistant_text() {
+    assert_done_partial_text(serde_json::Value::Null, false).await;
+}
+
+#[tokio::test]
+async fn string_done_budget_error_preserves_assistant_text() {
+    assert_done_partial_text(serde_json::json!("unusable result string"), false).await;
+}
+
+#[tokio::test]
+async fn mixed_done_budget_error_preserves_latest_assistant_text() {
+    for result in [
+        serde_json::Value::Null,
+        serde_json::json!("unusable result string"),
+    ] {
+        assert_done_partial_text(result, true).await;
+    }
+}
+
+#[tokio::test]
+async fn successive_reasks_replace_the_budget_error_text() {
+    for latest in ["the newest partial answer", ""] {
+        let r = rig(
+            MockProvider::new("mock")
+                .enqueue_response(metered(
+                    tool_use_response("done", DONE_TOOL, serde_json::json!({"result": null})),
+                    11,
+                    6,
+                ))
+                .enqueue_response(metered(text_response("first reask prose"), 13, 10))
+                .enqueue_response(metered(text_response(latest), 19, 12))
+                .enqueue_response(text_response(r#"{"score":7}"#)),
+            MockToolExecutor::new(),
+            Vec::new(),
+        );
+        let events = Recording::default();
+        let err = r
+            .verb
+            .with_schema_retry_budget(3)
+            .run_observed(typed_input(71), &events)
+            .await
+            .expect_err("no fourth call");
+        assert_token_stop(&err, 71, 43, 28);
+        let reqs = r.provider.captured_requests();
+        assert_eq!(reqs.len(), 3);
+        assert!(reqs[1..].iter().all(|q| q.tools.is_empty()));
+        assert!(
+            reqs.iter()
+                .all(|q| q.timeout == Some(Duration::from_secs(43)))
+        );
+        assert_eq!(events.checkpoints(), [(1, 17), (1, 40), (1, 71)]);
+        assert!(events.finished().is_empty());
+        assert!(r.tools.captured_calls().is_empty());
+        assert!(
+            matches!(err, VerbAgentError::MaxTokens { partial_output, .. } if partial_output == latest)
+        );
+    }
+}
+
+#[tokio::test]
+async fn every_text_repair_checks_the_accumulated_usage() {
+    // 17 initially + 23 on the first repair = 40. The queued valid
+    // answer is a trap: it must never be requested at the boundary.
+    let r = rig(
+        MockProvider::new("mock")
+            .enqueue_response(metered(text_response("initial prose"), 11, 6))
+            .enqueue_response(metered(text_response("still prose"), 13, 10))
+            .enqueue_response(text_response(r#"{"score":7}"#)),
+        MockToolExecutor::new(),
+        Vec::new(),
+    );
+    let events = Recording::default();
+    let result = r.verb.run_observed(typed_input(40), &events).await;
+    assert_eq!(r.provider.captured_requests().len(), 2);
+    let err = result.expect_err("no third request at the cumulative ceiling");
+    assert_token_stop(&err, 40, 24, 16);
+    assert!(
+        matches!(err, VerbAgentError::MaxTokens { partial_output, .. } if partial_output == "still prose")
+    );
+    assert_eq!(events.checkpoints(), [(1, 17), (1, 40)]);
+    assert!(events.finished().is_empty());
+    assert!(r.tools.captured_calls().is_empty());
+}
+
+#[tokio::test]
+async fn done_then_text_repairs_share_the_cumulative_token_ceiling() {
+    let r = rig(
+        MockProvider::new("mock")
+            .enqueue_response(metered(
+                tool_use_response(
+                    "bad",
+                    DONE_TOOL,
+                    serde_json::json!({"result":{"score":"bad"}}),
+                ),
+                11,
+                6,
+            ))
+            .enqueue_response(metered(text_response("unfinished prose"), 13, 10))
+            .enqueue_response(text_response(r#"{"score":7}"#)),
+        MockToolExecutor::new(),
+        Vec::new(),
+    );
+    let events = Recording::default();
+    let result = r.verb.run_observed(typed_input(40), &events).await;
+    assert_eq!(r.provider.captured_requests().len(), 2);
+    assert_token_stop(
+        &result.expect_err("no text repair after done spent the budget"),
+        40,
+        24,
+        16,
+    );
+    assert_eq!(events.checkpoints(), [(1, 17), (2, 40)]);
+    assert!(events.finished().is_empty());
+    assert!(r.tools.captured_calls().is_empty());
+}
+
+#[tokio::test]
+async fn a_valid_typed_conclusion_wins_at_or_above_both_budgets() {
+    let expected = serde_json::json!({"score": 7});
+    for first in [
+        text_response(r#"{"score":7}"#),
+        tool_use_response("done", DONE_TOOL, serde_json::json!({"result": expected})),
+        tool_use_response(
+            "done",
+            DONE_TOOL,
+            serde_json::json!({"result": r#"{"score":7}"#}),
+        ),
+    ] {
+        for budget in [17, 16, 0] {
+            let r = rig(
+                MockProvider::new("mock").enqueue_response(metered(first.clone(), 11, 6)),
+                MockToolExecutor::new(),
+                Vec::new(),
+            );
+            let events = Recording::default();
+            let mut input = typed_input(budget);
+            input.max_turns = Some(1);
+            let out = r
+                .verb
+                .run_observed(input, &events)
+                .await
+                .expect("valid conclusion wins");
+            assert_eq!(out.output, AgentValue::Structured(expected.clone()));
+            assert_eq!((out.turns, out.total_tokens), (1, 17));
+            assert_eq!((out.usage.input_tokens, out.usage.output_tokens), (11, 6));
+            assert_eq!(r.provider.captured_requests().len(), 1);
+            assert_eq!(events.finished(), [(1, 17)]);
+        }
+    }
+}
+
+#[tokio::test]
+async fn a_text_repair_below_budget_can_complete_over_budget() {
+    let r = rig(
+        MockProvider::new("mock")
+            .with_response_format_support(true)
+            .enqueue_response(metered(text_response("prose"), 11, 6))
+            .enqueue_response(metered(text_response(r#"{"score":7}"#), 13, 10)),
+        MockToolExecutor::new(),
+        Vec::new(),
+    );
+    let events = Recording::default();
+    let out = r
+        .verb
+        .run_observed(typed_input(18), &events)
+        .await
+        .expect("one token left allows repair");
+    assert_eq!(
+        out.output,
+        AgentValue::Structured(serde_json::json!({"score":7}))
+    );
+    assert_eq!(out.total_tokens, 40);
+    assert_eq!((out.usage.input_tokens, out.usage.output_tokens), (24, 16));
+    let reqs = r.provider.captured_requests();
+    assert_eq!(reqs.len(), 2);
+    assert!(reqs[1].tools.is_empty());
+    assert!(matches!(
+        reqs[1].response_format,
+        nika_kernel::ai::provider::ResponseFormat::JsonSchema(_)
+    ));
+    assert!(
+        reqs.iter()
+            .all(|r| r.timeout == Some(Duration::from_secs(43)))
+    );
+    assert_eq!(events.checkpoints(), [(1, 17), (1, 40)]);
+    // Existing telemetry counts tool-loop turns, not tools-off repairs.
+    assert_eq!(out.turns, 1);
+    assert_eq!(events.finished(), [(1, 40)]);
+}
+
+#[tokio::test]
+async fn repair_allowance_exhaustion_remains_a_schema_error() {
+    // No repair remains: validate as-is, regardless of token budget.
+    // The token gate governs additional requests, not error rewriting.
+    for allowance in [0, 1, 2] {
+        let r = rig(
+            MockProvider::new("mock")
+                .enqueue_response(metered(text_response("prose"), 11, 6))
+                .enqueue_response(metered(text_response("prose"), 13, 10))
+                .enqueue_response(metered(text_response("prose"), 19, 12)),
+            MockToolExecutor::new(),
+            Vec::new(),
+        );
+        let verb = r.verb.with_schema_retry_budget(allowance);
+        let budget = [17, 40, 71][usize::from(allowance)];
+        let err = verb
+            .run(typed_input(budget))
+            .await
+            .expect_err("schema never conformed");
+        assert!(
+            matches!(&err, VerbAgentError::SchemaValidation { .. }),
+            "{err:?}"
+        );
+        assert_eq!(
+            r.provider.captured_requests().len(),
+            usize::from(allowance) + 1
+        );
+        let spend = err.spend().expect("usage retained");
+        assert_eq!(spend.usage.input_tokens + spend.usage.output_tokens, budget);
+    }
+}
+
+#[tokio::test]
+async fn a_repair_provider_failure_retains_prior_usage_without_finished() {
+    let r = rig(
+        MockProvider::new("mock")
+            .enqueue_response(metered(text_response("prose"), 11, 6))
+            .enqueue_error(ProviderError::Api {
+                status: 503,
+                message: "scripted outage".to_owned(),
+            }),
+        MockToolExecutor::new(),
+        Vec::new(),
+    );
+    let events = Recording::default();
+    let err = r
+        .verb
+        .run_observed(typed_input(18), &events)
+        .await
+        .expect_err("provider failed");
+    assert!(matches!(err, VerbAgentError::Inference { .. }));
+    let spend = err.spend().expect("first response usage retained");
+    assert_eq!(
+        (spend.usage.input_tokens, spend.usage.output_tokens),
+        (11, 6)
+    );
+    assert_eq!(r.provider.captured_requests().len(), 2);
+    assert_eq!(events.checkpoints(), [(1, 17)]);
+    assert!(events.finished().is_empty());
+}
+
+#[tokio::test]
+async fn the_last_ordinary_turn_never_dispatches_an_unconsumed_tool() {
+    let r = rig(
+        MockProvider::new("mock").enqueue_response(metered(
+            tool_use_response("read", "nika:read", serde_json::json!({})),
+            11,
+            6,
+        )),
+        MockToolExecutor::new().enqueue_ok(ToolResult::success("read", "unused")),
+        vec![def("nika:read")],
+    );
+    let mut input = AgentInput::new("read");
+    input.tools = vec!["nika:read".to_owned()];
+    input.max_turns = Some(1);
+    let events = Recording::default();
+    let err = r
+        .verb
+        .run_observed(input, &events)
+        .await
+        .expect_err("turn budget");
+    assert!(matches!(err, VerbAgentError::MaxTurns { turns: 1, .. }));
+    assert_eq!(err.spec_code(), "NIKA-AGENT-001");
+    assert_eq!(r.provider.captured_requests().len(), 1);
+    assert!(r.tools.captured_calls().is_empty());
+    assert_eq!(events.checkpoints(), [(1, 17)]);
+    assert!(events.finished().is_empty());
+}

--- a/crates/nika-verb-agent/src/tests_refusal.rs
+++ b/crates/nika-verb-agent/src/tests_refusal.rs
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! Refusal wins over valid answers, tool dispatch and exhausted budgets.
+
+use super::*;
+use crate::tests::{def, rig, text_response, tool_use_response};
+use nika_error::traits::NikaErrorCode;
+use nika_kernel::ai::provider::StopReason;
+use nika_kernel::runtime::tool_executor::ToolResult;
+use nika_kernel_mock::{MockProvider, MockToolExecutor};
+use std::sync::Mutex;
+
+#[derive(Default)]
+struct Recording(Mutex<Vec<AgentEvent>>);
+
+impl AgentObserver for Recording {
+    fn on_event(&self, event: &AgentEvent) {
+        self.0.lock().unwrap().push(event.clone());
+    }
+}
+
+fn typed_input(budget: u64) -> AgentInput {
+    let mut input = AgentInput::new("return an integer score");
+    input.schema = Some(serde_json::json!({
+        "type": "object", "properties": {"score": {"type": "integer"}},
+        "required": ["score"], "additionalProperties": false
+    }));
+    input.tools = vec!["nika:read".into(), DONE_TOOL.into()];
+    input.max_tokens_total = Some(budget);
+    input
+}
+
+#[tokio::test]
+async fn refusal_precedes_output_tools_and_exhausted_budgets() {
+    for raw in [false, true] {
+        for reask in [false, true] {
+            for tight in [false, true] {
+                for mut response in [
+                    text_response("invalid JSON"),
+                    text_response(r#"{"score":7}"#),
+                    tool_use_response("c", "nika:read", serde_json::json!({})),
+                    tool_use_response("c", DONE_TOOL, serde_json::json!({"result":{"score":7}})),
+                ] {
+                    response.stop_reason = if raw {
+                        StopReason::Unknown("refusal".into())
+                    } else {
+                        StopReason::ContentFilter
+                    };
+                    response.finish_reason_raw = raw.then(|| "refusal".into());
+                    response.usage.cache_read_tokens = Some(3);
+                    response.usage.reasoning_tokens = Some(2);
+                    let mut provider = MockProvider::new("mock");
+                    if reask {
+                        provider = provider.enqueue_response(text_response("first invalid"));
+                    }
+                    let r = rig(
+                        provider
+                            .enqueue_response(response)
+                            .enqueue_response(text_response(r#"{"score":7}"#)),
+                        MockToolExecutor::new().enqueue_ok(ToolResult::success("c", "data")),
+                        vec![def("nika:read")],
+                    );
+                    let calls = 1 + u64::from(reask);
+                    let budget = if tight { calls * 15 } else { 6000 };
+                    let verb =
+                        r.verb
+                            .with_schema_retry_budget(if tight { u8::from(reask) } else { 2 });
+                    let events = Recording::default();
+                    let err = verb
+                        .run_observed(typed_input(budget), &events)
+                        .await
+                        .expect_err("explicit refusal wins over classification");
+                    assert!(matches!(err, VerbAgentError::Inference { .. }), "{err:?}");
+                    assert_eq!(err.spec_code(), "NIKA-INFER-001");
+                    assert!(!err.is_transient());
+                    let spend = err.spend().expect("the refusal was billed");
+                    assert_eq!(spend.usage.input_tokens, 10 * calls);
+                    assert_eq!(spend.usage.output_tokens, 5 * calls);
+                    assert_eq!(spend.usage.cache_read_tokens, Some(3));
+                    assert_eq!(spend.usage.reasoning_tokens, Some(2));
+                    assert_eq!(spend.model_resolved.as_deref(), Some("mock/agent"));
+                    assert_eq!(r.provider.captured_requests().len() as u64, calls);
+                    assert!(r.tools.captured_calls().is_empty());
+                    let events = events.0.lock().unwrap();
+                    let checkpoints: Vec<u64> = events
+                        .iter()
+                        .filter_map(|event| match event {
+                            AgentEvent::BudgetCheckpoint { total_tokens, .. } => {
+                                Some(*total_tokens)
+                            }
+                            _ => None,
+                        })
+                        .collect();
+                    assert_eq!(checkpoints, (1..=calls).map(|n| n * 15).collect::<Vec<_>>());
+                    assert!(
+                        !events
+                            .iter()
+                            .any(|e| matches!(e, AgentEvent::Finished { .. }))
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn ordinary_refusal_like_text_is_repairable_without_a_signal() {
+    let r = rig(
+        MockProvider::new("mock")
+            .enqueue_response(text_response("I cannot answer: synthetic refusal text"))
+            .enqueue_response(text_response(r#"{"score":7}"#)),
+        MockToolExecutor::new(),
+        Vec::new(),
+    );
+    let out = r
+        .verb
+        .run(typed_input(6000))
+        .await
+        .expect("ordinary repair");
+    assert_eq!(r.provider.captured_requests().len(), 2);
+    assert_eq!(out.usage.input_tokens, 20);
+    assert_eq!(out.usage.output_tokens, 10);
+}

--- a/crates/nika-verb-agent/src/tests_schema.rs
+++ b/crates/nika-verb-agent/src/tests_schema.rs
@@ -41,7 +41,10 @@ impl jsonschema::Retrieve for NoSchemaRetrieval {
     fn retrieve(
         &self,
         uri: &jsonschema::Uri<String>,
-    ) -> Result<serde_json::Value, Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<
+        serde_json::Value,
+        Box<dyn std::error::Error + Send + Sync>, // box-dyn-ok(vendor-seam): required by jsonschema::Retrieve; confined to this test validator
+    > {
         Err(format!("external schema retrieval forbidden: {uri}").into())
     }
 }

--- a/crates/nika-verb-agent/src/tests_schema.rs
+++ b/crates/nika-verb-agent/src/tests_schema.rs
@@ -23,6 +23,327 @@ use nika_kernel_mock::{MockProvider, MockToolExecutor};
 
 use crate::tests::{def, rig, text_response, tool_use_response};
 
+// The projection must preserve resource boundaries, not just the spelling
+// of a `$ref`. These tests validate the definition captured by MockProvider
+// after a native done run, independently of final-output validation.
+#[derive(Default)]
+struct SchemaEvents(std::sync::Mutex<Vec<AgentEvent>>);
+
+impl AgentObserver for SchemaEvents {
+    fn on_event(&self, event: &AgentEvent) {
+        self.0.lock().expect("event tape").push(event.clone());
+    }
+}
+
+struct NoSchemaRetrieval;
+
+impl jsonschema::Retrieve for NoSchemaRetrieval {
+    fn retrieve(
+        &self,
+        uri: &jsonschema::Uri<String>,
+    ) -> Result<serde_json::Value, Box<dyn std::error::Error + Send + Sync>> {
+        Err(format!("external schema retrieval forbidden: {uri}").into())
+    }
+}
+
+fn offline_validator(schema: &serde_json::Value) -> Result<jsonschema::Validator, String> {
+    jsonschema::options()
+        .with_retriever(NoSchemaRetrieval)
+        .build(schema)
+        .map_err(|error| error.to_string())
+}
+
+fn identified_score_schema(id: Option<&str>, definitions: &str) -> serde_json::Value {
+    let mut schema = score_schema();
+    schema["$schema"] = serde_json::json!(if definitions == "definitions" {
+        "http://json-schema.org/draft-07/schema#"
+    } else {
+        "https://json-schema.org/draft/2020-12/schema"
+    });
+    schema["properties"]["score"] = serde_json::json!({"$ref": format!("#/{definitions}/score")});
+    schema[definitions] = serde_json::json!({"score": {"type": "integer"}});
+    if let Some(id) = id {
+        schema["$id"] = serde_json::json!(id);
+    }
+    schema
+}
+
+async fn captured_score_projection(case: &str, schema: serde_json::Value) -> serde_json::Value {
+    let good = serde_json::json!({"score": 7});
+    let bad = serde_json::json!({"score": "bad"});
+    let declared = offline_validator(&schema).expect("standalone schema compiles offline");
+    assert!(
+        declared.is_valid(&good),
+        "{case}: standalone positive control"
+    );
+    assert!(
+        !declared.is_valid(&bad),
+        "{case}: standalone negative control"
+    );
+
+    let r = rig(
+        MockProvider::new("mock").enqueue_response(tool_use_response(
+            "done-score",
+            DONE_TOOL,
+            serde_json::json!({"result": good}),
+        )),
+        MockToolExecutor::new(),
+        Vec::new(),
+    );
+    let events = SchemaEvents::default();
+    let mut input = AgentInput::new("return a score");
+    input.tools = vec![DONE_TOOL.to_owned()];
+    input.schema = Some(schema.clone());
+    let out = r
+        .verb
+        .run_observed(input, &events)
+        .await
+        .expect("native done succeeds");
+    assert_eq!(out.output, AgentValue::Structured(good.clone()));
+    assert_eq!(out.stop_reason, AgentStopReason::ExplicitCompletion);
+    assert_eq!(out.turns, 1);
+    assert!(
+        r.tools.captured_calls().is_empty(),
+        "done never dispatches an external tool"
+    );
+    let events = events.0.lock().expect("event tape");
+    assert!(matches!(
+        events.first(),
+        Some(AgentEvent::RunStarted { .. })
+    ));
+    assert!(matches!(
+        events.last(),
+        Some(AgentEvent::Finished { turns: 1, .. })
+    ));
+    assert!(
+        !events
+            .iter()
+            .any(|event| matches!(event, AgentEvent::ToolCompleted { .. }))
+    );
+    let requests = r.provider.captured_requests();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].response_format, ResponseFormat::Text);
+    done_def_on(&requests[0]).parameters.clone()
+}
+
+async fn assert_score_projection(case: &str, schema: serde_json::Value) {
+    let parameters = captured_score_projection(case, schema).await;
+    let projected = offline_validator(&parameters)
+        .unwrap_or_else(|error| panic!("{case}: captured done schema must compile: {error}"));
+    assert!(
+        projected.is_valid(&serde_json::json!({"result": {"score": 7}})),
+        "{case}"
+    );
+    for bad in [
+        serde_json::json!({"result": {"score": "bad"}}),
+        serde_json::json!({"result": {}}),
+        serde_json::json!({"result": {"score": 7, "extra": true}}),
+        serde_json::json!({}),
+    ] {
+        assert!(!projected.is_valid(&bad), "{case}: must reject {bad}");
+    }
+}
+
+#[tokio::test]
+async fn projection_absolute_id_defs() {
+    assert_score_projection(
+        "absolute_id_defs",
+        identified_score_schema(Some("https://example.invalid/score.json"), "$defs"),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn projection_relative_id_defs() {
+    assert_score_projection(
+        "relative_id_defs",
+        identified_score_schema(Some("schemas/score.json"), "$defs"),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn projection_urn_id_defs() {
+    assert_score_projection(
+        "urn_id_defs",
+        identified_score_schema(Some("urn:example:score"), "$defs"),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn projection_absolute_id_empty_fragment() {
+    assert_score_projection(
+        "absolute_id_empty_fragment",
+        identified_score_schema(Some("https://example.invalid/score.json#"), "$defs"),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn projection_absolute_id_definitions() {
+    assert_score_projection(
+        "absolute_id_definitions",
+        identified_score_schema(Some("https://example.invalid/score.json"), "definitions"),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn projection_without_id_controls() {
+    for definitions in ["$defs", "definitions"] {
+        assert_score_projection(
+            &format!("no_id_{definitions}"),
+            identified_score_schema(None, definitions),
+        )
+        .await;
+    }
+}
+
+#[tokio::test]
+async fn projection_same_document_id_controls() {
+    for id in ["", "#"] {
+        assert_score_projection(
+            &format!("same_document_id_{id}"),
+            identified_score_schema(Some(id), "$defs"),
+        )
+        .await;
+    }
+}
+
+#[tokio::test]
+async fn projection_id_without_refs_control() {
+    let mut schema = score_schema();
+    schema["$id"] = serde_json::json!("https://example.invalid/plain.json");
+    assert_score_projection("id_without_refs", schema).await;
+}
+
+#[tokio::test]
+async fn projection_nested_relative_resource_keeps_its_parent_base() {
+    // Moving this definition outside its parent's `$id` loses the base
+    // URI needed to find it by its relative resource identifier.
+    let mut schema = identified_score_schema(
+        Some("https://example.invalid/contracts/result.json"),
+        "$defs",
+    );
+    schema["properties"]["score"] = serde_json::json!({"$ref": "score.json#/$defs/value"});
+    schema["$defs"]["score"] = serde_json::json!({
+        "$id": "score.json", "$defs": {"value": {"type": "integer"}}
+    });
+    assert_score_projection("nested_relative_resource", schema).await;
+}
+
+#[tokio::test]
+async fn projection_absolute_self_reference_keeps_result_identity() {
+    // Hoisting `$id` instead of keeping its resource intact would make
+    // this URI name the wrapper, silently changing what `score` validates.
+    let mut schema = identified_score_schema(Some("https://example.invalid/score.json"), "$defs");
+    schema["properties"]["previous"] =
+        serde_json::json!({"$ref": "https://example.invalid/score.json"});
+    let parameters = captured_score_projection("absolute_self_reference", schema).await;
+    let projected = offline_validator(&parameters).expect("self reference compiles");
+    assert!(projected.is_valid(&serde_json::json!({
+        "result": {"score": 7, "previous": {"score": 6}}
+    })));
+    assert!(!projected.is_valid(&serde_json::json!({
+        "result": {"score": 7, "previous": {"score": "bad"}}
+    })));
+}
+
+#[tokio::test]
+async fn projection_identified_done_repair_preserves_schema_and_trace() {
+    let schema = identified_score_schema(Some("https://example.invalid/score.json"), "$defs");
+    let r = rig(
+        MockProvider::new("mock")
+            .enqueue_response(tool_use_response(
+                "bad",
+                DONE_TOOL,
+                serde_json::json!({"result": {"score": "bad"}}),
+            ))
+            .enqueue_response(tool_use_response(
+                "good",
+                DONE_TOOL,
+                serde_json::json!({"result": {"score": 7}}),
+            )),
+        MockToolExecutor::new(),
+        Vec::new(),
+    );
+    let mut input = AgentInput::new("return a score");
+    input.tools = vec![DONE_TOOL.to_owned()];
+    input.schema = Some(schema);
+    let events = SchemaEvents::default();
+    let out = r
+        .verb
+        .run_observed(input, &events)
+        .await
+        .expect("repair succeeds");
+    assert_eq!(out.stop_reason, AgentStopReason::ExplicitCompletion);
+    assert_eq!(
+        out.output,
+        AgentValue::Structured(serde_json::json!({"score": 7}))
+    );
+    let requests = r.provider.captured_requests();
+    assert_eq!(requests.len(), 2);
+    assert_eq!(
+        done_def_on(&requests[0]).parameters,
+        done_def_on(&requests[1]).parameters
+    );
+    assert!(
+        requests[1]
+            .messages
+            .iter()
+            .flat_map(|m| &m.content)
+            .any(|block| matches!(
+                block, ContentBlock::ToolResult { tool_use_id, content, is_error: true }
+                if tool_use_id == "bad" && content.contains("integer")
+            ))
+    );
+    assert!(matches!(
+        events.0.lock().expect("event tape").last(),
+        Some(AgentEvent::Finished { turns: 2, .. })
+    ));
+    let validator = offline_validator(&done_def_on(&requests[1]).parameters)
+        .expect("repair definition compiles");
+    assert!(validator.is_valid(&serde_json::json!({"result": {"score": 7}})));
+}
+
+#[tokio::test]
+async fn projection_identified_invalid_done_is_schema_error_without_finished() {
+    let mut r = rig(
+        MockProvider::new("mock").enqueue_response(tool_use_response(
+            "bad",
+            DONE_TOOL,
+            serde_json::json!({"result": {"score": "bad"}}),
+        )),
+        MockToolExecutor::new(),
+        Vec::new(),
+    );
+    r.verb = r.verb.with_schema_retry_budget(0);
+    let mut input = AgentInput::new("return a score");
+    input.tools = vec![DONE_TOOL.to_owned()];
+    input.schema = Some(identified_score_schema(
+        Some("https://example.invalid/score.json"),
+        "$defs",
+    ));
+    let events = SchemaEvents::default();
+    let err = r
+        .verb
+        .run_observed(input, &events)
+        .await
+        .expect_err("bad value refused");
+    assert!(matches!(err, VerbAgentError::SchemaValidation { .. }));
+    assert_eq!(nika_error::traits::NikaErrorCode::nika_code(&err).num, 464);
+    assert_eq!(r.provider.captured_requests().len(), 1);
+    assert!(
+        !events
+            .0
+            .lock()
+            .expect("event tape")
+            .iter()
+            .any(|event| matches!(event, AgentEvent::Finished { .. }))
+    );
+}
+
 /// The task contract used across this suite: an object with one
 /// required integer. A string `score` misses it in a way no extraction
 /// trick can rescue — the model has to send a different value.

--- a/crates/nika-verb-agent/src/turn.rs
+++ b/crates/nika-verb-agent/src/turn.rs
@@ -12,6 +12,26 @@ use nika_kernel::runtime::agent::AgentStopReason;
 use crate::shape;
 use crate::{AgentOutput, AgentValue, VerbAgentError};
 
+/// Stop before another request when the cumulative token budget is met.
+/// Tool feedback, done-result repairs and final-text repairs all pass
+/// this gate; an already valid conclusion returns before reaching it.
+pub(crate) fn token_budget_gate(
+    budget: Option<u64>,
+    total_tokens: u64,
+    last_text: &str,
+) -> Result<(), VerbAgentError> {
+    if let Some(budget) = budget
+        && total_tokens >= budget
+    {
+        return Err(VerbAgentError::MaxTokens {
+            total_tokens,
+            partial_output: last_text.to_owned(),
+            spend: Box::default(), // decorated at the return seam
+        });
+    }
+    Ok(())
+}
+
 /// The ONE schema-repair allowance of a run, shared by BOTH repair
 /// paths: a non-conforming `nika:done` `result:` (fed back as a tool
 /// result so the model calls the sentinel again) and a free-text final

--- a/crates/nika-verb-infer/src/lib.rs
+++ b/crates/nika-verb-infer/src/lib.rs
@@ -380,7 +380,7 @@ where
             usage_total.absorb(&response.usage);
             // R3-F1 (2026-07-29 audit · run 3 · the agent loop's own
             // `NIKA-AGENT-005` sibling): the usage-absence gate.
-            refuse_unmetered(&response, model, incurred(&usage_total))?;
+            refuse_unusable_response(&response, model, incurred(&usage_total))?;
             let text = response_text(&response);
 
             let (Some(schema), Some(validator)) = (input.schema.as_ref(), validator.as_ref())
@@ -418,7 +418,7 @@ where
     }
 }
 
-/// The B-5 gate (the sibling of [`refuse_unmetered`] — a named refusal
+/// The B-5 gate (the sibling of [`refuse_unusable_response`] — a named refusal
 /// BEFORE the hang, never a silent one): probe the local endpoint a
 /// server-backed keyless model would call, and refuse FAST when it is
 /// silent (nothing listening · DNS stalled · blackholed) or mute
@@ -466,8 +466,9 @@ where
 /// `NIKA-AGENT-005` sibling): a priced backend that omits the usage
 /// block would bill this task $0 in the ledger while charging real
 /// money — fail CLOSED; a mock/local zero is a TRUE zero (the
-/// documented unmetered carve-out), never an invented number.
-fn refuse_unmetered(
+/// documented unmetered carve-out), never an invented number. Explicit
+/// refusals then stop before output validation, with the incurred spend.
+fn refuse_unusable_response(
     response: &InferResponse,
     model: &str,
     spend: Box<SpendOnFailure>,
@@ -475,6 +476,17 @@ fn refuse_unmetered(
     if !response.usage_reported && nika_catalog::find_pricing_for(model).is_some() {
         return Err(VerbInferError::UsageUnmetered {
             model: model.to_owned(),
+            spend,
+        });
+    }
+    // A refusal is terminal, including valid JSON or a schema reask.
+    if matches!(response.stop_reason, StopReason::ContentFilter)
+        || response.finish_reason_raw.as_deref() == Some("refusal")
+    {
+        return Err(VerbInferError::ProviderCall {
+            source: ProviderError::Other {
+                reason: "provider explicitly refused the response".to_owned(),
+            },
             spend,
         });
     }

--- a/crates/nika-verb-infer/src/tests.rs
+++ b/crates/nika-verb-infer/src/tests.rs
@@ -1,3 +1,5 @@
+mod refusal;
+
 use super::*;
 use nika_providers::ProvidersConfig;
 use serde_json::json;

--- a/crates/nika-verb-infer/src/tests/refusal.rs
+++ b/crates/nika-verb-infer/src/tests/refusal.rs
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+use super::*;
+use nika_error::traits::NikaErrorCode;
+
+fn response(text: &str, refusal: &serde_json::Value) -> String {
+    json!({"choices":[{"message":{"content":text,"refusal":refusal},"finish_reason":"stop"}],
+        "usage":{"prompt_tokens":81,"completion_tokens":11,
+            "prompt_tokens_details":{"cached_tokens":9},
+            "completion_tokens_details":{"reasoning_tokens":4}}})
+    .to_string()
+}
+
+#[tokio::test]
+async fn explicit_refusal_precedes_plain_or_valid_typed_output_and_repair() {
+    for reask in [false, true] {
+        for typed in [false, true] {
+            if reask && !typed {
+                continue;
+            }
+            for text in ["invalid JSON", r#"{"value":7}"#] {
+                let mut bodies = Vec::new();
+                if reask {
+                    bodies.push(response("first invalid", &json!(null)));
+                }
+                bodies.push(response(text, &json!("synthetic refusal")));
+                bodies.push(response(r#"{"value":7}"#, &json!(null)));
+                let seam =
+                    SeamHttp::with_json(&bodies.iter().map(String::as_str).collect::<Vec<_>>());
+                let verb = openai_verb(&seam).with_schema_retry_budget(u8::from(reask));
+                let mut input = InferInput::new("synthetic fixture");
+                input.max_tokens = Some(11);
+                if typed {
+                    input.schema = Some(json!({"type":"object"}));
+                }
+                let err = verb
+                    .run(input)
+                    .await
+                    .expect_err("refusal is not schema output");
+                assert!(
+                    matches!(err, VerbInferError::ProviderCall { .. }),
+                    "{err:?}"
+                );
+                assert_eq!(err.spec_code(), "NIKA-INFER-001");
+                assert!(!err.is_transient());
+                let calls = 1 + u64::from(reask);
+                let usage = &err.spend().expect("retain the billed response").usage;
+                assert_eq!(usage.input_tokens, 81 * calls);
+                assert_eq!(usage.output_tokens, 11 * calls);
+                assert_eq!(usage.cache_read_tokens, Some(9 * calls));
+                assert_eq!(usage.reasoning_tokens, Some(4 * calls));
+                assert_eq!(seam.captured().len() as u64, calls);
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn null_or_empty_refusal_preserves_plain_output_and_schema_repair() {
+    for refusal in [json!(null), json!("")] {
+        for typed in [false, true] {
+            let first = response("I cannot answer: synthetic refusal text", &refusal);
+            let second = response(r#"{"value":7}"#, &refusal);
+            let seam = SeamHttp::with_json(&[&first, &second]);
+            let mut input = InferInput::new("synthetic fixture");
+            if typed {
+                input.schema = Some(json!({"type":"object"}));
+            }
+            let out = openai_verb(&seam)
+                .run(input)
+                .await
+                .expect("no refusal signal");
+            let calls = if typed { 2 } else { 1 };
+            assert_eq!(seam.captured().len() as u64, calls);
+            assert_eq!(out.usage.input_tokens, 81 * calls);
+        }
+    }
+}


### PR DESCRIPTION
## What & why

Agents retain the last terminal text when a cumulative token budget prevents another final-text repair, preserve resource identifiers in typed `done` schemas, and stop explicit provider refusals after usage accounting but before repair or tool dispatch.

`nika:read` now distinguishes invalid arguments from missing files. The checker, CLI and LSP expose the corresponding diagnostics consistently; shared text collectors keep the checker within its existing size limit.

## Validation

Validated commit `abcecb8255f088ce40be432335b9cc1a1ae8194d` with the normal pre-push gate: 7,490 library tests passed, 3 skipped; workspace Clippy passed with warnings denied; all 12 CI ratchets passed. Engine hygiene has no red findings and retains its yellow warnings. Formatting was checked again before opening this PR.

Nextest reports one passing test as leaky: `nika-serve::schedule::tests::non_finite_and_non_positive_costs_refuse_through_canonical_validation`. The local gate runs library tests only; integration tests remain for CI. No live provider calls were needed for this qualification.

## Checklist

- [x] Conventional commits and `Co-Authored-By: Nika 🦋 <nika@supernovae.studio>`
- [x] Workspace `--lib` suite passed through the normal test driver
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] Normal hygiene and CI ratchets passed without bypasses
- [x] No new crate admitted

