### PR TITLE
chore(wiring): drop the two G6 watches the runtime now reads

### DIFF
--- a/wiring.yaml
+++ b/wiring.yaml
@@ -416,19 +416,7 @@ capabilities:
 # hashed into the resume key, never copied onto InferInput) ·
 # lsp --clientProcessId (clap accepts, comment says "currently unread").
 
-silent_drops:
-  - id: infer.vision
-    parsed_file: crates/nika-schema/src/parser/verbs.rs
-    parsed_needle: "action.vision"
-    runtime_file: crates/nika-runtime/src/dispatch.rs
-    runtime_needle: "action.vision"
-    issue: 1135
-  - id: infer.thinking
-    parsed_file: crates/nika-schema/src/parser/verbs.rs
-    parsed_needle: "action.thinking"
-    runtime_file: crates/nika-runtime/src/dispatch.rs
-    runtime_needle: "action.thinking"
-    issue: 1180
+silent_drops: []
   # lsp.client-process-id — REMOVED 2026-08-24. The flag is read at
   # main.rs and drives the `initialize` §processId watchdog; the field is
   # no longer silent, so the watch would now be the lie in the other


### PR DESCRIPTION
silent_drops listed infer.vision (#1135) and infer.thinking (#1180) as fields the parser accepted and the dispatcher dropped; dispatch.rs reads both now, so the studio wiring-g6 vector reported each watch as stale (« a drop that the runtime now reads »). The list stays, empty, for the next drop.

No code change · wiring ledger only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)