### PR TITLE
docs(verbs): align jq vision and agent implementation status

### DIFF
--- a/docs/crate-specs/nika-builtin.md
+++ b/docs/crate-specs/nika-builtin.md
@@ -121,9 +121,11 @@ after an uncertain result.
   test pins today's pass-through so the policy landing flips it visibly.
 - **jq evaluation cost**: the 16 MiB ceiling bounds the RENDERED output;
   jaq's internal materialization (`[range(1e9)]` builds in-engine before
-  any output is yielded) is bounded by the engine's task-level supervision
-  (timeout · memory caps), not re-implemented per-builtin. `spawn_blocking`
-  keeps the executor responsive meanwhile.
+  any output is yielded) has no evaluation budget here. `spawn_blocking`
+  keeps the async executor responsive, but a task timeout does not stop
+  its running computation or bound its memory. A jaq step budget or
+  process isolation with resource limits remains deferred (see
+  `crates/nika-builtin/src/data.rs` and `route_jq` in `src/lib.rs`).
 - **`BuiltinFailure.transient`** is typed at the failure plane; the wire
   `ToolResult` has no metadata slot yet — the flag projects when the kernel
   grows one (both types `#[non_exhaustive]`, strictly additive).

--- a/docs/crate-specs/nika-verb-agent.md
+++ b/docs/crate-specs/nika-verb-agent.md
@@ -2,7 +2,7 @@
 
 | | |
 |---|---|
-| Status | **SPEC** (Gate 1 · authored 2026-06-11 · announce-ladder step s12 · night arc · the 4th and LAST verb · **impl BLOCKED on a `ToolDefinitionProvider` seam** — see §8 ⛔ · not just deferred for time) |
+| Status | **Implemented** — the loop consumes the kernel `ToolDefinitionProviderDyn` seam; §8 records the original missing-seam decision from 2026-06-11. |
 | Layer | **L2** — verb crate · domain executor for the `agent` verb (4th of the 4 verbs · D-2026-05-22-N18) |
 | Design | the multi-turn agentic loop · consumes `nika-providers` (L1.5 · inference) **+ `nika-verb-invoke`** (L2 · tool dispatch · same-layer dep — layering-legal, §0.5) · drives infer → tool-calls → infer until a terminal condition |
 | LOC budget | ≤4k src (the most complex verb · brouillon agent loop was the largest verb) · caps ≤1500/file · ≤100/fn · ≤15k/crate |
@@ -203,7 +203,13 @@ vs brouillon agent loop.
 wip · `deny.toml` tokio wrapper · NIKA_460-469 registered in
 `nika-error/codes.rs` + `verb_help` · kernel hub doc row.
 
-## §8 · Why implementation is DEFERRED (not skipped) — + the BLOCKER found
+## §8 · Historical implementation deferral — missing seam, 2026-06-11
+
+The account below records the pre-implementation decision. Its blocker is
+resolved: `crates/nika-kernel-ai/src/tool_defs.rs` defines the tool-definition
+seam, and `AgentVerb` consumes `ToolDefinitionProviderDyn` through its injected
+`tool_defs` source (`crates/nika-verb-agent/src/lib.rs`). This is not an open
+implementation dependency.
 
 The agent verb is the most complex of the four — a stateful multi-turn loop
 with budget tracking, the `nika:done` sentinel protocol, whitelist-glob
@@ -212,7 +218,7 @@ discipline (`diamond-discipline.md` Rule 6 · `session-discipline.md`
 anti-patinage · quality > speed · « no rushing »), this crate is authored as
 a complete Gate-1 SPEC and its implementation is left to a focused session.
 
-### ⛔ The missing seam (found 2026-06-11 · verify-the-seam-first paid off)
+### The missing seam at the time (2026-06-11)
 
 A second-pass empirical check before coding surfaced a REAL upstream gap, not
 just complexity: **there is no tool-definition source in the workspace.** To
@@ -236,7 +242,7 @@ the Question-First doctrine), not a verb implementation. Building the loop now
 would mean inventing or stubbing that seam — exactly the fragile shortcut the
 deferral avoids.
 
-**Resolution for the next session** · decide the `ToolDefinitionProvider`
+**Original proposed resolution (2026-06-11)** · decide the `ToolDefinitionProvider`
 shape FIRST (likely: a kernel trait the wiring layer implements over
 `nika-catalog` for builtins + `nika-mcp` for MCP), admit it, THEN the agent
 loop has a clean seam to consume. The loop logic itself (turns · sentinel ·

--- a/docs/crate-specs/nika-verb-infer.md
+++ b/docs/crate-specs/nika-verb-infer.md
@@ -127,10 +127,11 @@ passthrough). Range registered in the kernel range-registry hub at admission.
   surface (brouillon kept it in the engine bridge; Diamond will too until
   `verb-agent` s15 needs it). Seam note: the registry already resolves
   stream-capable providers; adding `run_stream` later is additive.
-- **NOT vision** — `vision:` staging couples to media (deferred §10bis).
-  `InferInput` carries no vision field at v1; the spec field maps when
-  `nika-media-*` lands. (Spec allows partial conformance pre-1.0; the
-  conformance fixture for vision is marked pending.)
+- **NOT CAS vision staging** — `InferInput.vision` carries file and URL
+  references. `src/vision.rs` reads each local file in full and inlines
+  its bytes as a base64 `data:` URL; remote URLs are forwarded to the
+  provider. Missing or empty files fail before the provider call.
+  Content-addressed staging remains deferred to `nika-media-*` (§10bis).
 - **NOT template/CEL resolution** — `${{ }}` is resolved upstream.
 - **NOT retry-on-transport** — transport retry/backoff policy belongs to the
   engine scheduler; the verb retries ONLY schema-validation (spec-sanctioned).

--- a/estate.yaml
+++ b/estate.yaml
@@ -183,7 +183,7 @@ patterns:
 - glob: "docs/**"
   class: authored
   match_count: 124
-  aggregate_sha256: 694f29f1e7078a91e9c439b317ca440354fedba0a9db58bac88c3386454dea21
+  aggregate_sha256: 9324ccbe1a88b849836b306f80112a3d25db0240daeeca1672ebcfda1a88bc58
   evidence: "crate-specs · architecture prose · perf notes — no generation markers at file heads"
 - glob: "scripts/**"
   class: authored


### PR DESCRIPTION
Three crate documents describe behavior that no longer matches the implementation. Clarify that jq output limits do not bound internal materialization or stop blocking work, document the existing vision field and deferred CAS staging, and mark the former agent tool-definition blocker as historical.

The changes are limited to these three documents and the regenerated estate manifest. Assertions were checked against the current Rust sources; `git diff --check` and the normal commit hooks pass. The underlying code is the consolidation merged in PR1533, whose full GitHub battery passed 8,573 tests (seven skipped), plus three Loom tests.
