### PR TITLE
fix(check): an ancestor project file the process may not read is a hint, never a refusal

### DIFF
--- a/changelog.d/1547.fixed.md
+++ b/changelog.d/1547.fixed.md
@@ -1,0 +1,10 @@
+- **An ancestor `nika.yaml` this process may not read is a hint, never a
+  refusal.** A nested `nika check` under an exec sandbox (the Lab's own L0
+  campaign, a CI job in a monorepo) met the repository's root project file
+  with `EPERM` and exited 3 on `project.unreadable`, masking every finding
+  of the workflow itself; `nika run` refused the same way. The walk now
+  reports the unreachable ancestor (`↳ HINT [project] … is not readable from
+  here`, `project_unreachable` in `check --json`, a `project:` note on the
+  run's stderr) and that file's `ceiling:` simply does not govern from
+  there. A file that reads but will not parse, and every other read error,
+  keep their refusal (#1494). Closes #1547.

--- a/crates/nika-cli/src/verbs/check/budget.rs
+++ b/crates/nika-cli/src/verbs/check/budget.rs
@@ -26,27 +26,47 @@ pub(super) struct AmbientCeiling {
     pub line: Option<usize>,
 }
 
+/// What the cwd can see: the ceiling that governs, and the ancestor
+/// `nika.yaml` this process may not read (#1547) — said, never refused.
+#[derive(Debug, Default)]
+pub(super) struct Ambient {
+    pub ceiling: Option<AmbientCeiling>,
+    pub unreachable: Option<PathBuf>,
+}
+
 /// Walk from `start` the same way `run::ceiling::ladder` does.
-pub(super) fn at(start: &Path) -> Result<Option<AmbientCeiling>, ProjectError> {
-    let Some((path, project)) = nika_vocab::project::discover(start)? else {
-        return Ok(None);
-    };
-    let Some(usd) = project.ceiling else {
-        return Ok(None);
-    };
-    let line = ceiling_line(&path);
-    Ok(Some(AmbientCeiling { usd, path, line }))
+pub(super) fn at(start: &Path) -> Result<Ambient, ProjectError> {
+    let found = nika_vocab::project::discover_reachable(start)?;
+    let unreachable = found.unreachable.map(|(path, _)| path);
+    let ceiling = found.found.and_then(|(path, project)| {
+        let usd = project.ceiling?;
+        let line = ceiling_line(&path);
+        Some(AmbientCeiling { usd, path, line })
+    });
+    Ok(Ambient {
+        ceiling,
+        unreachable,
+    })
 }
 
 /// The CWD door — identical start to `nika run` with no flag.
-pub(super) fn from_cwd() -> Result<Option<AmbientCeiling>, ProjectError> {
+pub(super) fn from_cwd() -> Result<Ambient, ProjectError> {
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
     at(&cwd)
 }
 
 /// Human footnote. Presence-gated: silence when no file governs spend.
-pub(super) fn footnote(text: &mut String, theme: Theme, ceiling: Option<&AmbientCeiling>) {
-    let Some(c) = ceiling else {
+pub(super) fn footnote(text: &mut String, theme: Theme, ambient: &Ambient) {
+    if let Some(path) = &ambient.unreachable {
+        let _ = writeln!(
+            text,
+            " {} {}     [project] `{}` is not readable from here — its ceiling: does not govern this check · a run caps with --max-cost-usd",
+            theme.paint(Role::Accent, "↳"),
+            theme.paint(Role::Strong, "HINT"),
+            path.display(),
+        );
+    }
+    let Some(c) = &ambient.ceiling else {
         return;
     };
     let where_ = provenance(c);
@@ -60,11 +80,14 @@ pub(super) fn footnote(text: &mut String, theme: Theme, ceiling: Option<&Ambient
 }
 
 /// Presence-gated `--json` object. `clean` does not read it.
-pub(super) fn stamp_json(
-    obj: &mut serde_json::Map<String, serde_json::Value>,
-    ceiling: Option<&AmbientCeiling>,
-) {
-    let Some(c) = ceiling else {
+pub(super) fn stamp_json(obj: &mut serde_json::Map<String, serde_json::Value>, ambient: &Ambient) {
+    if let Some(path) = &ambient.unreachable {
+        obj.insert(
+            "project_unreachable".to_owned(),
+            serde_json::json!(path.display().to_string()),
+        );
+    }
+    let Some(c) = &ambient.ceiling else {
         return;
     };
     let mut v = serde_json::json!({
@@ -127,7 +150,10 @@ mod tests {
         let child = root.join("sub");
         std::fs::create_dir_all(&child).expect("mkdir");
         std::fs::write(root.join("nika.yaml"), "nika: proj\nceiling: 0.01\n").expect("seed");
-        let c = at(&child).expect("valid project").expect("walks up");
+        let c = at(&child)
+            .expect("valid project")
+            .ceiling
+            .expect("walks up");
         assert_eq!(c.usd.to_bits(), 0.01f64.to_bits());
         assert_eq!(c.line, Some(2));
         assert!(c.path.ends_with("nika.yaml"), "{:?}", c.path);
@@ -139,7 +165,7 @@ mod tests {
         let dir = fresh("none");
         std::fs::write(dir.join("nika.yaml"), "nika: proj\n").expect("seed");
         assert!(
-            at(&dir).expect("valid project").is_none(),
+            at(&dir).expect("valid project").ceiling.is_none(),
             "no ceiling → check stays silent"
         );
         let _ = std::fs::remove_dir_all(&dir);
@@ -152,7 +178,7 @@ mod tests {
         // ancestor ceiling.
         let dir = fresh("boundary");
         std::fs::write(dir.join("nika.yaml"), "nika: boundary\n").expect("seed");
-        assert!(at(&dir).expect("valid boundary").is_none());
+        assert!(at(&dir).expect("valid boundary").ceiling.is_none());
         let _ = std::fs::remove_dir_all(&dir);
     }
 
@@ -163,7 +189,7 @@ mod tests {
         std::fs::create_dir_all(&child).expect("mkdir");
         std::fs::write(root.join("nika.yaml"), "nika: root\nceiling: 9.99\n").expect("root");
         std::fs::write(child.join("nika.yaml"), "nika: leaf\nceiling: 0.25\n").expect("leaf");
-        let c = at(&child).expect("valid project").expect("leaf");
+        let c = at(&child).expect("valid project").ceiling.expect("leaf");
         assert_eq!(
             c.usd.to_bits(),
             0.25f64.to_bits(),
@@ -219,7 +245,7 @@ mod tests {
         std::fs::write(room.path().join("nika.yaml"), "nika: root\nceiling: 0.50\n")
             .expect("ancestor");
         std::fs::write(child.join("nika.yaml"), "nika: child\n").expect("boundary");
-        assert!(at(&child).expect("valid boundary").is_none());
+        assert!(at(&child).expect("valid boundary").ceiling.is_none());
     }
 
     #[test]
@@ -231,7 +257,7 @@ mod tests {
         std::env::set_current_dir(&dir).expect("chdir");
         let mut text = String::new();
         let ceiling = from_cwd().expect("valid project");
-        footnote(&mut text, Theme::new(false, true, false), ceiling.as_ref());
+        footnote(&mut text, Theme::new(false, true, false), &ceiling);
         let _ = std::env::set_current_dir(prev);
         assert!(
             text.contains("BUDGET") && text.contains("0.0100") && text.contains("nika.yaml:2"),
@@ -289,7 +315,7 @@ mod tests {
         std::env::set_current_dir(&dir).expect("chdir");
         let mut obj = serde_json::Map::new();
         let ceiling = from_cwd().expect("valid project");
-        stamp_json(&mut obj, ceiling.as_ref());
+        stamp_json(&mut obj, &ceiling);
         let _ = std::env::set_current_dir(&prev);
         let v = obj.get("run_budget").expect("present");
         assert_eq!(v["max_cost_usd"], 0.01);
@@ -306,7 +332,7 @@ mod tests {
         std::env::set_current_dir(&empty).expect("chdir empty");
         let mut silent = serde_json::Map::new();
         let ceiling = from_cwd().expect("valid boundary");
-        stamp_json(&mut silent, ceiling.as_ref());
+        stamp_json(&mut silent, &ceiling);
         let _ = std::env::set_current_dir(prev);
         assert!(silent.is_empty(), "{silent:?}");
         let _ = std::fs::remove_dir_all(&dir);

--- a/crates/nika-cli/src/verbs/check/mod.rs
+++ b/crates/nika-cli/src/verbs/check/mod.rs
@@ -714,7 +714,7 @@ fn render_checked_with_profile(
     access_pin: Option<&str>,
     theme: Theme,
 ) -> Result<VerbOutput, nika_vocab::project::ProjectError> {
-    let ceiling = budget::from_cwd()?;
+    let ambient = budget::from_cwd()?;
     let lanes = nika_cli_host::oracle::Lanes::new(native_strict, profile == Profile::Operational);
     let verdict = fold_verdicts(wf, report, skills, access_pin);
     // The risk grade (P0-6): a pure projection — advisory by default;
@@ -732,14 +732,7 @@ fn render_checked_with_profile(
     }
 
     if json {
-        return Ok(json_verdict(
-            wf,
-            report,
-            skills,
-            &verdict,
-            lanes,
-            ceiling.as_ref(),
-        ));
+        return Ok(json_verdict(wf, report, skills, &verdict, lanes, &ambient));
     }
 
     let mut text = render(
@@ -765,7 +758,7 @@ fn render_checked_with_profile(
         verdict.grade,
     );
     naming_note(&mut text, theme, path, wf);
-    budget::footnote(&mut text, theme, ceiling.as_ref());
+    budget::footnote(&mut text, theme, &ambient);
     Ok(if strict_clean {
         VerbOutput::ok(nika_display::vocab::sober(theme, &text))
     } else {
@@ -849,13 +842,13 @@ fn json_verdict(
     skills: &nika_schema::ResolvedSkills,
     verdict: &nika_cli_host::oracle::Verdict,
     lanes: nika_cli_host::oracle::Lanes,
-    ceiling: Option<&budget::AmbientCeiling>,
+    ambient: &budget::Ambient,
 ) -> VerbOutput {
     let mut obj = match nika_cli_host::oracle::audit_json(wf, report, skills, verdict, lanes) {
         Ok(obj) => obj,
         Err(why) => return VerbOutput::env(why),
     };
-    budget::stamp_json(&mut obj, ceiling);
+    budget::stamp_json(&mut obj, ambient);
     let text = format!("{:#}", serde_json::Value::Object(obj));
     if verdict.strict_clean(report, lanes) {
         VerbOutput::ok(text)

--- a/crates/nika-cli/src/verbs/check/tests/project_context.rs
+++ b/crates/nika-cli/src/verbs/check/tests/project_context.rs
@@ -277,3 +277,44 @@ fn an_ambient_path_with_control_characters_stays_machine_readable() {
     );
     assert_ambient_refusal(&run_snapshot_export("value.nika.yaml", theme()), true, &err);
 }
+
+/// #1547 · the room's project file is unreadable (the sandboxed nested
+/// `nika check` shape): the check exits on the WORKFLOW's verdict, the
+/// hint names the file, `--json` carries `project_unreachable`, `clean`
+/// stays the workflow's.
+#[cfg(unix)]
+#[test]
+fn an_unreadable_ancestor_project_is_a_hint_never_a_refusal() {
+    use std::os::unix::fs::PermissionsExt as _;
+    let room = tempfile::tempdir().expect("room");
+    std::fs::write(room.path().join("value.nika.yaml"), WORKFLOW).expect("workflow");
+    let project = room.path().join("nika.yaml");
+    std::fs::write(&project, "nika: root\nceiling: 0.50\n").expect("valid project");
+    std::fs::set_permissions(&project, std::fs::Permissions::from_mode(0o000)).expect("chmod");
+    if std::fs::read_to_string(&project).is_ok() {
+        return; // root reads through 0o000 — nothing to measure here
+    }
+    let _cwd = crate::cwd::enter(room.path()).expect("cwd lease");
+    let human = run("value.nika.yaml", false, false, None, theme());
+    assert_eq!(human.code, exit::OK, "{}", human.text);
+    assert!(
+        human.text.contains("[project]") && human.text.contains("is not readable from here"),
+        "{}",
+        human.text
+    );
+    assert!(!human.text.contains("BUDGET"), "{}", human.text);
+    let json = run("value.nika.yaml", true, false, None, theme());
+    assert_eq!(json.code, exit::OK, "{}", json.text);
+    let payload: serde_json::Value = serde_json::from_str(&json.text).expect("check json");
+    assert_eq!(payload["clean"], true, "{payload}");
+    // The walk starts at the cwd, which macOS hands back canonical
+    // (`/private/var/…` for a `/var/…` tempdir): compare canonical paths.
+    let canonical = std::fs::canonicalize(&project).expect("canonical project path");
+    assert_eq!(
+        payload["project_unreachable"],
+        canonical.display().to_string(),
+        "{payload}"
+    );
+    assert!(payload.get("run_budget").is_none(), "{payload}");
+    std::fs::set_permissions(&project, std::fs::Permissions::from_mode(0o644)).expect("restore");
+}

--- a/crates/nika-cli/src/verbs/run/ceiling.rs
+++ b/crates/nika-cli/src/verbs/run/ceiling.rs
@@ -18,10 +18,16 @@ use nika_vocab::project::{self, ProjectError};
 
 /// The ladder at an explicit root (the tempdir-injectable half).
 pub(super) fn ladder(flag: Option<f64>, start: &Path) -> Result<Option<f64>, ProjectError> {
-    let Some((_path, project)) = project::discover(start)? else {
-        return Ok(flag);
-    };
-    Ok(flag.or(project.ceiling))
+    let found = project::discover_reachable(start)?;
+    // An ancestor this process may not read (an exec sandbox · another
+    // owner) governs nothing from here — said, never refused (#1547).
+    if let Some((path, _)) = &found.unreachable {
+        eprintln!(
+            "project: `{}` is not readable from here — its ceiling: does not govern this run · cap it with --max-cost-usd",
+            path.display()
+        );
+    }
+    Ok(flag.or(found.found.and_then(|(_, project)| project.ceiling)))
 }
 
 /// The CWD door — discovery walks up from the invocation directory,
@@ -95,6 +101,32 @@ mod tests {
             ladder(Some(9.99), &dir).is_err(),
             "the flag does not pardon a broken file"
         );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// #1547 · an ancestor the process may not read is not a budget and
+    /// not a refusal: the flag still wins, absence of a flag is the
+    /// built-in default, and the walk says so on stderr.
+    #[cfg(unix)]
+    #[test]
+    fn an_unreadable_ancestor_file_governs_nothing_and_refuses_nothing() {
+        use std::os::unix::fs::PermissionsExt as _;
+        let dir = fresh_dir("unreachable");
+        let project = dir.join("nika.yaml");
+        std::fs::write(&project, "nika: proj\nceiling: 0.50\n").expect("seed");
+        std::fs::set_permissions(&project, std::fs::Permissions::from_mode(0o000)).expect("chmod");
+        if std::fs::read_to_string(&project).is_ok() {
+            return; // root reads through 0o000 — nothing to measure here
+        }
+        let child = dir.join("sub");
+        std::fs::create_dir_all(&child).expect("child");
+        assert_eq!(ladder(None, &child).expect("never a refusal"), None);
+        assert_eq!(
+            ladder(Some(1.25), &child).expect("never a refusal"),
+            Some(1.25)
+        );
+        std::fs::set_permissions(&project, std::fs::Permissions::from_mode(0o644))
+            .expect("restore");
         std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/crates/nika-vocab/public-api.txt
+++ b/crates/nika-vocab/public-api.txt
@@ -698,6 +698,27 @@ impl<T> core::clone::CloneToUninit for nika_vocab::project::ArmEntry where T: co
 pub unsafe fn nika_vocab::project::ArmEntry::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for nika_vocab::project::ArmEntry
 pub fn nika_vocab::project::ArmEntry::from(t: T) -> T
+#[non_exhaustive] pub struct nika_vocab::project::Discovery
+pub nika_vocab::project::Discovery::found: core::option::Option<(std::path::PathBuf, nika_vocab::project::Project)>
+pub nika_vocab::project::Discovery::unreachable: core::option::Option<(std::path::PathBuf, core::io::error::Error)>
+impl core::fmt::Debug for nika_vocab::project::Discovery
+pub fn nika_vocab::project::Discovery::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<T, U> core::convert::Into<U> for nika_vocab::project::Discovery where U: core::convert::From<T>
+pub fn nika_vocab::project::Discovery::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_vocab::project::Discovery where U: core::convert::Into<T>
+pub type nika_vocab::project::Discovery::Error = core::convert::Infallible
+pub fn nika_vocab::project::Discovery::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_vocab::project::Discovery where U: core::convert::TryFrom<T>
+pub type nika_vocab::project::Discovery::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_vocab::project::Discovery::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for nika_vocab::project::Discovery where T: 'static + ?core::marker::Sized
+pub fn nika_vocab::project::Discovery::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_vocab::project::Discovery where T: ?core::marker::Sized
+pub fn nika_vocab::project::Discovery::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_vocab::project::Discovery where T: ?core::marker::Sized
+pub fn nika_vocab::project::Discovery::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for nika_vocab::project::Discovery
+pub fn nika_vocab::project::Discovery::from(t: T) -> T
 #[non_exhaustive] pub struct nika_vocab::project::Project
 pub nika_vocab::project::Project::ceiling: core::option::Option<f64>
 pub nika_vocab::project::Project::name: core::option::Option<alloc::string::String>
@@ -856,6 +877,7 @@ pub const nika_vocab::project::STARTER: &str
 pub const nika_vocab::project::TOP_LEVEL_KEYS: &[&str]
 pub fn nika_vocab::project::discover(start: &std::path::Path) -> core::result::Result<core::option::Option<(std::path::PathBuf, nika_vocab::project::Project)>, nika_vocab::project::ProjectError>
 pub fn nika_vocab::project::discover_from_cwd() -> core::result::Result<core::option::Option<(std::path::PathBuf, nika_vocab::project::Project)>, nika_vocab::project::ProjectError>
+pub fn nika_vocab::project::discover_reachable(start: &std::path::Path) -> core::result::Result<nika_vocab::project::Discovery, nika_vocab::project::ProjectError>
 pub fn nika_vocab::project::is_kebab_id(s: &str) -> bool
 pub fn nika_vocab::project::is_project_document(yaml: &str) -> bool
 pub fn nika_vocab::project::parse(text: &str) -> core::result::Result<nika_vocab::project::Project, nika_vocab::project::ProjectError>

--- a/crates/nika-vocab/src/project.rs
+++ b/crates/nika-vocab/src/project.rs
@@ -514,6 +514,36 @@ impl std::error::Error for ProjectError {}
 /// YAML (the line names it), or a closed-grammar fault (unknown key ·
 /// frozen tag · bad value).
 pub fn discover(start: &Path) -> Result<Option<(PathBuf, Project)>, ProjectError> {
+    let found = discover_reachable(start)?;
+    if let Some((path, err)) = &found.unreachable {
+        return Err(ProjectError::io(path, err));
+    }
+    Ok(found.found)
+}
+
+/// What the walk saw from here.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct Discovery {
+    /// The governing file and its parse — `None` when no file governs.
+    pub found: Option<(PathBuf, Project)>,
+    /// An ancestor `nika.yaml` this process is not ALLOWED to read (an
+    /// exec sandbox · another owner's directory), with the refusal the
+    /// OS gave. Its law cannot apply from here; a consumer says so and
+    /// carries on (#1547) — [`discover`] turns it into a refusal instead.
+    pub unreachable: Option<(PathBuf, std::io::Error)>,
+}
+
+/// [`discover`], except that an ancestor answering `PermissionDenied`
+/// ends the walk as [`Discovery::unreachable`] instead of a refusal. A
+/// nested `nika` under an exec sandbox meets the repository's root file
+/// exactly this way, and refusing there masked every finding of the
+/// workflow itself (#1547). A file that reads but will not parse, and
+/// every other read error, still refuse.
+///
+/// # Errors
+/// As [`discover`], minus the permission case.
+pub fn discover_reachable(start: &Path) -> Result<Discovery, ProjectError> {
     for dir in start.ancestors() {
         let candidate = dir.join(FILE_NAME);
         // seam-bypass-ok: local operator config, read-only — the
@@ -521,15 +551,27 @@ pub fn discover(start: &Path) -> Result<Option<(PathBuf, Project)>, ProjectError
         match std::fs::read_to_string(&candidate) {
             Ok(text) => {
                 let project = parse(&text).map_err(|e| e.in_path(&candidate))?;
-                return Ok(Some((candidate, project)));
+                return Ok(Discovery {
+                    found: Some((candidate, project)),
+                    unreachable: None,
+                });
             }
             // Absent here → keep walking (the arm's fall-through IS
             // the walk; an explicit `continue` trips the lint).
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {
+                return Ok(Discovery {
+                    found: None,
+                    unreachable: Some((candidate, e)),
+                });
+            }
             Err(e) => return Err(ProjectError::io(&candidate, &e)),
         }
     }
-    Ok(None)
+    Ok(Discovery {
+        found: None,
+        unreachable: None,
+    })
 }
 
 /// The CWD door — discovery walks up from the invocation directory,

--- a/crates/nika-vocab/src/project/tests.rs
+++ b/crates/nika-vocab/src/project/tests.rs
@@ -12,7 +12,8 @@
 #![allow(clippy::float_cmp)]
 
 use super::{
-    ArmLocus, MissPolicy, Project, ProjectErrorKind, ProvenanceFloor, STARTER, discover, parse,
+    ArmLocus, MissPolicy, Project, ProjectErrorKind, ProvenanceFloor, STARTER, discover,
+    discover_reachable, parse,
 };
 use proptest::strategy::Strategy as _;
 use std::time::Duration;
@@ -610,4 +611,34 @@ fn the_project_schema_mirrors_the_parser() {
         );
     }
     assert_eq!(miss.len(), 3);
+}
+
+/// #1547 · an ancestor the process may not read ends the walk as
+/// `unreachable` (the sandboxed nested `nika` case); `discover` keeps
+/// refusing it, byte for byte, for the consumers that need the file.
+#[cfg(unix)]
+#[test]
+fn an_unreadable_ancestor_is_unreachable_not_a_refusal() {
+    use std::os::unix::fs::PermissionsExt as _;
+    let room = std::env::temp_dir().join(format!("nika-vocab-1547-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&room);
+    std::fs::create_dir_all(&room).expect("room");
+    let project = room.join("nika.yaml");
+    std::fs::write(&project, "nika: root\nceiling: 0.50\n").expect("seed");
+    std::fs::set_permissions(&project, std::fs::Permissions::from_mode(0o000)).expect("chmod");
+    if std::fs::read_to_string(&project).is_ok() {
+        return; // root reads through 0o000 — nothing to measure here
+    }
+    let child = room.join("a").join("b");
+    std::fs::create_dir_all(&child).expect("child");
+    let seen = discover_reachable(&child).expect("never a refusal");
+    assert!(seen.found.is_none(), "{seen:?}");
+    let (path, err) = seen.unreachable.expect("the ancestor is named");
+    assert_eq!(path, project);
+    assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied);
+    let refusal = discover(&child).expect_err("discover still refuses");
+    assert_eq!(refusal.kind(), ProjectErrorKind::Unreadable);
+    assert_eq!(refusal.path(), Some(project.as_path()));
+    std::fs::set_permissions(&project, std::fs::Permissions::from_mode(0o644)).expect("restore");
+    let _ = std::fs::remove_dir_all(&room);
 }


### PR DESCRIPTION
## Why

A nested `nika check` under an exec sandbox (the Lab's L0 campaign, a CI job in a monorepo) met the repository's root `nika.yaml` with `EPERM` and exited 3 on `project.unreadable`, masking every finding of the workflow itself; `nika run` refused the same way. The published 0.118.7 audits that case; `main` since #1494 refuses it. Measured on the Bench: 124/127 contract tests on `main`, 127/127 on the published binary; the same three admission cases green outside the sandbox on both.

## What

`nika_vocab::project::discover_reachable` ends the walk on `PermissionDenied` as `Discovery::unreachable`; `discover` keeps refusing it byte for byte for the consumers that need the file (`arm`). `check` prints `↳ HINT [project] … is not readable from here`, carries `project_unreachable` in `--json` and keeps the workflow's own verdict; the run ladder notes it on stderr and takes no ceiling from it. A file that reads but will not parse, and every other read error, keep their #1494 refusal.

## Proof

- the vocab walk test (a `0o000` ancestor; skips itself when root reads through), the check test (exit 0 · hint · json field · `clean` stays the workflow's), the ladder test (no budget, the flag still wins) — 30/30 in the cwd suites single-threaded
- clippy `-D warnings`, fmt, the ratchets (nika-cli 14965/15000), the nika-vocab `public-api.txt` regenerated with the pinned nightly
- the release binary of this branch, run inside the Bench's exec sandbox under the monorepo root (the exact #1547 shape): `missing` and `wrong` → rc=2 `NIKA-SEC-004`, `matching` → rc=0 — the findings that `main` masked with `project.unreadable`
- the pre-push gate (nextest 7634 · clippy · hygiene · ratchets) green

Closes #1547

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>