### PR TITLE
fix(release): the wasm package publishes through npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -817,9 +817,10 @@ jobs:
         uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-path: '*.tgz'
+      - name: Pin npm CLI
+        run: npm install --global npm@11.19.1
       - name: Converge npm by exact sha512 SRI
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           VERSION: ${{ needs.release-draft.outputs.version }}
         run: |
           set -euo pipefail

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -257,10 +257,15 @@ without an explicit operator decision.
    **v0.116.2 is not retroactively atomic**, and its already-public registry
    history is not rewritten to pretend otherwise.
 
-   Before the first future stable train, configure both `NPM_TOKEN` (granular
-   automation token) and the repository-scoped `TAP_DEPLOY_KEY`. Missing npm
-   authority blocks an absent package version; missing tap authority blocks a
-   stable draft before visibility. Identical occupied npm bytes need no token.
+   npm authority is the package's **trusted publisher** on npmjs.com
+   (`@supernovae-st/nika-check-wasm` → GitHub Actions · `supernovae-st/nika` ·
+   `release.yml`): the job publishes through GitHub OIDC with `--provenance`
+   and carries no token. A granular automation token stopped publishing on
+   2026-09-12 (npm's 2FA-bypass restriction; the registry answers `E404` on
+   the PUT), which is how the v0.119.0 train first stopped at the barrier.
+   The repository-scoped `TAP_DEPLOY_KEY` stays. Missing npm authority blocks
+   an absent package version; missing tap authority blocks a stable draft
+   before visibility. Identical occupied npm bytes need no authority.
 
    The portable Agent Plugins mirror is downstream of this immutable tag.
    After the release assets are green, its release-heal lane runs

--- a/scripts/release/npm-publish-immutable.sh
+++ b/scripts/release/npm-publish-immutable.sh
@@ -75,8 +75,8 @@ esac
   echo "npm barrier: package version is absent" >&2
   exit 73
 }
-[ -n "${NODE_AUTH_TOKEN:-}" ] || {
-  echo "npm barrier: NPM_TOKEN is required to publish an absent version" >&2
+[ -n "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ] && [ -n "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" ] || {
+  echo "npm barrier: GitHub OIDC is required to publish an absent version · id-token: write on the job, and the package's trusted publisher names this repository and workflow" >&2
   exit 77
 }
 

--- a/scripts/release/tests/publication-barrier.test.sh
+++ b/scripts/release/tests/publication-barrier.test.sh
@@ -395,22 +395,29 @@ if PATH="$BIN:$PATH" NPM_STATE="$NPM_STATE" NPM_LOG="$NPM_LOG" NPM_SRI="$NPM_SRI
   fail 'npm absent verification passed'
 fi
 PATH="$BIN:$PATH" NPM_STATE="$NPM_STATE" NPM_LOG="$NPM_LOG" NPM_SRI="$NPM_SRI" \
-  NODE_AUTH_TOKEN=test bash "$ROOT/scripts/release/npm-publish-immutable.sh" publish \
+  ACTIONS_ID_TOKEN_REQUEST_URL=https://oidc.test ACTIONS_ID_TOKEN_REQUEST_TOKEN=test bash "$ROOT/scripts/release/npm-publish-immutable.sh" publish \
   x "$NPM_TGZ" "$NPM_SHA" >/dev/null
 [ "$(wc -l <"$NPM_LOG" | tr -d ' ')" = 1 ] || fail 'npm first publish count differs'
 printf 'absent\n' >"$NPM_STATE"
 PATH="$BIN:$PATH" NPM_STATE="$NPM_STATE" NPM_LOG="$NPM_LOG" NPM_SRI="$NPM_SRI" \
-  NPM_PUBLISH_ERROR=1 NODE_AUTH_TOKEN=test \
+  NPM_PUBLISH_ERROR=1 ACTIONS_ID_TOKEN_REQUEST_URL=https://oidc.test ACTIONS_ID_TOKEN_REQUEST_TOKEN=test \
   bash "$ROOT/scripts/release/npm-publish-immutable.sh" publish x \
   "$NPM_TGZ" "$NPM_SHA" >/dev/null
 [ "$(wc -l <"$NPM_LOG" | tr -d ' ')" = 2 ] || fail 'npm committed publish error retried publish'
 printf 'mixed\n' >"$NPM_STATE"
 if PATH="$BIN:$PATH" NPM_STATE="$NPM_STATE" NPM_LOG="$NPM_LOG" NPM_SRI="$NPM_SRI" \
-  NODE_AUTH_TOKEN=test bash "$ROOT/scripts/release/npm-publish-immutable.sh" \
+  ACTIONS_ID_TOKEN_REQUEST_URL=https://oidc.test ACTIONS_ID_TOKEN_REQUEST_TOKEN=test bash "$ROOT/scripts/release/npm-publish-immutable.sh" \
   publish x "$NPM_TGZ" "$NPM_SHA" >/dev/null 2>&1; then
   fail 'mixed npm 500/E404/unauthorized granted publish authority'
 fi
 [ "$(wc -l <"$NPM_LOG" | tr -d ' ')" = 2 ] || fail 'mixed npm lookup reached publish'
+
+printf 'absent\n' >"$NPM_STATE"
+if PATH="$BIN:$PATH" NPM_STATE="$NPM_STATE" NPM_LOG="$NPM_LOG" NPM_SRI="$NPM_SRI" \
+  bash "$ROOT/scripts/release/npm-publish-immutable.sh" publish x "$NPM_TGZ" "$NPM_SHA" >/dev/null 2>&1; then
+  fail 'an absent version published without GitHub OIDC'
+fi
+[ "$(wc -l <"$NPM_LOG" | tr -d ' ')" = 2 ] || fail 'the OIDC barrier reached npm publish'
 
 # OCI: absent/equal/divergent and label drift. The fake exposes two runnable
 # platforms plus their BuildKit attestations, like the real release index.


### PR DESCRIPTION
The `v0.119.0` train (run 34687247111) stopped at the npm barrier: the provenance statement was signed and logged, then the registry answered `E404` on the PUT for `@supernovae-st/nika-check-wasm`. The job authenticated with a granular token (`NODE_AUTH_TOKEN` from `NPM_TOKEN`); npm's restriction on tokens that bypass 2FA now lands such a publish on a 404, the same wall the SDK packages crossed on 2026-09-10 by moving to trusted publishing.

The job drops the token, pins npm 11.19.1 (the SDK train's pin), keeps `id-token: write`, and publishes through GitHub OIDC with `--provenance`. The immutable publish script's barrier asks for the OIDC pair instead of the token (negative twin in `publication-barrier.test.sh`); `RELEASING.md` names the operator's npm gesture (the package's trusted publisher → `supernovae-st/nika` · `release.yml`) and the replay (`gh workflow run release.yml --ref main -f tag=v0.119.0`). Proof: `publication-barrier.test.sh` PASS, `release-tooling.test.sh` PASS. Checkpoint on #1340.

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>