### PR TITLE
fix(onboard): preserve authoring discovery and installed hook provenance

### DIFF
--- a/.agents/plugins/nika/scripts/session-context.sh
+++ b/.agents/plugins/nika/scripts/session-context.sh
@@ -187,7 +187,7 @@ if [ -n "$kitv" ] && [ -n "$binv" ]; then
   bin_min="$(printf '%s' "$binv" | cut -d. -f2)"
   if [ -n "$kit_maj" ] && [ -n "$kit_min" ] && [ -n "$bin_maj" ] && [ -n "$bin_min" ]; then
     if [ "$bin_maj" -lt "$kit_maj" ] || { [ "$bin_maj" -eq "$kit_maj" ] && [ "$bin_min" -lt "$kit_min" ]; }; then
-      drift=' Version drift: '"$kit_label $kitv"' rides ahead of nika binary '"$binv"'. Align the binary: brew upgrade nika.'
+      drift=' Version drift: '"$kit_label $kitv"' rides ahead of nika binary '"$binv"'. Update the nika executable resolved by PATH using its installation method, then verify nika --version.'
     elif [ "$bin_maj" -gt "$kit_maj" ] || { [ "$bin_maj" -eq "$kit_maj" ] && [ "$bin_min" -gt "$kit_min" ]; }; then
       drift=' Version drift: nika binary '"$binv"' rides ahead of '"$kit_label $kitv"'.'"$refresh"
     fi

--- a/.agents/plugins/nika/scripts/session-context.sh
+++ b/.agents/plugins/nika/scripts/session-context.sh
@@ -30,6 +30,11 @@
 # so nothing user-controlled can break the JSON.
 set -euo pipefail
 
+# nika init stamps ONLY this slot in its project copy. The stamp describes
+# this hook's producer, not the contents of files an init rerun skipped.
+# Plugin installs leave it empty and read their own manifest below.
+scaffold_version=""
+
 input="$(cat)"
 
 # Dialect sniff: `hook_event_name` is Claude Code's (SessionStart);
@@ -134,7 +139,7 @@ fi
 
 # The map is STATIC — fixed content, hand-escaped once, zero
 # interpolation. Both envelopes carry the SAME text.
-map='This workspace uses Nika (nika.sh): repeatable AI work lives in .nika.yaml workflow files, audited BEFORE they run (nika check), metered while they run, with recording enabled by default (.nika/traces/). Missing recording does not prove no effects. Laws: (1) nika check <file> must pass before any run. When the human asks you to run it, run it yourself with --max-cost-usd (announce the ceiling first); nika guard judges every run at the hook. NEVER answer a human gate for them: when a run pauses (exit 4), surface the gate'"'"'s question in the conversation verbatim, wait for their answer, then resume with --resume <trace> --answer <task>=<their answer>. (2) Cost honesty: report the output-token estimate and unpriced input billing; a local model is unpriced, never free. Already admitted calls may overshoot a metered cap. A mock model does not remove real tools or effects. (3) The boundary: an absent permits: block is ZERO authority, not a floor · any effect with no grant refuses NIKA-AUTH-006 at check. (4) Values ride three authorities · inputs (caller-supplied, and deployment-supplied via required: false + a default:) · const (baked in the file) · secrets (store references) · vars: and env: are dead envelope fields, and config: is not a field at all (NIKA-PARSE-005). Installed surfaces: read-only MCP oracle (nika_check, nika_inspect, nika_explain, nika_schema, nika_examples, nika_template, nika_canon, nika_catalog, nika_tools) · subagents nika-author (write a workflow), nika-debugger (root-cause a run from its trace), nika-migrator (port a script) · skills nika-authoring, nika-debugging, nika-operating, nika-migration · commands check, explain, new, trace, permits, doctor (slash-prefixed per your client). CLI: nika check|run|try|test|trace|explain|inspect|new|catalog|doctor|welcome|wire|model|init|spec|sign|key|mcp|lsp|dap|completions. Use the relevant skill for requested repeatable workflow work, not unrelated code edits or one-off answers. Read only the references needed for the task. Preserve existing authorization and continue through the requested outcome; the selected model does not change engine contracts.'
+map='This workspace uses Nika (nika.sh): repeatable AI work lives in .nika.yaml workflow files, audited BEFORE they run (nika check), metered while they run, with recording enabled by default (.nika/traces/). Missing recording does not prove no effects. Laws: (1) nika check <file> must pass before any run. When the human asks you to run it, run it yourself with --max-cost-usd (announce the ceiling first); nika guard judges every run at the hook. NEVER answer a human gate for them: when a run pauses (exit 4), surface the gate'"'"'s question in the conversation verbatim, wait for their answer, then resume with --resume <trace> --answer <task>=<their answer>. (2) Cost honesty: report the output-token estimate and unpriced input billing; a local model is unpriced, never free. Already admitted calls may overshoot a metered cap. A mock model does not remove real tools or effects. (3) The boundary: an absent permits: block is ZERO authority, not a floor · any effect with no grant refuses NIKA-AUTH-006 at check. (4) Values ride three authorities · inputs (caller-supplied, and deployment-supplied via required: false + a default:) · const (baked in the file) · secrets (store references) · vars: and env: are dead envelope fields, and config: is not a field at all (NIKA-PARSE-005). Kit surfaces (availability depends on the installation): read-only MCP oracle (nika_check, nika_inspect, nika_explain, nika_schema, nika_examples, nika_template, nika_canon, nika_catalog, nika_tools) · subagents nika-author (write a workflow), nika-debugger (root-cause a run from its trace), nika-migrator (port a script) · skills nika-authoring, nika-debugging, nika-operating, nika-migration · commands check, explain, new, trace, permits, doctor (slash-prefixed per your client). CLI: nika check|run|try|test|trace|explain|inspect|new|catalog|doctor|welcome|wire|model|init|spec|sign|key|mcp|lsp|dap|completions. Use the relevant skill for requested repeatable workflow work, not unrelated code edits or one-off answers. Read only the references needed for the task. Preserve existing authorization and continue through the requested outcome; the selected model does not change engine contracts.'
 
 # A claim names its proof: the resolved root and the evidence source
 # (P0-14 — an unnamed "this workspace" taught the agent to trust a
@@ -152,8 +157,12 @@ fi
 
 # Version handshake — kit manifest vs `nika --version`, major.minor
 # only (the kit follows release trains; patch drift is not a finding).
-# Both tokens sanitized to [0-9.]; unreadable on either side → silence
-# (never guess a version).
+# Select the version token before normalizing: the long binary version also
+# carries a git hash, whose digits are not part of its semantic version.
+# An unreadable version stays unknown; it never becomes an inferred match.
+release_version() {
+  sed -nE 's/^([0-9]+\.[0-9]+\.[0-9]+)([-+][[:alnum:].-]+)?$/\1/p'
+}
 drift=""
 kit_raw=""
 for m in .claude-plugin/plugin.json .codex-plugin/plugin.json .cursor-plugin/plugin.json; do
@@ -162,8 +171,15 @@ for m in .claude-plugin/plugin.json .codex-plugin/plugin.json .cursor-plugin/plu
     [ -n "$kit_raw" ] && break
   fi
 done
-kitv="$(printf '%s' "$kit_raw" | tr -cd '0-9.')"
-binv="$(nika --version 2>/dev/null | tr -cd '0-9.' || true)"
+kitv="$(printf '%s' "$scaffold_version" | release_version)"
+kit_label='project hook scaffold'
+refresh=' Generate a fresh scaffold with nika init <new-dir> --yes, then review and merge its hooks and authoring resources into this project. Existing files are skipped by default; the hook stamp does not attest skipped or edited files.'
+if [ -z "$kitv" ]; then
+  kitv="$(printf '%s' "$kit_raw" | sed -nE 's/.*"version"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p' | release_version)"
+  kit_label='plugin kit'
+  refresh=' Refresh the kit from your marketplace (Codex: codex plugin marketplace upgrade nika · Claude Code: claude plugin marketplace update nika, then claude plugin update nika@nika).'
+fi
+binv="$(nika --version 2>/dev/null | sed -nE 's/^nika ([^[:space:]]+).*$/\1/p' | release_version || true)"
 if [ -n "$kitv" ] && [ -n "$binv" ]; then
   kit_maj="$(printf '%s' "$kitv" | cut -d. -f1)"
   kit_min="$(printf '%s' "$kitv" | cut -d. -f2)"
@@ -171,9 +187,9 @@ if [ -n "$kitv" ] && [ -n "$binv" ]; then
   bin_min="$(printf '%s' "$binv" | cut -d. -f2)"
   if [ -n "$kit_maj" ] && [ -n "$kit_min" ] && [ -n "$bin_maj" ] && [ -n "$bin_min" ]; then
     if [ "$bin_maj" -lt "$kit_maj" ] || { [ "$bin_maj" -eq "$kit_maj" ] && [ "$bin_min" -lt "$kit_min" ]; }; then
-      drift=' Version drift: plugin kit '"$kitv"' rides ahead of nika binary '"$binv"'. Align the binary: brew upgrade nika.'
+      drift=' Version drift: '"$kit_label $kitv"' rides ahead of nika binary '"$binv"'. Align the binary: brew upgrade nika.'
     elif [ "$bin_maj" -gt "$kit_maj" ] || { [ "$bin_maj" -eq "$kit_maj" ] && [ "$bin_min" -gt "$kit_min" ]; }; then
-      drift=' Version drift: nika binary '"$binv"' rides ahead of plugin kit '"$kitv"'. Refresh the kit from your marketplace (Codex: codex plugin marketplace upgrade nika · Claude Code: claude plugin marketplace update nika, then claude plugin update nika@nika).'
+      drift=' Version drift: nika binary '"$binv"' rides ahead of '"$kit_label $kitv"'.'"$refresh"
     fi
   fi
 fi

--- a/.agents/plugins/nika/scripts/tests/session-context.test.sh
+++ b/.agents/plugins/nika/scripts/tests/session-context.test.sh
@@ -142,6 +142,8 @@ unset CLAUDE_PLUGIN_ROOT
 play "$ROOT" "{\"cwd\":\"$WS\"}"
 need binary-build-hash 'nika binary 0.117.2.'
 deny binary-build-hash '0.117.24123'
+deny binary-build-hash 'brew upgrade nika'
+need binary-build-hash 'Update the nika executable resolved by PATH using its installation method'
 
 NIKA_TEST_VERSION='nika 0.118.9 (1234567)'
 play "$ROOT" "{\"cwd\":\"$WS\"}"

--- a/.agents/plugins/nika/scripts/tests/session-context.test.sh
+++ b/.agents/plugins/nika/scripts/tests/session-context.test.sh
@@ -122,6 +122,59 @@ OUT="$(cd "$ROOT" && printf '%s' "{\"cwd\":\"$REALWS\",\"note\":\"see \\\"cwd\\\
 need fallback-first-cwd "$(cd "$REALWS" && pwd)"
 deny fallback-first-cwd 'fakews'
 
+# 6 · version evidence comes from the semantic version, not digits in the
+# build hash. Use a disposable binary and kit, never the machine's install.
+BIN="$ROOT/bin"
+KIT="$ROOT/kit"
+mkdir -p "$BIN" "$KIT/scripts" "$KIT/.claude-plugin"
+cp "$HOOK" "$KIT/scripts/session-context.sh"
+printf '%s\n' '{"version":"0.118.7"}' >"$KIT/.claude-plugin/plugin.json"
+cat >"$BIN/nika" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$NIKA_TEST_VERSION"
+SH
+chmod +x "$BIN/nika"
+REAL_HOOK="$HOOK"
+HOOK="$KIT/scripts/session-context.sh"
+export PATH="$BIN:$PATH"
+export NIKA_TEST_VERSION='nika 0.117.2 (c4cdbeafb123)'
+unset CLAUDE_PLUGIN_ROOT
+play "$ROOT" "{\"cwd\":\"$WS\"}"
+need binary-build-hash 'nika binary 0.117.2.'
+deny binary-build-hash '0.117.24123'
+
+NIKA_TEST_VERSION='nika 0.118.9 (1234567)'
+play "$ROOT" "{\"cwd\":\"$WS\"}"
+deny patch-only 'Version drift:'
+
+NIKA_TEST_VERSION='nika 0.117.2-rc.1 (c4cdbeafb123)'
+play "$ROOT" "{\"cwd\":\"$WS\"}"
+need prerelease-build-hash 'nika binary 0.117.2.'
+
+NIKA_TEST_VERSION='unavailable build 1234'
+play "$ROOT" "{\"cwd\":\"$WS\"}"
+deny unknown-version 'Version drift:'
+
+NIKA_TEST_VERSION='nika 0.119.0 (1234567)'
+play "$ROOT" "{\"cwd\":\"$WS\"}"
+need plugin-behind 'plugin kit 0.118.7'
+need plugin-behind 'Refresh the kit from your marketplace'
+
+# 7 · init's project copy has no plugin manifest. The producer stamps a
+# version in the copied hook; a newer binary must route to scaffold refresh,
+# not to marketplace installation. An unrelated plugin root cannot win.
+PROJECT_HOOK="$WS/.cursor/hooks-nika/session-context.sh"
+mkdir -p "$(dirname "$PROJECT_HOOK")"
+sed 's/scaffold_version=""/scaffold_version="0.117.2"/' "$REAL_HOOK" >"$PROJECT_HOOK"
+HOOK="$PROJECT_HOOK"
+NIKA_TEST_VERSION='nika 0.118.7 (9876543)'
+export CLAUDE_PLUGIN_ROOT="$KIT"
+play "$ROOT" "{\"cwd\":\"$WS\"}"
+need project-hook 'project hook scaffold 0.117.2'
+need project-hook 'nika binary 0.118.7'
+need project-hook 'nika init'
+deny project-hook 'Refresh the kit from your marketplace'
+
 if [ "$FAILS" -gt 0 ]; then
   say "── $FAILS failure(s)"
   exit 1

--- a/crates/nika-onboard/src/briefs.rs
+++ b/crates/nika-onboard/src/briefs.rs
@@ -40,6 +40,15 @@ effect scope and budget. Continue through requested checks, repairs and
 execution. A missing business decision or human-gate answer remains a question;
 a clean checker result does not supply authorization or prove effects.
 
+For authoring details, open the project-local
+[authoring skill](.agents/skills/nika-authoring/SKILL.md), then only the reference
+needed for the task. `nika init` ships that entry and its six linked guides;
+clients that do not discover `.agents/skills` can follow this link directly.
+Check `nika --version` and use the installed schema/catalog for supported names.
+An installed marketplace plugin and this project's scaffold can be from different
+releases. `nika doctor` diagnoses installed plugin drift; init preserves existing
+files, so review a fresh scaffold in a separate directory before updating them.
+
 ## The workflow tools
 - **Author** · `nika new <template> <file>.nika.yaml` (or write one —
   the envelope is `nika: <id>` (kebab-case — the id lives ON the tag)
@@ -352,8 +361,9 @@ const CURSOR_DELEGATION: &str = include_str!(concat!(
     "/../../.agents/plugins/nika/rules/nika-delegation.mdc"
 ));
 
-/// `.cursor/hooks-nika/*.sh` — the three seatbelts, verbatim from the
-/// kit. The scripts sniff their dialect from stdin and self-silence
+/// `.cursor/hooks-nika/*.sh` — the three seatbelts from the kit. The session
+/// hook's one provenance slot is stamped by `apply_briefs`; all other script
+/// bytes are preserved. The scripts sniff their dialect from stdin and self-silence
 /// outside nika contexts, so carrying them project-side is safe by the
 /// same proof that ships them in the plugin.
 const HOOK_SESSION_CONTEXT: &str = include_str!(concat!(

--- a/crates/nika-onboard/src/founding.rs
+++ b/crates/nika-onboard/src/founding.rs
@@ -189,11 +189,11 @@ pub fn scripted_run(
         |first| {
             if has_drafts {
                 format!(
-                    "next ·\n  $EDITOR {first}                   # fill the remaining `<SLOT: …>` values\n  nika check {first}                    # audit before a single token\n  nika run {first} --model mock/echo   # offline proof · zero keys\n  nika explain <NIKA-XXXX>              # every finding teaches"
+                    "next ·\n  $EDITOR {first}                   # fill the remaining `<SLOT: …>` values\n  nika check {first}                    # audit before a single token\n  nika run {first} --model mock/echo   # mocked envelope inference; task model pins, tools and effects remain real\n  nika explain <NIKA-XXXX>              # every finding teaches"
                 )
             } else {
                 format!(
-                "next ·\n  nika run {first} --model mock/echo   # offline proof · zero keys\n  nika check {first}                    # audit before a single token\n  nika explain <NIKA-XXXX>              # every finding teaches"
+                "next ·\n  nika check {first}                    # audit before a single token\n  nika run {first} --model mock/echo   # mocked envelope inference; task model pins, tools and effects remain real\n  nika explain <NIKA-XXXX>              # every finding teaches"
                 )
             }
         },
@@ -291,7 +291,8 @@ pub(crate) enum BriefOutcome {
 }
 
 /// Write the briefs per `plan`, honoring the canvas stamp on a CREATED
-/// settings file.
+/// settings file and producer version in a CREATED session hook. Skipped
+/// files retain their content and provenance.
 pub(crate) fn apply_briefs(
     dir: &str,
     force: bool,
@@ -303,6 +304,17 @@ pub(crate) fn apply_briefs(
         match action {
             Action::Skip { path } => rows.push((path, BriefOutcome::Skipped)),
             Action::Create { path, body } => {
+                let stamped;
+                let body = if path.ends_with(".cursor/hooks-nika/session-context.sh") {
+                    stamped = body.replacen(
+                        "scaffold_version=\"\"",
+                        concat!("scaffold_version=\"", env!("CARGO_PKG_VERSION"), "\""),
+                        1,
+                    );
+                    stamped.as_str()
+                } else {
+                    body
+                };
                 let themed;
                 let body = match canvas {
                     Some(c) if path.ends_with(".vscode/settings.json") => {
@@ -538,6 +550,55 @@ mod tests {
     }
 
     #[test]
+    fn effectful_scaffolds_teach_check_before_run_without_an_offline_promise() {
+        for draft in [false, true] {
+            let tmp = std::env::temp_dir().join(format!(
+                "nika-init-effectful-{}-{draft}",
+                std::process::id()
+            ));
+            let audit = |_: &str| {
+                Outcome::ok(
+                    if draft {
+                        "not a workflow yet"
+                    } else {
+                        "audited clean"
+                    }
+                    .to_owned(),
+                )
+            };
+            let out = scripted_run(
+                tmp.to_str().expect("path"),
+                false,
+                None,
+                Some("03-exec-pipeline"),
+                None,
+                &[],
+                &audit,
+                &stub_wire,
+            );
+            let source = std::fs::read_to_string(tmp.join("workflows/03-exec-pipeline.nika.yaml"))
+                .expect("effectful example");
+            assert!(
+                source.contains("exec:"),
+                "the fixture has real subprocess effects"
+            );
+            let next = out.text.split("next ·").last().expect("handover");
+            let check = next.find("nika check ").expect("inspection command");
+            let run = next.find("nika run ").expect("execution command");
+            assert!(check < run, "inspection precedes real execution: {next}");
+            assert!(
+                !next.contains("offline proof") && !next.contains("zero keys"),
+                "mock does not remove effects or task model pins: {next}"
+            );
+            assert!(
+                next.contains("effects remain real"),
+                "handover names the execution boundary: {next}"
+            );
+            std::fs::remove_dir_all(tmp).expect("remove temp project");
+        }
+    }
+
+    #[test]
     fn successful_init_hands_over_to_the_next_command() {
         // The 2026-07-05 beginner walk: init ended SILENTLY (4 files ·
         // no workflow · no next step). An onboarding surface must hand
@@ -635,6 +696,65 @@ mod tests {
             "adds-only: the second run changed nothing"
         );
         std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn fresh_project_routes_to_the_shipped_authoring_resources() {
+        let tmp = std::env::temp_dir().join(format!("nika-authoring-route-{}", std::process::id()));
+        std::fs::create_dir_all(&tmp).expect("temp project");
+        let rows = apply_briefs(tmp.to_str().expect("path"), false, None);
+        assert!(
+            rows.iter()
+                .all(|(_, outcome)| matches!(outcome, BriefOutcome::Created))
+        );
+        let entry = std::fs::read_to_string(tmp.join("AGENTS.md")).expect("entry");
+        let skill_path = ".agents/skills/nika-authoring/SKILL.md";
+        assert!(
+            entry.contains(&format!("]({skill_path})")),
+            "the loaded entry must route to the local skill"
+        );
+        let skill = std::fs::read_to_string(tmp.join(skill_path)).expect("local skill");
+        let mut references = 0;
+        for part in skill.split("](references/").skip(1) {
+            let relative = part.split(')').next().expect("reference link");
+            let path = tmp
+                .join(".agents/skills/nika-authoring/references")
+                .join(relative);
+            assert!(
+                std::fs::read_to_string(path).is_ok(),
+                "reference {relative} is readable"
+            );
+            references += 1;
+        }
+        assert_eq!(
+            references, 6,
+            "all conditional guides reachable from the entry"
+        );
+        std::fs::remove_dir_all(tmp).expect("remove temp project");
+    }
+
+    #[test]
+    fn project_hook_carries_its_generator_version_and_reruns_preserve_it() {
+        let tmp = std::env::temp_dir().join(format!("nika-hook-provenance-{}", std::process::id()));
+        std::fs::create_dir_all(&tmp).expect("temp project");
+        apply_briefs(tmp.to_str().expect("path"), false, None);
+        let hook = tmp.join(".cursor/hooks-nika/session-context.sh");
+        let body = std::fs::read_to_string(&hook).expect("project hook");
+        assert!(
+            body.contains(concat!(
+                "scaffold_version=\"",
+                env!("CARGO_PKG_VERSION"),
+                "\""
+            )),
+            "the relocated hook must retain its producer version"
+        );
+        std::fs::write(&hook, "# user-owned hook\n").expect("custom hook");
+        apply_briefs(tmp.to_str().expect("path"), false, None);
+        assert_eq!(
+            std::fs::read_to_string(&hook).expect("preserved hook"),
+            "# user-owned hook\n"
+        );
+        std::fs::remove_dir_all(tmp).expect("remove temp project");
     }
 
     #[test]


### PR DESCRIPTION
## What & why

A fresh `nika init` copied the session hook without its plugin manifest, silently disabling version-drift diagnostics. The hook also appended digits from build hashes to the binary version and assumed Homebrew owned the active executable. The generated hook now retains its producing package version, parses the semantic version separately from the build stamp, points at the executable resolved by PATH, and recommends a scaffold refresh for project copies. Existing files remain untouched on an init rerun; the hook stamp does not attest skipped or customized files.

Generated `AGENTS.md` now links to the local authoring skill and its references. Scripted handovers show `check` before `run` and explain that a mock envelope model leaves task model pins, tools and effects real.

## Validation

- Reproduced the hook handshake, version parsing, authoring discovery, and misleading run handover defects before correction; regression cases now pass. Also reproduced and corrected installation-specific upgrade advice.
- 127 onboarding tests passed (one existing calibration probe ignored), plus 7 plugin contract tests and 9 CLI teaching-parity tests.
- Hook artifact suites, plugin admission and mutation suite, formatting and shell checks passed.
- Normal pre-push: all 7,638 workspace library tests passed with four nextest workers (6 existing skips), and workspace Clippy passed with `--all-targets -- -D warnings`. An initial default-concurrency run timed out in the untouched server trace-journal test; that same test passed both in isolation and in the complete four-worker rerun. No test code or test deadline was changed, and no hook was bypassed.
- Rebuilt CLI verified in fresh disposable projects: all six references reachable and byte-identical to source, emitted hook tested with older/newer/aligned binaries, customized files preserved on rerun, effectful example scaffolded and statically checked without executing it.

The normal gate accepts hygiene YELLOW and blocks RED. This run reported eight YELLOW vectors: memory-head anchor, file cohesion, stale proposed ADR, crate descent window, future ADR-081 admission guard, public API coverage, Gate 5 attestations, and hygiene self-tests. A prior standalone run hit the self-test vector deadline; the final gate used the existing 600-second vector timeout setting and completed without RED.

No release or installed plugin/cache update is included. The existing major/minor release-train comparison remains a compatibility signal, not a content or capability attestation.

## Checklist

- [x] Conventional commits, author-matching DCO signoffs, and required Nika co-author trailer
- [x] Workspace library tests green via normal pre-push nextest gate (7,638 passed; 6 existing skips)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` green
- [x] `cargo fmt --check` clean
- [x] No new production `.unwrap()` / `.expect()` calls
- [x] Normal repository hygiene gate completed without RED (exit 1: eight YELLOW advisory vectors); all 12 CI ratchets passed
- [x] No crate admitted (12 admission gates not applicable)
